### PR TITLE
Add the beginnings of window rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,7 @@ dependencies = [
  "knuffel",
  "miette",
  "niri-ipc",
+ "regex",
  "smithay",
  "tracing",
  "tracy-client",

--- a/niri-config/Cargo.toml
+++ b/niri-config/Cargo.toml
@@ -12,6 +12,7 @@ bitflags.workspace = true
 knuffel = "3.2.0"
 miette = "5.10.0"
 niri-ipc = { version = "0.1.1", path = "../niri-ipc" }
+regex = "1.10.3"
 smithay = { workspace = true, features = ["backend_libinput"] }
 tracing.workspace = true
 tracy-client.workspace = true

--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -143,7 +143,8 @@ impl Layout {
     }
 
     fn add_window(&mut self, window: TestWindow, width: Option<ColumnWidth>) {
-        self.layout.add_window(window.clone(), width, false);
+        self.layout
+            .add_window(window.clone(), width.map(Some), false);
         if window.communicate() {
             self.layout.update_window(&window);
         }
@@ -157,7 +158,7 @@ impl Layout {
         width: Option<ColumnWidth>,
     ) {
         self.layout
-            .add_window_right_of(right_of, window.clone(), width, false);
+            .add_window_right_of(right_of, window.clone(), width.map(Some), false);
         if window.communicate() {
             self.layout.update_window(&window);
         }

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -248,6 +248,49 @@ animations {
     }
 }
 
+// Window rules let you adjust behavior for individual windows.
+// They are processed in order of appearance in this file.
+// (This example rule is commented out with a "/-" in front.)
+/-window-rule {
+    // Match directives control which windows this rule will apply to.
+    // You can match by app-id and by title.
+    // The window must match all properties of the match directive.
+    match app-id="org.myapp.MyApp" title="My Cool App"
+
+    // There can be multiple match directives. A window must match any one
+    // of the rule's match directives.
+    //
+    // If there are no match directives, any window will match the rule.
+    match title="Second App"
+
+    // You can also add exclude directives which have the same properties.
+    // If a window matches any exclude directive, it won't match this rule.
+    //
+    // Both app-id and title are regular expressions.
+    // Raw KDL strings are helpful here.
+    exclude app-id=r#"\.unwanted\."#
+
+    // Here are the properties that you can set on a window rule.
+    // You can override the default column width.
+    default-column-width { proportion 0.75; }
+
+    // You can set the output that this window will initially open on.
+    // If such an output does not exist, it will open on the currently
+    // focused output as usual.
+    open-on-output "eDP-1"
+}
+
+// Here's a useful example. Work around WezTerm's initial configure bug
+// by setting an empty default-column-width.
+window-rule {
+    // This regular expression is intentially made as specific as possile,
+    // since this is the default config, and we want no false positives.
+    // You can get away with just app-id="wezterm" if you want.
+    // The regular expression can match anywhere in the string.
+    match app-id=r#"^org\.wezfurlong\.wezterm$"#
+    default-column-width {}
+}
+
 binds {
     // Keys consist of modifiers separated by + signs, followed by an XKB key name
     // in the end. To find an XKB name for a particular key, you may use a program

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -76,6 +76,10 @@ impl<W: LayoutElement> Monitor<W> {
         }
     }
 
+    pub fn active_workspace_ref(&self) -> &Workspace<W> {
+        &self.workspaces[self.active_workspace_idx]
+    }
+
     pub fn active_workspace(&mut self) -> &mut Workspace<W> {
         &mut self.workspaces[self.active_workspace_idx]
     }

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -321,8 +321,17 @@ impl<W: LayoutElement> Workspace<W> {
         ))
     }
 
-    pub fn new_window_size(&self) -> Size<i32, Logical> {
-        let width = if let Some(width) = self.options.default_width {
+    pub fn new_window_size(
+        &self,
+        default_width: Option<Option<ColumnWidth>>,
+    ) -> Size<i32, Logical> {
+        let default_width = match default_width {
+            Some(Some(width)) => Some(width),
+            Some(None) => None,
+            None => self.options.default_width,
+        };
+
+        let width = if let Some(width) = default_width {
             let mut width = width.resolve(&self.options, self.working_area.size.w);
             if !self.options.border.off {
                 width -= self.options.border.width as i32 * 2;
@@ -340,8 +349,12 @@ impl<W: LayoutElement> Workspace<W> {
         Size::from((width, max(height, 1)))
     }
 
-    pub fn configure_new_window(&self, window: &Window) {
-        let size = self.new_window_size();
+    pub fn configure_new_window(
+        &self,
+        window: &Window,
+        default_width: Option<Option<ColumnWidth>>,
+    ) {
+        let size = self.new_window_size(default_width);
         let bounds = self.toplevel_bounds();
 
         if let Some(output) = self.output.as_ref() {


### PR DESCRIPTION
For now just `default-column-width` and `open-on-output`. Other interesting rules will need some refactoring, and rules that can apply dynamically will also need some Smithay additions.

@zkat I think this should partially cover your use-case of opening some applications on specific outputs. Mind giving it a try?