### PR TITLE
exclude visual tests from nix, closes #181

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,16 +39,12 @@
           pname = "niri";
           version = self.rev or "dirty";
 
-          src = nix-filter.lib.filter {
-            root = ./.;
-            include = [
-              ./src
-              ./niri-config
-              ./niri-ipc
-              ./Cargo.toml
-              ./Cargo.lock
-              ./resources
-            ];
+          src = nixpkgs.lib.cleanSourceWith {
+            src = craneLib.path ./.;
+            filter = path: type:
+              (builtins.match "resources" path == null) ||
+              ((craneLib.filterCargoSources path type) &&
+              (builtins.match "niri-visual-tests" path == null));
           };
 
           nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
i originally tried to address this using `nix-filter`'s `exclude`, tho that approach i had not managed to get to work.
reviews welcome. 🙏 @bryceberger @billksun
