### PR TITLE
Correctly handle parsing of Binds and DefaultColumnWidth

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,10 @@
             pkg-config
             autoPatchelfHook
             clang
+            gdk-pixbuf
+            graphene
+            gtk4
+            libadwaita
           ];
 
           buildInputs = with pkgs; [

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate tracing;
 
 use std::collections::HashSet;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -823,7 +824,13 @@ impl Config {
             .into_diagnostic()
             .with_context(|| format!("error reading {path:?}"))?;
 
-        let config = Self::parse("config.kdl", &contents).context("error parsing")?;
+        let config = Self::parse(
+            path.file_name()
+                .and_then(OsStr::to_str)
+                .unwrap_or("config.kdl"),
+            &contents,
+        )
+        .context("error parsing")?;
         debug!("loaded config from {path:?}");
         Ok(config)
     }

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -81,7 +81,7 @@ pub fn resolve_window_rules(
             if let Some(x) = rule
                 .default_column_width
                 .as_ref()
-                .map(|d| d.0.first().copied().map(ColumnWidth::from))
+                .map(|d| d.0.map(ColumnWidth::from))
             {
                 resolved.default_width = Some(x);
             }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1650,7 +1650,7 @@ fn bound_action(
         }
 
         if bind_modifiers == modifiers {
-            return bind.actions.first().cloned();
+            return Some(bind.action.clone());
         }
     }
 
@@ -1815,7 +1815,7 @@ mod tests {
                 keysym: close_keysym,
                 modifiers: Modifiers::COMPOSITOR | Modifiers::CTRL,
             },
-            actions: vec![Action::CloseWindow],
+            action: Action::CloseWindow,
         }]);
 
         let comp_mod = CompositorMod::Super;
@@ -1937,35 +1937,35 @@ mod tests {
                     keysym: Keysym::q,
                     modifiers: Modifiers::COMPOSITOR,
                 },
