### PR TITLE
Allow selecting windows in screenshot UI

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -21,6 +21,7 @@ use smithay::utils::{Logical, Point, SERIAL_COUNTER};
 use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraint};
 use smithay::wayland::tablet_manager::{TabletDescriptor, TabletSeatTrait};
 
+use crate::layout::LayoutElement;
 use crate::niri::State;
 use crate::screenshot_ui::ScreenshotUi;
 use crate::utils::{center, get_monotonic_time, spawn};
@@ -719,7 +720,14 @@ impl State {
             let point = (point - geom.loc.to_f64())
                 .to_physical(output.current_scale().fractional_scale())
                 .to_i32_round();
-            self.niri.screenshot_ui.pointer_motion(point);
+            let window_hovered = self.niri.window_under_cursor().map(|window| {
+                window
+                    .geometry()
+                    .to_physical_precise_round(output.current_scale().fractional_scale())
+            });
+            self.niri
+                .screenshot_ui
+                .pointer_motion(point, window_hovered);
         }
 
         let under = self.niri.surface_under_and_global_space(new_pos);
@@ -819,7 +827,16 @@ impl State {
             let point = (point - geom.loc.to_f64())
                 .to_physical(output.current_scale().fractional_scale())
                 .to_i32_round();
-            self.niri.screenshot_ui.pointer_motion(point);
+            let window_hovered = self.niri.window_under_cursor().map(|window| {
+                let mut window_geom = window.geometry();
+                window_geom.loc += window.buf_loc();
+
+                window_geom.to_physical_precise_round(output.current_scale().fractional_scale())
+            });
+            dbg!(&window_hovered);
+            self.niri
+                .screenshot_ui
+                .pointer_motion(point, window_hovered);
         }
 
         let under = self.niri.surface_under_and_global_space(pos);

--- a/src/input.rs
+++ b/src/input.rs
@@ -720,11 +720,19 @@ impl State {
             let point = (point - geom.loc.to_f64())
                 .to_physical(output.current_scale().fractional_scale())
                 .to_i32_round();
-            let window_hovered = self.niri.window_under_cursor().map(|window| {
-                window
-                    .geometry()
-                    .to_physical_precise_round(output.current_scale().fractional_scale())
-            });
+            let window_hovered = self
+                .niri
+                .layout
+                .window_under(
+                    output,
+                    self.niri.seat.get_pointer().unwrap().current_location(),
+                )
+                .map(|(window, buf_loc)| {
+                    let mut window_geom = window.geometry();
+                    window_geom.loc = buf_loc.unwrap_or_default() - window.buf_loc();
+
+                    window_geom.to_physical_precise_round(output.current_scale().fractional_scale())
+                });
             self.niri
                 .screenshot_ui
                 .pointer_motion(point, window_hovered);
@@ -827,13 +835,19 @@ impl State {
             let point = (point - geom.loc.to_f64())
                 .to_physical(output.current_scale().fractional_scale())
                 .to_i32_round();
-            let window_hovered = self.niri.window_under_cursor().map(|window| {
-                let mut window_geom = window.geometry();
-                window_geom.loc += window.buf_loc();
+            let window_hovered = self
+                .niri
+                .layout
+                .window_under(
+                    output,
+                    self.niri.seat.get_pointer().unwrap().current_location(),
+                )
+                .map(|(window, buf_loc)| {
+                    let mut window_geom = window.geometry();
+                    window_geom.loc = buf_loc.unwrap_or_default() - window.buf_loc();
 
-                window_geom.to_physical_precise_round(output.current_scale().fractional_scale())
-            });
-            dbg!(&window_hovered);
+                    window_geom.to_physical_precise_round(output.current_scale().fractional_scale())
+                });
             self.niri
                 .screenshot_ui
                 .pointer_motion(point, window_hovered);

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1348,7 +1348,7 @@ impl Niri {
     /// The cursor may be inside the window's activation region, but not within the window's input
     /// region.
     pub fn window_under(&self, pos: Point<f64, Logical>) -> Option<&Window> {
-        if self.is_locked() {
+        if self.is_locked() || self.screenshot_ui.is_open() {
             return None;
         }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1348,7 +1348,7 @@ impl Niri {
     /// The cursor may be inside the window's activation region, but not within the window's input
     /// region.
     pub fn window_under(&self, pos: Point<f64, Logical>) -> Option<&Window> {
-        if self.is_locked() || self.screenshot_ui.is_open() {
+        if self.is_locked() {
             return None;
         }
 


### PR DESCRIPTION
When the screenshot UI is opened, this PR allows you to select a window region by clicking on a window.

The region is not shown when dragging or when hovering over an already selected window.

Not tested on multiple outputs since I only have 1 screen. I also had to refactor the code somewhat since it now needs to draw in both open and closed states.

[output.webm](https://github.com/YaLTeR/niri/assets/2574730/c10ea323-92bf-4024-80ea-8b777ed259fc)
