### PR TITLE
Check alternative cursor names when loading cursor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "cursor-icon"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740bb192a8e2d1350119916954f4409ee7f62f149b536911eeb78ba5a20526bf"
+checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "deranged"

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -111,6 +111,17 @@ impl CursorManager {
             .or_insert_with_key(|(icon, scale)| {
                 let size = self.size as i32 * scale;
                 let mut cursor = Self::load_xcursor(&self.theme, icon.name(), size);
+
+                // Check alternative names to account for non-compliant themes.
+                if cursor.is_err() {
+                    for name in icon.alt_names() {
+                        cursor = Self::load_xcursor(&self.theme, name, size);
+                        if cursor.is_ok() {
+                            break;
+                        }
+                    }
+                }
+
                 if let Err(err) = &cursor {
                     warn!("error loading xcursor {}@{size}: {err:?}", icon.name());
                 }


### PR DESCRIPTION
Some themes don't have all the cursors specified as in w3c specification, thus try to check for alternative names as well.