### PR TITLE
implement wlr-screencopy

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707685877,
-        "narHash": "sha256-XoXRS+5whotelr1rHiZle5t5hDg9kpguS5yk8c8qzOc=",
+        "lastModified": 1709610799,
+        "narHash": "sha256-5jfLQx0U9hXbi2skYMGodDJkIgffrjIOgMRjZqms2QE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2c653e4478476a52c6aa3ac0495e4dea7449ea0e",
+        "rev": "81c393c776d5379c030607866afef6406ca1be57",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1706768574,
-        "narHash": "sha256-4o6TMpzBHO659EiJTzd/EGQGUDdbgwKwhqf3u6b23U8=",
+        "lastModified": 1709274179,
+        "narHash": "sha256-O6EC6QELBLHzhdzBOJj0chx8AOcd4nDRECIagfT5Nd0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "668102037129923cd0fc239d864fce71eabdc6a3",
+        "rev": "4be608f4f81d351aacca01b21ffd91028c23cc22",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707619277,
-        "narHash": "sha256-vKnYD5GMQbNQyyQm4wRlqi+5n0/F1hnvqSQgaBy4BqY=",
+        "lastModified": 1709386671,
+        "narHash": "sha256-VPqfBnIJ+cfa78pd4Y5Cr6sOWVW8GYHRVucxJGmRf8Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3a93440fbfff8a74350f4791332a19282cc6dc8",
+        "rev": "fa9a51752f1b5de583ad5213eb621be071806663",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1706735270,
-        "narHash": "sha256-IJk+UitcJsxzMQWm9pa1ZbJBriQ4ginXOlPyVq+Cu40=",
+        "lastModified": 1709219524,
+        "narHash": "sha256-8HHRXm4kYQLdUohNDUuCC3Rge7fXrtkjBUf0GERxrkM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "42cb1a2bd79af321b0cc503d2960b73f34e2f92b",
+        "rev": "9efa23c4dacee88b93540632eb3d88c5dfebfe17",
         "type": "github"
       },
       "original": {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -383,13 +383,12 @@ delegate_foreign_toplevel!(State);
 
 impl ScreencopyHandler for State {
     fn frame(&mut self, screencopy: Screencopy) {
-        let output = screencopy.output().clone();
-        if let Some(state) = self.niri.output_state.get_mut(&output) {
-            state.pending_screencopy.push(screencopy);
+        if let Err(err) = self
+            .niri
+            .render_for_screencopy(&mut self.backend, screencopy)
+        {
+            warn!("error rendering for screencopy: {err:?}");
         }
-
-        // Force redraw, to prevent screencopy stalling.
-        self.niri.queue_redraw(output);
     }
 }
 delegate_screencopy!(State);

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -54,12 +54,13 @@ use smithay::{
     delegate_text_input_manager, delegate_virtual_keyboard_manager,
 };
 
-use crate::delegate_foreign_toplevel;
 use crate::niri::{ClientState, State};
 use crate::protocols::foreign_toplevel::{
     self, ForeignToplevelHandler, ForeignToplevelManagerState,
 };
+use crate::protocols::screencopy::{Screencopy, ScreencopyHandler};
 use crate::utils::output_size;
+use crate::{delegate_foreign_toplevel, delegate_screencopy};
 
 impl SeatHandler for State {
     type KeyboardFocus = WlSurface;
@@ -379,6 +380,19 @@ impl ForeignToplevelHandler for State {
     }
 }
 delegate_foreign_toplevel!(State);
+
+impl ScreencopyHandler for State {
+    fn frame(&mut self, screencopy: Screencopy) {
+        let output = screencopy.output().clone();
+        if let Some(state) = self.niri.output_state.get_mut(&output) {
+            state.pending_screencopy.push(screencopy);
+        }
+
+        // Force redraw, to prevent screencopy stalling.
+        self.niri.queue_redraw(output);
+    }
+}
+delegate_screencopy!(State);
 
 impl DrmLeaseHandler for State {
     fn drm_lease_state(&mut self, node: DrmNode) -> &mut DrmLeaseState {

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -1,1 +1,2 @@
 pub mod foreign_toplevel;
+pub mod screencopy;

--- a/src/protocols/screencopy.rs
+++ b/src/protocols/screencopy.rs
@@ -1,0 +1,346 @@
+use std::os::fd::OwnedFd;
+use std::time::UNIX_EPOCH;
+
+use calloop::generic::Generic;
+use calloop::{Interest, LoopHandle, Mode, PostAction};
+use smithay::output::Output;
+use smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_frame_v1::{
+    Flags, ZwlrScreencopyFrameV1,
+};
+use smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1;
+use smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::{
+    zwlr_screencopy_frame_v1, zwlr_screencopy_manager_v1,
+};
+use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
+use smithay::reexports::wayland_server::protocol::wl_shm;
+use smithay::reexports::wayland_server::{
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+};
+use smithay::utils::{Physical, Rectangle};
+use smithay::wayland::shm;
+
+const VERSION: u32 = 3;
+
+pub struct ScreencopyManagerState;
+
+pub struct ScreencopyManagerGlobalData {
+    filter: Box<dyn for<'c> Fn(&'c Client) -> bool + Send + Sync>,
+}
+
+impl ScreencopyManagerState {
+    pub fn new<D, F>(display: &DisplayHandle, filter: F) -> Self
+    where
+        D: GlobalDispatch<ZwlrScreencopyManagerV1, ScreencopyManagerGlobalData>,
+        D: Dispatch<ZwlrScreencopyManagerV1, ()>,
+        D: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameState>,
+        D: ScreencopyHandler,
+        D: 'static,
+        F: for<'c> Fn(&'c Client) -> bool + Send + Sync + 'static,
+    {
+        let global_data = ScreencopyManagerGlobalData {
+            filter: Box::new(filter),
+        };
+        display.create_global::<D, ZwlrScreencopyManagerV1, _>(VERSION, global_data);
+
+        Self
+    }
+}
+
+impl<D> GlobalDispatch<ZwlrScreencopyManagerV1, ScreencopyManagerGlobalData, D>
+    for ScreencopyManagerState
+where
+    D: GlobalDispatch<ZwlrScreencopyManagerV1, ScreencopyManagerGlobalData>,
+    D: Dispatch<ZwlrScreencopyManagerV1, ()>,
+    D: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameState>,
+    D: ScreencopyHandler,
+    D: 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _display: &DisplayHandle,
+        _client: &Client,
+        manager: New<ZwlrScreencopyManagerV1>,
+        _manager_state: &ScreencopyManagerGlobalData,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(manager, ());
+    }
+
+    fn can_view(client: Client, global_data: &ScreencopyManagerGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+impl<D> Dispatch<ZwlrScreencopyManagerV1, (), D> for ScreencopyManagerState
+where
+    D: GlobalDispatch<ZwlrScreencopyManagerV1, ScreencopyManagerGlobalData>,
+    D: Dispatch<ZwlrScreencopyManagerV1, ()>,
+    D: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameState>,
+    D: ScreencopyHandler,
+    D: 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &Client,
+        manager: &ZwlrScreencopyManagerV1,
+        request: zwlr_screencopy_manager_v1::Request,
+        _data: &(),
+        _display: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        let (frame, overlay_cursor, rect, output) = match request {
+            zwlr_screencopy_manager_v1::Request::CaptureOutput {
+                frame,
+                overlay_cursor,
+                output,
+            } => {
+                let output = Output::from_resource(&output).unwrap();
+                let rect =
+                    Rectangle::from_loc_and_size((0, 0), output.current_mode().unwrap().size);
+                (frame, overlay_cursor, rect, output)
+            }
+            zwlr_screencopy_manager_v1::Request::CaptureOutputRegion {
+                frame,
+                overlay_cursor,
+                x,
+                y,
+                width,
+                height,
+                output,
+            } => {
+                let output = Output::from_resource(&output).unwrap();
+                let (x, width) = if width < 0 {
+                    (x + width, -width)
+                } else {
+                    (x, width)
+                };
+                let (y, height) = if height < 0 {
+                    (y + height, -height)
+                } else {
+                    (y, height)
+                };
+                let rect = Rectangle::from_loc_and_size((x, y), (width, height));
+
+                // Translate logical rect to physical framebuffer coordinates.
+                let output_transform = output.current_transform();
+                let rotated_rect = output_transform.transform_rect_in(
+                    rect,
+                    &output
+                        .current_mode()
+                        .unwrap()
+                        .size
+                        .to_f64()
+                        .to_logical(output.current_scale().fractional_scale())
+                        .to_i32_round(),
+                );
+                let physical_rect =
+                    rotated_rect.to_physical_precise_round(output.current_scale().integer_scale());
+
+                // Clamp captured region to the output.
+                let clamped_rect = physical_rect
+                    .intersection(Rectangle::from_loc_and_size(
+                        (0, 0),
+                        output.current_mode().unwrap().size,
+                    ))
+                    .unwrap_or_default();
+
+                (frame, overlay_cursor, clamped_rect, output)
+            }
+            zwlr_screencopy_manager_v1::Request::Destroy => return,
+            _ => unreachable!(),
+        };
+
+        // Create the frame.
+        let overlay_cursor = overlay_cursor != 0;
+        let frame = data_init.init(
+            frame,
+            ScreencopyFrameState {
+                output,
+                overlay_cursor,
+                rect,
+            },
+        );
+
+        // Send desired SHM buffer parameters.
+        frame.buffer(
+            wl_shm::Format::Argb8888,
+            rect.size.w as u32,
+            rect.size.h as u32,
+            rect.size.w as u32 * 4,
+        );
+
+        if manager.version() >= 3 {
+            // // Send desired DMA buffer parameters.
+            // frame.linux_dmabuf(
+            //     Fourcc::Argb8888 as u32,
+            //     rect.size.w as u32,
+            //     rect.size.h as u32,
+            // );
+
+            // Notify client that all supported buffers were enumerated.
+            frame.buffer_done();
+        }
+    }
+}
+
+/// Handler trait for wlr-screencopy.
+pub trait ScreencopyHandler {
+    /// Handle new screencopy request.
+    fn frame(&mut self, frame: Screencopy);
+}
+
+#[allow(missing_docs)]
+#[macro_export]
+macro_rules! delegate_screencopy {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        smithay::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1: $crate::protocols::screencopy::ScreencopyManagerGlobalData
+        ] => $crate::protocols::screencopy::ScreencopyManagerState);
+
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1: ()
+        ] => $crate::protocols::screencopy::ScreencopyManagerState);
+
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_frame_v1::ZwlrScreencopyFrameV1: $crate::protocols::screencopy::ScreencopyFrameState
+        ] => $crate::protocols::screencopy::ScreencopyManagerState);
+    };
+}
+
+#[derive(Clone)]
+pub struct ScreencopyFrameState {
+    pub output: Output,
+    pub rect: Rectangle<i32, Physical>,
+    pub overlay_cursor: bool,
+}
+
+impl<D> Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameState, D> for ScreencopyManagerState
+where
+    D: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameState>,
+    D: ScreencopyHandler,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        frame: &ZwlrScreencopyFrameV1,
+        request: zwlr_screencopy_frame_v1::Request,
+        data: &ScreencopyFrameState,
+        _display: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        let (buffer, send_damage) = match request {
+            zwlr_screencopy_frame_v1::Request::Copy { buffer } => (buffer, false),
+            zwlr_screencopy_frame_v1::Request::CopyWithDamage { buffer } => (buffer, true),
+            zwlr_screencopy_frame_v1::Request::Destroy => return,
+            _ => unreachable!(),
+        };
+
+        if let Ok(true) = shm::with_buffer_contents(&buffer, |_buf, shm_len, buffer_data| {
+            buffer_data.format == wl_shm::Format::Argb8888
+                && buffer_data.stride == data.rect.size.w * 4
+                && buffer_data.height == data.rect.size.h
+                && shm_len as i32 == buffer_data.stride * buffer_data.height
+        }) {
+            state.frame(Screencopy {
+                send_damage,
+                buffer,
+                frame: frame.clone(),
+                frame_state: data.clone(),
+                submitted: false,
+            });
+        } else {
+            warn!("Client provided invalid buffer for screencopy. Rejecting.");
+            frame.failed();
+        }
+    }
+}
+
+/// Screencopy frame.
+pub struct Screencopy {
+    frame_state: ScreencopyFrameState,
+    frame: ZwlrScreencopyFrameV1,
+    send_damage: bool,
+    buffer: WlBuffer,
+    submitted: bool,
+}
+
+impl Drop for Screencopy {
+    fn drop(&mut self) {
+        if !self.submitted {
+            self.frame.failed();
+        }
+    }
+}
+
+impl Screencopy {
+    /// Get the target buffer to copy to.
+    pub fn buffer(&self) -> &WlBuffer {
+        &self.buffer
+    }
+
+    /// Get the region which should be copied.
+    pub fn region(&self) -> Rectangle<i32, Physical> {
+        self.frame_state.rect
+    }
+
+    pub fn output(&self) -> &Output {
+        &self.frame_state.output
+    }
+
+    pub fn overlay_cursor(&self) -> bool {
+        self.frame_state.overlay_cursor
+    }
+
+    /// Mark damaged regions of the screencopy buffer.
+    pub fn damage(&mut self, damage: &[Rectangle<i32, Physical>]) {
+        if !self.send_damage {
+            return;
+        }
+
+        for Rectangle { loc, size } in damage {
+            self.frame
+                .damage(loc.x as u32, loc.y as u32, size.w as u32, size.h as u32);
+        }
+    }
+
+    /// Submit the copied content.
+    pub fn submit(mut self, y_invert: bool) {
+        // Notify client that buffer is ordinary.
+        self.frame.flags(if y_invert {
+            Flags::YInvert
+        } else {
+            Flags::empty()
+        });
+
+        // Notify client about successful copy.
+        let now = UNIX_EPOCH.elapsed().unwrap();
+        let secs = now.as_secs();
+        self.frame
+            .ready((secs >> 32) as u32, secs as u32, now.subsec_nanos());
+
+        // Mark frame as submitted to ensure destructor isn't run.
+        self.submitted = true;
+    }
+
+    pub fn submit_after_sync<T>(
+        self,
+        y_invert: bool,
+        sync_point: Option<OwnedFd>,
+        event_loop: &LoopHandle<'_, T>,
+    ) {
+        match sync_point {
+            None => self.submit(y_invert),
+            Some(sync_fd) => {
+                let source = Generic::new(sync_fd, Interest::READ, Mode::OneShot);
+                let mut screencopy = Some(self);
+                event_loop
+                    .insert_source(source, move |_, _, _| {
+                        screencopy.take().unwrap().submit(y_invert);
+                        Ok(PostAction::Remove)
+                    })
+                    .unwrap();
+            }
+        }
+    }
+}

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -1,10 +1,15 @@
 use anyhow::Context;
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::renderer::element::RenderElement;
-use smithay::backend::renderer::gles::{GlesMapping, GlesRenderer, GlesTexture};
+use smithay::backend::renderer::gles::{
+    self, GlesMapping, GlesRenderbuffer, GlesRenderer, GlesTexture,
+};
 use smithay::backend::renderer::sync::SyncPoint;
 use smithay::backend::renderer::{Bind, ExportMem, Frame, Offscreen, Renderer};
