### PR TITLE
input: enable configuring of trackpoint devices

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -57,6 +57,8 @@ pub struct Input {
     #[knuffel(child, default)]
     pub mouse: Mouse,
     #[knuffel(child, default)]
+    pub trackpoint: Trackpoint,
+    #[knuffel(child, default)]
     pub tablet: Tablet,
     #[knuffel(child)]
     pub disable_power_key_handling: bool,
@@ -143,6 +145,16 @@ pub struct Touchpad {
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
 pub struct Mouse {
+    #[knuffel(child)]
+    pub natural_scroll: bool,
+    #[knuffel(child, unwrap(argument), default)]
+    pub accel_speed: f64,
+    #[knuffel(child, unwrap(argument, str))]
+    pub accel_profile: Option<AccelProfile>,
+}
+
+#[derive(knuffel::Decode, Debug, Default, PartialEq)]
+pub struct Trackpoint {
     #[knuffel(child)]
     pub natural_scroll: bool,
     #[knuffel(child, unwrap(argument), default)]
@@ -924,6 +936,12 @@ mod tests {
                     accel-profile "flat"
                 }
 
+                trackpoint {
+                    natural-scroll
+                    accel-speed 0.0
+                    accel-profile "flat"
+                }
+
                 tablet {
                     map-to-output "eDP-1"
                 }
@@ -1041,6 +1059,11 @@ mod tests {
                     mouse: Mouse {
                         natural_scroll: true,
                         accel_speed: 0.4,
+                        accel_profile: Some(AccelProfile::Flat),
+                    },
+                    trackpoint: Trackpoint {
+                        natural_scroll: true,
+                        accel_speed: 0.0,
                         accel_profile: Some(AccelProfile::Flat),
                     },
                     tablet: Tablet {

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -41,6 +41,12 @@ input {
         // accel-profile "flat"
     }
 
+    trackpoint {
+        // natural-scroll
+        // accel-speed 0.2
+        // accel-profile "flat"
+    }
+
     tablet {
         // Set the name of the output (see below) which the tablet will map to.
         // If this is unset or the output doesn't exist, the tablet maps to one of the

--- a/src/input.rs
+++ b/src/input.rs
@@ -1622,6 +1622,18 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
             let _ = device.config_accel_set_profile(default);
         }
     }
+
+    if is_trackpoint {
+        let c = &config.trackpoint;
+        let _ = device.config_scroll_set_natural_scroll_enabled(c.natural_scroll);
+        let _ = device.config_accel_set_speed(c.accel_speed);
+
+        if let Some(accel_profile) = c.accel_profile {
+            let _ = device.config_accel_set_profile(accel_profile.into());
+        } else if let Some(default) = device.config_accel_default_profile() {
+            let _ = device.config_accel_set_profile(default);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -628,6 +628,7 @@ impl State {
 
         if config.input.touchpad != old_config.input.touchpad
             || config.input.mouse != old_config.input.mouse
+            || config.input.trackpoint != old_config.input.trackpoint
         {
             libinput_config_changed = true;
         }


### PR DESCRIPTION
This adds the ability to configure trackpoint type input devices in a similar manner it can be done for regular mice, i.e. using the same set of configuration options.

I've tested this on ThinkPad X1 Extreme Gen. 5 running NixOS, and I suppose it should likely work elsewhere where there's basic trackpoint support.

Let me know if I missed anything.