### PR TITLE
Don't send key on release from niri actions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -229,8 +229,6 @@ bitflags! {
 
 #[derive(knuffel::Decode, Debug, Clone, PartialEq)]
 pub enum Action {
-    #[knuffel(skip)]
-    None,
     Quit,
     #[knuffel(skip)]
     ChangeVt(i32),

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -136,6 +136,8 @@ pub struct Niri {
     pub presentation_state: PresentationState,
 
     pub seat: Seat<State>,
+    /// Scancodes of the keys to suppress.
+    pub suppressed_keys: HashSet<u32>,
 
     pub default_cursor: Cursor,
     pub cursor_image: CursorImageStatus,
@@ -629,6 +631,7 @@ impl Niri {
             primary_selection_state,
             data_control_state,
             popups: PopupManager::default(),
+            suppressed_keys: HashSet::new(),
             presentation_state,
 
             seat,


### PR DESCRIPTION
Some clients run logic on `Release`, thus don't send the key originally used for running `niri` actions.

Fixes #28.