### PR TITLE
add move-window-left/right commands

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -459,6 +459,8 @@ pub enum Action {
     MoveWindowUp,
     MoveWindowDownOrToWorkspaceDown,
     MoveWindowUpOrToWorkspaceUp,
+    ConsumeOrExpelWindowLeft,
+    ConsumeOrExpelWindowRight,
     ConsumeWindowIntoColumn,
     ExpelWindowFromColumn,
     CenterColumn,

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -322,6 +322,10 @@ binds {
     Mod+Comma  { consume-window-into-column; }
     Mod+Period { expel-window-from-column; }
 
+    // There are also commands that consume or expel a single window to the side.
+    // Mod+BracketLeft  { consume-or-expel-window-left; }
+    // Mod+BracketRight { consume-or-expel-window-right; }
+
     Mod+R { switch-preset-column-width; }
     Mod+F { maximize-column; }
     Mod+Shift+F { fullscreen-window; }

--- a/src/input.rs
+++ b/src/input.rs
@@ -407,6 +407,16 @@ impl State {
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
+            Action::ConsumeOrExpelWindowLeft => {
+                self.niri.layout.consume_or_expel_window_left();
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
+            Action::ConsumeOrExpelWindowRight => {
+                self.niri.layout.consume_or_expel_window_right();
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
             Action::FocusColumnLeft => {
                 self.niri.layout.focus_left();
                 // FIXME: granular

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -898,6 +898,20 @@ impl<W: LayoutElement> Layout<W> {
         monitor.move_up_or_to_workspace_up();
     }
 
+    pub fn consume_or_expel_window_left(&mut self) {
+        let Some(monitor) = self.active_monitor() else {
+            return;
+        };
+        monitor.consume_or_expel_window_left();
+    }
+
+    pub fn consume_or_expel_window_right(&mut self) {
+        let Some(monitor) = self.active_monitor() else {
+            return;
+        };
+        monitor.consume_or_expel_window_right();
+    }
+
     pub fn focus_left(&mut self) {
         let Some(monitor) = self.active_monitor() else {
             return;
@@ -1780,6 +1794,8 @@ mod tests {
         MoveWindowUp,
         MoveWindowDownOrToWorkspaceDown,
         MoveWindowUpOrToWorkspaceUp,
+        ConsumeOrExpelWindowLeft,
+        ConsumeOrExpelWindowRight,
         ConsumeWindowIntoColumn,
         ExpelWindowFromColumn,
         CenterColumn,
@@ -1906,6 +1922,8 @@ mod tests {
                 Op::MoveWindowUp => layout.move_up(),
                 Op::MoveWindowDownOrToWorkspaceDown => layout.move_down_or_to_workspace_down(),
                 Op::MoveWindowUpOrToWorkspaceUp => layout.move_up_or_to_workspace_up(),
+                Op::ConsumeOrExpelWindowLeft => layout.consume_or_expel_window_left(),
+                Op::ConsumeOrExpelWindowRight => layout.consume_or_expel_window_right(),
                 Op::ConsumeWindowIntoColumn => layout.consume_into_column(),
                 Op::ExpelWindowFromColumn => layout.expel_from_column(),
                 Op::CenterColumn => layout.center_column(),
@@ -2072,6 +2090,8 @@ mod tests {
             Op::MoveWindowDownOrToWorkspaceDown,
             Op::MoveWindowUp,
             Op::MoveWindowUpOrToWorkspaceUp,
+            Op::ConsumeOrExpelWindowLeft,
+            Op::ConsumeOrExpelWindowRight,
             Op::MoveWorkspaceToOutput(1),
         ];
 
@@ -2203,6 +2223,8 @@ mod tests {
             Op::MoveWindowDownOrToWorkspaceDown,
             Op::MoveWindowUp,
             Op::MoveWindowUpOrToWorkspaceUp,
+            Op::ConsumeOrExpelWindowLeft,
+            Op::ConsumeOrExpelWindowRight,
         ];
 
         for third in every_op {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -215,6 +215,14 @@ impl<W: LayoutElement> Monitor<W> {
         }
     }
 
+    pub fn consume_or_expel_window_left(&mut self) {
+        self.active_workspace().consume_or_expel_window_left();
+    }
+
+    pub fn consume_or_expel_window_right(&mut self) {
+        self.active_workspace().consume_or_expel_window_right();
+    }
+
     pub fn focus_left(&mut self) {
         self.active_workspace().focus_left();
     }


### PR DESCRIPTION
These move the active window alternately into and out of columns. As such, they can be thought of as alternative options to the `consume-window-into-column` and `expel-window-from-column` commands.

In the expel case, they are strictly more flexible, as they can expel the active window both to the left and right.

In the consume case, they differ in that they move the active window into an adjacent column instead of pulling a window to the right into the active column. One example where this is more convenient is when opening two new windows (say terminals) and putting them into one column.

This PR does not add default bindings for these commands. Bindings can be discussed once these commands have been found useful in practice.