### PR TITLE
Add keyboard.repeat-rate and keyboard.repeat-delay

### DIFF
--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -3,6 +3,14 @@
 
 input {
     keyboard {
+        // Control the repeat rate of the keyboard.
+
+        // Repeat delay in milliseconds.
+        repeat-delay 660
+
+        // Repeat rate in characters per second.
+        repeat-rate 25
+
         xkb {
             // You can set rules, model, layout, variant and options.
             // For more information, see xkeyboard-config(7).

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,12 @@ pub struct Input {
 pub struct Keyboard {
     #[knuffel(child, default)]
     pub xkb: Xkb,
+    // The default value represents the one used by Xorg.
+    #[knuffel(child, unwrap(argument), default = 660)]
+    pub repeat_delay: u16,
+    // The default value represents the one used by Xorg.
+    #[knuffel(child, unwrap(argument), default = 25)]
+    pub repeat_rate: u8,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq, Eq)]
@@ -244,6 +250,8 @@ mod tests {
             r#"
             input {
                 keyboard {
+                    repeat-delay 660
+                    repeat-rate 25
                     xkb {
                         layout "us,ru"
                         options "grp:win_space_toggle"
@@ -277,6 +285,8 @@ mod tests {
                             options: Some("grp:win_space_toggle".to_owned()),
                             ..Default::default()
                         },
+                        repeat_delay: 660,
+                        repeat_rate: 25,
                     },
                     touchpad: Touchpad {
                         tap: true,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -228,7 +228,12 @@ impl Niri {
             variant: &config_.input.keyboard.xkb.variant,
             options: config_.input.keyboard.xkb.options.clone(),
         };
-        seat.add_keyboard(xkb, 400, 30).unwrap();
+        seat.add_keyboard(
+            xkb,
+            config_.input.keyboard.repeat_delay as i32,
+            config_.input.keyboard.repeat_rate as i32,
+        )
+        .unwrap();
         seat.add_pointer();
 
         let socket_source = ListeningSocketSource::new_auto().unwrap();


### PR DESCRIPTION
Add option to let the users configure the keyboard repeat delay and rate. Also change the default values to mimic the Xorg, which is also the values used by default by the majority of the compositors.