+use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
+use smithay::reexports::wayland_server::protocol::wl_shm;
 use smithay::utils::{Physical, Rectangle, Scale, Size, Transform};
+use smithay::wayland::shm;
 
 pub mod gradient;
 pub mod offscreen;
@@ -23,7 +28,6 @@ pub fn render_to_texture(
 ) -> anyhow::Result<(GlesTexture, SyncPoint)> {
     let _span = tracy_client::span!();
 
-    let output_rect = Rectangle::from_loc_and_size((0, 0), size);
     let buffer_size = size.to_logical(1).to_buffer(1, Transform::Normal);
 
     let texture: GlesTexture = renderer
@@ -34,27 +38,7 @@ pub fn render_to_texture(
         .bind(texture.clone())
         .context("error binding texture")?;
 
-    let mut frame = renderer
-        .render(size, Transform::Normal)
-        .context("error starting frame")?;
-
-    frame
-        .clear([0., 0., 0., 0.], &[output_rect])
-        .context("error clearing")?;
-
-    for element in elements {
-        let src = element.src();
-        let dst = element.geometry(scale);
-
-        if let Some(mut damage) = output_rect.intersection(dst) {
-            damage.loc -= dst.loc;
-            element
-                .draw(&mut frame, src, dst, &[damage])
-                .context("error drawing element")?;
-        }
-    }
-
-    let sync_point = frame.finish().context("error finishing frame")?;
+    let sync_point = render_elements(renderer, scale, size, elements)?;
     Ok((texture, sync_point))
 }
 
@@ -101,12 +85,108 @@ pub fn render_to_dmabuf(
     size: Size<i32, Physical>,
     scale: Scale<f64>,
     elements: impl Iterator<Item = impl RenderElement<GlesRenderer>>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<SyncPoint> {
     let _span = tracy_client::span!();
+    renderer.bind(dmabuf).context("error binding texture")?;
+    render_elements(renderer, scale, size, elements)
+}
 
+pub fn render_to_shm(
+    renderer: &mut GlesRenderer,
+    buffer: &WlBuffer,
+    size: Size<i32, Physical>,
+    scale: Scale<f64>,
+    elements: impl Iterator<Item = impl RenderElement<GlesRenderer>>,
+) -> anyhow::Result<()> {
+    let buffer_size = smithay::backend::renderer::buffer_dimensions(buffer).unwrap();
+    let offscreen_buffer: GlesRenderbuffer = renderer
+        .create_buffer(Fourcc::Abgr8888, buffer_size)
+        .context("error creating renderbuffer")?;
+    renderer
+        .bind(offscreen_buffer)
+        .context("error binding renderbuffer")?;
+
+    let sync_point = render_elements(renderer, scale, size, elements)?;
+
+    shm::with_buffer_contents_mut(buffer, |shm_buffer, shm_len, buffer_data| {
+        anyhow::ensure!(
+            // The buffer prefers pixels in little endian ...
+            buffer_data.format == wl_shm::Format::Argb8888
+                && buffer_data.stride == size.w * 4
+                && buffer_data.height == size.h
+                && shm_len as i32 == buffer_data.stride * buffer_data.height,
+            "invalid buffer format or size"
+        );
+
+        renderer.with_context(|gl| unsafe {
+            gl.ReadPixels(
+                0,
+                0,
+                size.w,
+                size.h,
+                // ... but OpenGL prefers them in big endian.
+                gles::ffi::BGRA_EXT,
+                gles::ffi::UNSIGNED_BYTE,
+                shm_buffer.cast(),
+            )
+        })?;
+
+        // gl.ReadPixels already waits for the rendering to finish.
+        // as such, the SyncPoint is already reached.
+        // and we needn't wait for it again.
+        debug_assert!(sync_point.is_reached());
+
+        Ok(())
+    })
+    .context("expected shm buffer, but didn't get one")?
+}
+
+pub fn render_to_shm_alt(
+    renderer: &mut GlesRenderer,
+    buffer: &WlBuffer,
+    size: Size<i32, Physical>,
+    scale: Scale<f64>,
+    elements: impl Iterator<Item = impl RenderElement<GlesRenderer>>,
+) -> anyhow::Result<()> {
+    let mapping = render_and_download(renderer, size, scale, Fourcc::Argb8888, elements)?;
+    let bytes = renderer
+        .map_texture(&mapping)
+        .context("error mapping texture")?;
+
+    shm::with_buffer_contents_mut(buffer, |shm_buffer, shm_len, buffer_data| {
+        anyhow::ensure!(
+            // The buffer prefers pixels in little endian ...
+            buffer_data.format == wl_shm::Format::Argb8888
+                && buffer_data.stride == size.w * 4
+                && buffer_data.height == size.h
+                && shm_len as i32 == buffer_data.stride * buffer_data.height,
+            "invalid buffer format or size"
+        );
+
+        debug!("copying {} bytes to shm buffer", bytes.len());
+        debug!("shm buffer size: {}", shm_len);
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                shm_buffer.cast(),
+                bytes.len().min(shm_len),
+            );
+        }
+
+        Ok(())
+    })
+    .context("expected shm buffer, but didn't get one")?
+}
+
+fn render_elements(
+    renderer: &mut GlesRenderer,
+    scale: Scale<f64>,
+    size: Size<i32, Physical>,
+    elements: impl Iterator<Item = impl RenderElement<GlesRenderer>>,
+) -> anyhow::Result<SyncPoint> {
     let output_rect = Rectangle::from_loc_and_size((0, 0), size);
 
-    renderer.bind(dmabuf).context("error binding texture")?;
     let mut frame = renderer
         .render(size, Transform::Normal)
         .context("error starting frame")?;
@@ -127,7 +207,5 @@ pub fn render_to_dmabuf(
         }
     }
 
