### PR TITLE
Add option to rotate outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/Smithay/smithay.git#ed05c8c6c5b721066b919213156616ebe081e343"
+source = "git+https://github.com/Smithay/smithay.git#3b3e07952e471618fe8b590ba3223f4201cec10c"
 dependencies = [
  "appendlist",
  "bitflags 2.4.2",
@@ -2788,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#ed05c8c6c5b721066b919213156616ebe081e343"
+source = "git+https://github.com/Smithay/smithay.git#3b3e07952e471618fe8b590ba3223f4201cec10c"
 dependencies = [
  "drm",
  "edid-rs",

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -65,6 +65,10 @@ input {
     // Scale is a floating-point number, but at the moment only integer values work.
     scale 2.0
 
+    // Transform allows to rotate the output counter-clockwise, valid values are:
+    // normal, 90, 180, 270, flipped, flipped-90, flipped-180 and flipped-270.
+    transform "normal"
+
     // Resolution and, optionally, refresh rate of the output.
     // The format is "<width>x<height>" or "<width>x<height>@<refresh rate>".
     // If the refresh rate is omitted, niri will pick the highest refresh rate

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -16,7 +16,6 @@ use smithay::reexports::calloop::LoopHandle;
 use smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback;
 use smithay::reexports::winit::dpi::LogicalSize;
 use smithay::reexports::winit::window::WindowBuilder;
-use smithay::utils::Transform;
 
 use super::RenderResult;
 use crate::niri::{RedrawState, State};
@@ -54,7 +53,7 @@ impl Winit {
             size: backend.window_size(),
             refresh: 60_000,
         };
-        output.change_current_state(Some(mode), Some(Transform::Flipped180), None, None);
+        output.change_current_state(Some(mode), None, None, None);
         output.set_preferred(mode);
 
         let physical_properties = output.physical_properties();

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -654,9 +654,13 @@ impl State {
                 let scale = config.map(|c| c.scale).unwrap_or(1.);
                 let scale = scale.clamp(1., 10.).ceil() as i32;
 
-                let transform = config
+                let mut transform = config
                     .map(|c| c.transform.into())
                     .unwrap_or(Transform::Normal);
+                // FIXME: fix winit damage on other transforms.
+                if name == "winit" {
+                    transform = Transform::Flipped180;
+                }
 
                 if output.current_scale().integer_scale() != scale
                     || output.current_transform() != transform
@@ -1179,7 +1183,11 @@ impl Niri {
         let c = config.outputs.iter().find(|o| o.name == name);
         let scale = c.map(|c| c.scale).unwrap_or(1.);
         let scale = scale.clamp(1., 10.).ceil() as i32;
-        let transform = c.map(|c| c.transform.into()).unwrap_or(Transform::Normal);
+        let mut transform = c.map(|c| c.transform.into()).unwrap_or(Transform::Normal);
+        // FIXME: fix winit damage on other transforms.
+        if name == "winit" {
+            transform = Transform::Flipped180;
+        }
         drop(config);
 
         // Set scale and transform before adding to the layout since that will read the output size.

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2434,6 +2434,7 @@ impl Niri {
         let scale = Scale::from(output.current_scale().fractional_scale());
 
         let mut elements = None;
+        let mut casts_to_stop = vec![];
 
         let mut casts = mem::take(&mut self.casts);
         for cast in &mut casts {
@@ -2442,6 +2443,12 @@ impl Niri {
             }
 
             if &cast.output != output {
+                continue;
+            }
+
+            if cast.size != size {
+                debug!("stopping screencast due to output size change");
+                casts_to_stop.push(cast.session_id);
                 continue;
             }
 
@@ -2499,6 +2506,10 @@ impl Niri {
             cast.last_frame_time = target_presentation_time;
         }
         self.casts = casts;
+
+        for id in casts_to_stop {
+            self.stop_cast(id);
+        }
     }
 
     #[cfg(feature = "xdp-gnome-screencast")]

--- a/src/pw_utils.rs
+++ b/src/pw_utils.rs
@@ -27,6 +27,7 @@ use smithay::output::Output;
 use smithay::reexports::calloop::generic::Generic;
 use smithay::reexports::calloop::{self, Interest, LoopHandle, Mode, PostAction};
 use smithay::reexports::gbm::Modifier;
+use smithay::utils::{Physical, Size};
 use zbus::SignalContext;
 
 use crate::dbus::mutter_screen_cast::{self, CursorMode, ScreenCastToNiri};
@@ -43,6 +44,7 @@ pub struct Cast {
     _listener: StreamListener<()>,
     pub is_active: Rc<Cell<bool>>,
     pub output: Output,
+    pub size: Size<i32, Physical>,
     pub cursor_mode: CursorMode,
     pub last_frame_time: Duration,
     pub min_time_between_frames: Rc<Cell<Duration>>,
@@ -385,6 +387,7 @@ impl PipeWire {
             _listener: listener,
             is_active,
             output,
+            size,
             cursor_mode,
             last_frame_time: Duration::ZERO,
             min_time_between_frames,

--- a/src/pw_utils.rs
+++ b/src/pw_utils.rs
@@ -112,6 +112,8 @@ impl PipeWire {
 
         let mode = output.current_mode().unwrap();
         let size = mode.size;
+        let transform = output.current_transform();
+        let size = transform.transform_size(size);
         let refresh = mode.refresh;
 
         let stream = Stream::new(&self.core, "niri-screen-cast-src", Properties::new())

--- a/src/screenshot_ui.rs
+++ b/src/screenshot_ui.rs
@@ -42,6 +42,7 @@ pub enum ScreenshotUi {
 pub struct OutputData {
     size: Size<i32, Physical>,
     scale: i32,
+    transform: Transform,
     texture: GlesTexture,
     texture_buffer: TextureBuffer<GlesTexture>,
     buffers: [SolidColorBuffer; 8],
@@ -94,6 +95,7 @@ impl ScreenshotUi {
                 )
             }
         };
+
         let scale = selection.0.current_scale().integer_scale();
         let selection = (
             selection.0,
@@ -104,9 +106,9 @@ impl ScreenshotUi {
         let output_data = screenshots
             .into_iter()
             .map(|(output, texture)| {
-                let output_transform = output.current_transform();
+                let transform = output.current_transform();
                 let output_mode = output.current_mode().unwrap();
-                let size = output_transform.transform_size(output_mode.size);
+                let size = transform.transform_size(output_mode.size);
                 let scale = output.current_scale().integer_scale();
                 let texture_buffer = TextureBuffer::from_texture(
                     renderer,
@@ -129,6 +131,7 @@ impl ScreenshotUi {
                 let data = OutputData {
                     size,
                     scale,
+                    transform,
                     texture,
                     texture_buffer,
                     buffers,
@@ -333,10 +336,10 @@ impl ScreenshotUi {
         }
     }
 
-    pub fn output_size(&self, output: &Output) -> Option<(Size<i32, Physical>, i32)> {
+    pub fn output_size(&self, output: &Output) -> Option<(Size<i32, Physical>, i32, Transform)> {
         if let Self::Open { output_data, .. } = self {
             let data = output_data.get(output)?;
-            Some((data.size, data.scale))
+            Some((data.size, data.scale, data.transform))
         } else {
             None
         }


### PR DESCRIPTION
Adds support for output Transformation using a config option `transform` in the `output` section to allow setting it per output
closes #106

Attempting to do a screenshot on a rotated output (tested with rotation 270) currently cuts the available output to screenshot by half, any part of the selected area that goes into the "invisible" area becomes transparent
