### PR TITLE
CI: check nix build works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,3 +143,18 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --all
 
+  nix:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check flake inputs
+        uses: DeterminateSystems/flake-checker-action@v4
+        continue-on-error: true
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v3
+        continue-on-error: true
+
+      - run: nix build
+        continue-on-error: true


### PR DESCRIPTION
it looks like nix builds weren't checked yet so far.

i think it fails now tho, i'm now trying to bisect that (edit: see #181).