-    let _sync_point = frame.finish().context("error finishing frame")?;
-
-    Ok(())
+    frame.finish().context("error finishing frame")
 }

--- a/src/render_helpers/offscreen.rs
+++ b/src/render_helpers/offscreen.rs
@@ -54,6 +54,7 @@ impl OffscreenRenderElement {
             renderer,
             geo.size,
             Scale::from(scale as f64),
+            Transform::Normal,
             Fourcc::Abgr8888,
             elements,
         ) {


### PR DESCRIPTION
Resolves #33

Significant parts of this are taken from Catacomb.

I don't fully understand everything i've done so far with this, but damnit am i proud of what i've done, and you don't even KNOW the pure amounts of dopamine rushing through my veins when i finally saw a screenshot output from my own little thing!!

As i submit this as a draft, it basically works.

- The image is upside down. This flipping happens *before* selection of the region, i.e. if you take a screenshot of the top half of the screen, the resulting image will be of the bottom half of the screen, flipped. This is likely a consequence of the order of the pixels sent to the screencopy. Maybe?

![image](https://github.com/YaLTeR/niri/assets/37938646/6de24aea-9ca0-4687-a45a-b9cd6c0107ae)

- After taking a screenshot, the keyboard input just gets completely fucked. I cannot type commands in the terminal. I cannot use binds to spawn processes. I cannot use binds to move windows, or even the focus. To test the screenshot functionality, i genuinely just set `WAYLAND_DISPLAY` in a terminal in the "real" compositor in order to work around this and focus on screencopy implementation. Why does this happen. I have no idea, please help.

- Does it work on multiple outputs? Probably not. Catacomb, to my knowledge, doesn't expect there to be more than 1 output(??), and my development setup does not have multiple monitors at the moment, so i can't easily test multimonitor. Therefore, no particular care has been taken towards keeping track of multiple outputs yet.

- DmaBuf/tty is currently untested. I don't see why it wouldn't work, but i have only tested it on winit so far.