### PR TITLE
tty: reset device to recover from certain errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,25 +1406,22 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e74cd82cedcd66db78742a8337bdc48f188c4d2c12742cbc5cd85113f0b059"
+checksum = "7911ce3db9c10c5ab4a35c49af778a5f9a827bd0f7371d9be56175d8dd2740d0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "input-sys",
  "io-lifetimes 1.0.11",
  "libc",
- "udev 0.7.0",
+ "udev",
 ]
 
 [[package]]
 name = "input-sys"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f6c2a17e8aba7217660e32863af87b0febad811d4b8620ef76b386603fddc2"
-dependencies = [
- "libc",
-]
+checksum = "bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0"
 
 [[package]]
 name = "instant"
@@ -2695,7 +2692,7 @@ checksum = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/Smithay/smithay.git#b7284bc6ca6afc782bd55a5c34ef3f902005951f"
+source = "git+https://github.com/Smithay/smithay.git?rev=7d77b85ebe0627c2a8c0a4954c5b30a318b15cf1#7d77b85ebe0627c2a8c0a4954c5b30a318b15cf1"
 dependencies = [
  "appendlist",
  "bitflags 2.4.2",
@@ -2726,7 +2723,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
- "udev 0.8.0",
+ "udev",
  "wayland-backend",
  "wayland-egl",
  "wayland-protocols",
@@ -2766,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#b7284bc6ca6afc782bd55a5c34ef3f902005951f"
+source = "git+https://github.com/Smithay/smithay.git?rev=7d77b85ebe0627c2a8c0a4954c5b30a318b15cf1#7d77b85ebe0627c2a8c0a4954c5b30a318b15cf1"
 dependencies = [
  "drm",
  "edid-rs",
@@ -3061,17 +3058,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "udev"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebdbbd670373442a12fe9ef7aeb53aec4147a5a27a00bbc3ab639f08f48191a"
-dependencies = [
- "libc",
- "libudev-sys",
- "pkg-config",
-]
 
 [[package]]
 name = "udev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ tracy-client = { version = "0.16.5", default-features = false }
 
 [workspace.dependencies.smithay]
 git = "https://github.com/Smithay/smithay.git"
+rev = "7d77b85ebe0627c2a8c0a4954c5b30a318b15cf1"
 # path = "../smithay"
 default-features = false
 
 [workspace.dependencies.smithay-drm-extras]
 git = "https://github.com/Smithay/smithay.git"
+rev = "7d77b85ebe0627c2a8c0a4954c5b30a318b15cf1"
 # path = "../smithay/smithay-drm-extras"
 
 [package]


### PR DESCRIPTION
after a session resume (tty switch) we might
end up with a state mismatch. in this case
we can try to reset the device to recover
from the mismatch.

depends on https://github.com/Smithay/smithay/pull/1295