### PR TITLE
Add actions to move the active workspace to another monitor

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -438,6 +438,10 @@ pub enum Action {
     SetColumnWidth(#[knuffel(argument, str)] SizeChange),
     SwitchLayout(#[knuffel(argument)] LayoutAction),
     ShowHotkeyOverlay,
+    MoveWorkspaceToMonitorLeft,
+    MoveWorkspaceToMonitorRight,
+    MoveWorkspaceToMonitorDown,
+    MoveWorkspaceToMonitorUp,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -263,6 +263,10 @@ binds {
     // Mod+Shift+Ctrl+Left  { move-window-to-monitor-left; }
     // ...
 
+    // And you can also move a whole workspace to another monitor:
+    // Mod+Shift+Ctrl+Left  { move-workspace-to-monitor-left; }
+    // ...
+
     Mod+Page_Down      { focus-workspace-down; }
     Mod+Page_Up        { focus-workspace-up; }
     Mod+U              { focus-workspace-down; }

--- a/src/input.rs
+++ b/src/input.rs
@@ -609,6 +609,30 @@ impl State {
                     self.niri.queue_redraw_all();
                 }
             }
+            Action::MoveWorkspaceToMonitorLeft => {
+                if let Some(output) = self.niri.output_left() {
+                    self.niri.layout.move_workspace_to_output(&output);
+                    self.move_cursor_to_output(&output);
+                }
+            }
+            Action::MoveWorkspaceToMonitorRight => {
+                if let Some(output) = self.niri.output_right() {
+                    self.niri.layout.move_workspace_to_output(&output);
+                    self.move_cursor_to_output(&output);
+                }
+            }
+            Action::MoveWorkspaceToMonitorDown => {
+                if let Some(output) = self.niri.output_down() {
+                    self.niri.layout.move_workspace_to_output(&output);
+                    self.move_cursor_to_output(&output);
+                }
+            }
+            Action::MoveWorkspaceToMonitorUp => {
+                if let Some(output) = self.niri.output_up() {
+                    self.niri.layout.move_workspace_to_output(&output);
+                    self.move_cursor_to_output(&output);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
I didn't add the new actions to the default config because I don't have good default bindings. I personally use Mod+Ctrl+Alt, but that clashes with `Alt` as mod for nested Niri and also it's three modifiers at the same time. Unfortunately, this also makes the new actions a bit hard to discover, as the default config also seems to serve as documentation about available features.