### PR TITLE
Use nearest scaling for integer-upscaled surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3005,7 +3005,7 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/Smithay/smithay.git#91e61f13501f21d66803efac947bfafed43080c5"
+source = "git+https://github.com/YaLTeR/smithay.git?rev=0c06b7889b72e4392d89fab91f2d2cf4f272db83#0c06b7889b72e4392d89fab91f2d2cf4f272db83"
 dependencies = [
  "appendlist",
  "bitflags 2.4.2",
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#91e61f13501f21d66803efac947bfafed43080c5"
+source = "git+https://github.com/YaLTeR/smithay.git?rev=0c06b7889b72e4392d89fab91f2d2cf4f272db83#0c06b7889b72e4392d89fab91f2d2cf4f272db83"
 dependencies = [
  "drm",
  "edid-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,14 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracy-client = { version = "0.16.5", default-features = false }
 
 [workspace.dependencies.smithay]
-git = "https://github.com/Smithay/smithay.git"
+git = "https://github.com/YaLTeR/smithay.git"
+rev = "0c06b7889b72e4392d89fab91f2d2cf4f272db83"
 # path = "../smithay"
 default-features = false
 
 [workspace.dependencies.smithay-drm-extras]
-git = "https://github.com/Smithay/smithay.git"
+git = "https://github.com/YaLTeR/smithay.git"
+rev = "0c06b7889b72e4392d89fab91f2d2cf4f272db83"
 # path = "../smithay/smithay-drm-extras"
 
 [package]

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -629,12 +629,18 @@ impl<W: LayoutElement> Monitor<W> {
                 let before = self.workspaces[before_idx].render_elements(renderer);
                 let after = self.workspaces[after_idx].render_elements(renderer);
 
+                // HACK: crop to infinite bounds for all sides except the side where the workspaces
+                // join, to decrease the chance of cutting a lower-scale surface in the middle of a
+                // pixel, thereby disabling its nearest-neighbor upscaling.
                 let before = before.into_iter().filter_map(|elem| {
                     Some(RelocateRenderElement::from_element(
                         CropRenderElement::from_element(
                             elem,
                             output_scale,
-                            Rectangle::from_extemities((0, offset), (size.w, size.h)),
+                            Rectangle::from_extemities(
+                                (-i32::MAX / 2, -i32::MAX / 2),
+                                (i32::MAX / 2, size.h),
+                            ),
                         )?,
                         (0, -offset),
                         Relocate::Relative,
@@ -645,7 +651,10 @@ impl<W: LayoutElement> Monitor<W> {
                         CropRenderElement::from_element(
                             elem,
                             output_scale,
-                            Rectangle::from_extemities((0, 0), (size.w, offset)),
+                            Rectangle::from_extemities(
+                                (-i32::MAX / 2, 0),
+                                (i32::MAX / 2, i32::MAX / 2),
+                            ),
                         )?,
                         (0, -offset + size.h),
                         Relocate::Relative,

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -6,6 +6,7 @@ use smithay::backend::renderer::sync::SyncPoint;
 use smithay::backend::renderer::{Bind, ExportMem, Frame, Offscreen, Renderer};
 use smithay::utils::{Physical, Rectangle, Scale, Size, Transform};
 
+pub mod nearest_integer_scale;
 pub mod offscreen;
 pub mod primary_gpu_texture;
 pub mod render_elements;

--- a/src/render_helpers/nearest_integer_scale.rs
+++ b/src/render_helpers/nearest_integer_scale.rs
@@ -1,0 +1,100 @@
+use smithay::backend::renderer::element::{Element, Id, Kind, RenderElement, UnderlyingStorage};
+use smithay::backend::renderer::utils::CommitCounter;
+use smithay::backend::renderer::{Frame, Renderer, TextureFilter};
+use smithay::utils::{Buffer, Physical, Rectangle, Scale, Transform};
+
+#[derive(Debug)]
+pub struct NearestIntegerScale<E: Element>(E);
+
+impl<E: Element> From<E> for NearestIntegerScale<E> {
+    fn from(value: E) -> Self {
+        Self(value)
+    }
+}
+
+impl<E: Element> Element for NearestIntegerScale<E> {
+    fn id(&self) -> &Id {
+        self.0.id()
+    }
+
+    fn current_commit(&self) -> CommitCounter {
+        self.0.current_commit()
+    }
+
+    fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
+        self.0.geometry(scale)
+    }
+
+    fn transform(&self) -> Transform {
+        self.0.transform()
+    }
+
+    fn src(&self) -> Rectangle<f64, Buffer> {
+        self.0.src()
+    }
+
+    fn damage_since(
+        &self,
+        scale: Scale<f64>,
+        commit: Option<CommitCounter>,
+    ) -> Vec<Rectangle<i32, Physical>> {
+        self.0.damage_since(scale, commit)
+    }
+
+    fn opaque_regions(&self, scale: Scale<f64>) -> Vec<Rectangle<i32, Physical>> {
+        self.0.opaque_regions(scale)
+    }
+
+    fn alpha(&self) -> f32 {
+        self.0.alpha()
+    }
+
+    fn kind(&self) -> Kind {
+        self.0.kind()
+    }
+}
+
+impl<R: Renderer, E: RenderElement<R>> RenderElement<R> for NearestIntegerScale<E> {
+    fn draw(
+        &self,
+        frame: &mut <R as Renderer>::Frame<'_>,
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+    ) -> Result<(), R::Error> {
+        let mut use_nearest = false;
+
+        // Check that we don't need to interpolate between src pixels.
+        let src_i32 = src.to_i32_down::<i32>();
+        if src_i32.to_f64() == src {
+            // Check that the src is not zero.
+            if !src_i32.size.is_empty() {
+                // Check that the scale factor is an integer.
+                let scale_x = dst.size.w / src_i32.size.w;
+                let scale_y = dst.size.h / src_i32.size.h;
+                if scale_x * src_i32.size.w == dst.size.w && scale_y * src_i32.size.h == dst.size.h
+                {
+                    use_nearest = true;
+                }
+            }
+        }
+
+        let mut prev_filter = TextureFilter::Linear;
+        if use_nearest {
+            prev_filter = frame.upscale_filter();
+            frame.set_upscale_filter(TextureFilter::Nearest);
+        }
+
+        let rv = self.0.draw(frame, src, dst, damage);
+
+        if use_nearest {
+            frame.set_upscale_filter(prev_filter);
+        }
+
+        rv
+    }
+
+    fn underlying_storage(&self, renderer: &mut R) -> Option<UnderlyingStorage> {
+        self.0.underlying_storage(renderer)
+    }
+}


### PR DESCRIPTION
Doesn't currently work for the cursor plane, as a similar logic would need to somehow be threaded inside there.

For the primary plane I'm not even sure what sets the scaling filter, seems to use linear for me.

@kchibisov please give this a try.