-                actions: vec![Action::CloseWindow],
+                action: Action::CloseWindow,
             },
             Bind {
                 key: Key {
                     keysym: Keysym::h,
                     modifiers: Modifiers::SUPER,
                 },
-                actions: vec![Action::FocusColumnLeft],
+                action: Action::FocusColumnLeft,
             },
             Bind {
                 key: Key {
                     keysym: Keysym::j,
                     modifiers: Modifiers::empty(),
                 },
-                actions: vec![Action::FocusWindowDown],
+                action: Action::FocusWindowDown,
             },
             Bind {
                 key: Key {
                     keysym: Keysym::k,
                     modifiers: Modifiers::COMPOSITOR | Modifiers::SUPER,
                 },
-                actions: vec![Action::FocusWindowUp],
+                action: Action::FocusWindowUp,
             },
             Bind {
                 key: Key {
                     keysym: Keysym::l,
                     modifiers: Modifiers::SUPER | Modifiers::ALT,
                 },
-                actions: vec![Action::FocusColumnRight],
+                action: Action::FocusColumnRight,
             },
         ]);
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -200,7 +200,7 @@ impl Options {
         let default_width = layout
             .default_column_width
             .as_ref()
-            .map(|w| w.0.first().copied().map(ColumnWidth::from))
+            .map(|w| w.0.map(ColumnWidth::from))
             .unwrap_or(Some(ColumnWidth::Proportion(0.5)));
 
         Self {

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -159,15 +159,9 @@ fn render(config: &Config, comp_mod: CompositorMod, scale: i32) -> anyhow::Resul
 
     // Prefer Quit(false) if found, otherwise try Quit(true), and if there's neither, fall back to
     // Quit(false).
-    if binds
-        .iter()
-        .any(|bind| bind.actions.first() == Some(&Action::Quit(false)))
-    {
+    if binds.iter().any(|bind| bind.action == Action::Quit(false)) {
         actions.push(&Action::Quit(false));
-    } else if binds
-        .iter()
-        .any(|bind| bind.actions.first() == Some(&Action::Quit(true)))
-    {
+    } else if binds.iter().any(|bind| bind.action == Action::Quit(true)) {
         actions.push(&Action::Quit(true));
     } else {
         actions.push(&Action::Quit(false));
@@ -186,12 +180,12 @@ fn render(config: &Config, comp_mod: CompositorMod, scale: i32) -> anyhow::Resul
     // Prefer move-column-to-workspace-down, but fall back to move-window-to-workspace-down.
     if binds
         .iter()
-        .any(|bind| bind.actions.first() == Some(&Action::MoveColumnToWorkspaceDown))
+        .any(|bind| bind.action == Action::MoveColumnToWorkspaceDown)
     {
         actions.push(&Action::MoveColumnToWorkspaceDown);
     } else if binds
         .iter()
-        .any(|bind| bind.actions.first() == Some(&Action::MoveWindowToWorkspaceDown))
+        .any(|bind| bind.action == Action::MoveWindowToWorkspaceDown)
     {
         actions.push(&Action::MoveWindowToWorkspaceDown);
     } else {
@@ -201,12 +195,12 @@ fn render(config: &Config, comp_mod: CompositorMod, scale: i32) -> anyhow::Resul
     // Same for -up.
     if binds
         .iter()
-        .any(|bind| bind.actions.first() == Some(&Action::MoveColumnToWorkspaceUp))
+        .any(|bind| bind.action == Action::MoveColumnToWorkspaceUp)
     {
         actions.push(&Action::MoveColumnToWorkspaceUp);
     } else if binds
         .iter()
-        .any(|bind| bind.actions.first() == Some(&Action::MoveWindowToWorkspaceUp))
+        .any(|bind| bind.action == Action::MoveWindowToWorkspaceUp)
     {
         actions.push(&Action::MoveWindowToWorkspaceUp);
     } else {
@@ -221,22 +215,19 @@ fn render(config: &Config, comp_mod: CompositorMod, scale: i32) -> anyhow::Resul
     ]);
 
     // Screenshot is not as important, can omit if not bound.
-    if binds
-        .iter()
-        .any(|bind| bind.actions.first() == Some(&Action::Screenshot))
-    {
+    if binds.iter().any(|bind| bind.action == Action::Screenshot) {
         actions.push(&Action::Screenshot);
     }
 
     // Add the spawn actions.
     let mut spawn_actions = Vec::new();
     for bind in binds.iter().filter(|bind| {
-        matches!(bind.actions.first(), Some(Action::Spawn(_)))
+        matches!(bind.action, Action::Spawn(_))
             // Only show binds with Mod or Super to filter out stuff like volume up/down.
             && (bind.key.modifiers.contains(Modifiers::COMPOSITOR)
                 || bind.key.modifiers.contains(Modifiers::SUPER))
     }) {
-        let action = bind.actions.first().unwrap();
+        let action = &bind.action;
 
         // We only show one bind for each action, so we need to deduplicate the Spawn actions.
         if !spawn_actions.contains(&action) {
@@ -252,7 +243,7 @@ fn render(config: &Config, comp_mod: CompositorMod, scale: i32) -> anyhow::Resul
                 .binds
                 .0
                 .iter()
-                .find(|bind| bind.actions.first() == Some(action))
+                .find(|bind| bind.action == *action)
                 .map(|bind| key_name(comp_mod, &bind.key))
                 .unwrap_or_else(|| String::from("(not bound)"));
 


### PR DESCRIPTION
Previously, for `default-column-width` as well as keybinds, you could specify multiple children. Subsequent children after the first one were ignored. Now, this emits an error.

Additionally, i've also also made sure you can't register duplicate keybinds. This will emit an error, too. Previously, this resulted in some very strange behaviour, as detailed in the issue that this will fix #233

However, there is still the question of how  `Mod` and `Super`/`Alt` should interact, if they result in duplicate keybinds. Currently, this edge case just results in the old behaviour. I haven't handled it. Maybe binds that differs only by `Mod` vs `Super`/`Alt` should always count as duplicates? Should some new property be added to configure this behaviour? i.e. `Super+Alt+L nested="Ctrl+Alt+L" { spawn "swaylock"; }`, `Super+Alt+L nested=null { spawn "swaylock"; }`?