### PR TITLE
Mouse warp

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -69,6 +69,8 @@ pub struct Input {
     pub touch: Touch,
     #[knuffel(child)]
     pub disable_power_key_handling: bool,
+    #[knuffel(child)]
+    pub warp_mouse_to_focus: bool,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq, Eq)]
@@ -1592,6 +1594,8 @@ mod tests {
                 }
 
                 disable-power-key-handling
+
+                warp-mouse-to-focus
             }
 
             output "eDP-1" {
@@ -1731,6 +1735,7 @@ mod tests {
                         map_to_output: Some("eDP-1".to_owned()),
                     },
                     disable_power_key_handling: true,
+                    warp_mouse_to_focus: true,
                 },
                 outputs: vec![Output {
                     off: false,

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -67,6 +67,9 @@ input {
     // Uncomment this if you would like to configure the power button elsewhere
     // (i.e. logind.conf).
     // disable-power-key-handling
+
+    // Uncomment this to make the mouse warp to the center of newly focused windows.
+    // warp-mouse-to-focus
 }
 
 // You can configure outputs by their name, which you can find

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -143,6 +143,7 @@ impl CompositorHandler for State {
                         })
                         .map(|(window, _)| window.clone());
 
+                    let window = window.clone();
                     let win = window.clone();
 
                     let output = if let Some(p) = parent {
@@ -161,6 +162,12 @@ impl CompositorHandler for State {
 
                     if let Some(output) = output.cloned() {
                         self.niri.layout.start_open_animation_for_window(&window);
+
+                        let new_active_window = self.niri.layout.active_window().map(|(w, _)| w);
+                        if new_active_window == Some(&window) {
+                            self.maybe_warp_cursor_to_focus();
+                        }
+
                         self.niri.queue_redraw(output);
                     }
                     return;

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -460,7 +460,15 @@ impl XdgShellHandler for State {
             return;
         };
 
+        let active_window = self.niri.layout.active_window().map(|(w, _)| w);
+        let was_active = active_window == Some(&window);
+
         self.niri.layout.remove_window(&window);
+
+        if was_active {
+            self.maybe_warp_cursor_to_focus();
+        }
+
         self.niri.queue_redraw(output);
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -411,139 +411,166 @@ impl State {
             }
             Action::MoveColumnLeft => {
                 self.niri.layout.move_left();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveColumnRight => {
                 self.niri.layout.move_right();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveColumnToFirst => {
                 self.niri.layout.move_column_to_first();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveColumnToLast => {
                 self.niri.layout.move_column_to_last();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveWindowDown => {
                 self.niri.layout.move_down();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveWindowUp => {
                 self.niri.layout.move_up();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveWindowDownOrToWorkspaceDown => {
                 self.niri.layout.move_down_or_to_workspace_down();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveWindowUpOrToWorkspaceUp => {
                 self.niri.layout.move_up_or_to_workspace_up();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::ConsumeOrExpelWindowLeft => {
                 self.niri.layout.consume_or_expel_window_left();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::ConsumeOrExpelWindowRight => {
                 self.niri.layout.consume_or_expel_window_right();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::FocusColumnLeft => {
                 self.niri.layout.focus_left();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::FocusColumnRight => {
                 self.niri.layout.focus_right();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::FocusColumnFirst => {
                 self.niri.layout.focus_column_first();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::FocusColumnLast => {
                 self.niri.layout.focus_column_last();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::FocusWindowDown => {
                 self.niri.layout.focus_down();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::FocusWindowUp => {
                 self.niri.layout.focus_up();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::FocusWindowOrWorkspaceDown => {
                 self.niri.layout.focus_window_or_workspace_down();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::FocusWindowOrWorkspaceUp => {
                 self.niri.layout.focus_window_or_workspace_up();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveWindowToWorkspaceDown => {
                 self.niri.layout.move_to_workspace_down();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveWindowToWorkspaceUp => {
                 self.niri.layout.move_to_workspace_up();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveWindowToWorkspace(idx) => {
                 let idx = idx.saturating_sub(1) as usize;
                 self.niri.layout.move_to_workspace(idx);
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveColumnToWorkspaceDown => {
                 self.niri.layout.move_column_to_workspace_down();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveColumnToWorkspaceUp => {
                 self.niri.layout.move_column_to_workspace_up();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::MoveColumnToWorkspace(idx) => {
                 let idx = idx.saturating_sub(1) as usize;
                 self.niri.layout.move_column_to_workspace(idx);
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::FocusWorkspaceDown => {
                 self.niri.layout.switch_workspace_down();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::FocusWorkspaceUp => {
                 self.niri.layout.switch_workspace_up();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::FocusWorkspace(idx) => {
                 let idx = idx.saturating_sub(1) as usize;
                 self.niri.layout.switch_workspace(idx);
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
@@ -559,11 +586,14 @@ impl State {
             }
             Action::ConsumeWindowIntoColumn => {
                 self.niri.layout.consume_into_column();
+                // This does not cause immediate focus or window size change, so warping mouse to
+                // focus won't do anything here.
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
             Action::ExpelWindowFromColumn => {
                 self.niri.layout.expel_from_column();
+                self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
@@ -581,81 +611,105 @@ impl State {
             Action::FocusMonitorLeft => {
                 if let Some(output) = self.niri.output_left() {
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::FocusMonitorRight => {
                 if let Some(output) = self.niri.output_right() {
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::FocusMonitorDown => {
                 if let Some(output) = self.niri.output_down() {
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::FocusMonitorUp => {
                 if let Some(output) = self.niri.output_up() {
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::MoveWindowToMonitorLeft => {
                 if let Some(output) = self.niri.output_left() {
                     self.niri.layout.move_to_output(&output);
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::MoveWindowToMonitorRight => {
                 if let Some(output) = self.niri.output_right() {
                     self.niri.layout.move_to_output(&output);
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::MoveWindowToMonitorDown => {
                 if let Some(output) = self.niri.output_down() {
                     self.niri.layout.move_to_output(&output);
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::MoveWindowToMonitorUp => {
                 if let Some(output) = self.niri.output_up() {
                     self.niri.layout.move_to_output(&output);
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::MoveColumnToMonitorLeft => {
                 if let Some(output) = self.niri.output_left() {
                     self.niri.layout.move_column_to_output(&output);
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::MoveColumnToMonitorRight => {
                 if let Some(output) = self.niri.output_right() {
                     self.niri.layout.move_column_to_output(&output);
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::MoveColumnToMonitorDown => {
                 if let Some(output) = self.niri.output_down() {
                     self.niri.layout.move_column_to_output(&output);
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::MoveColumnToMonitorUp => {
                 if let Some(output) = self.niri.output_up() {
                     self.niri.layout.move_column_to_output(&output);
                     self.niri.layout.focus_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::SetColumnWidth(change) => {
@@ -672,25 +726,33 @@ impl State {
             Action::MoveWorkspaceToMonitorLeft => {
                 if let Some(output) = self.niri.output_left() {
                     self.niri.layout.move_workspace_to_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::MoveWorkspaceToMonitorRight => {
                 if let Some(output) = self.niri.output_right() {
                     self.niri.layout.move_workspace_to_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::MoveWorkspaceToMonitorDown => {
                 if let Some(output) = self.niri.output_down() {
                     self.niri.layout.move_workspace_to_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
             Action::MoveWorkspaceToMonitorUp => {
                 if let Some(output) = self.niri.output_up() {
                     self.niri.layout.move_workspace_to_output(&output);
-                    self.move_cursor_to_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
                 }
             }
         }

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -583,6 +583,14 @@ impl<W: LayoutElement> Monitor<W> {
         self.clean_up_workspaces();
     }
 
+    /// Returns the geometry of the active tile relative to and clamped to the output.
+    ///
+    /// During animations, assumes the final view position.
+    pub fn active_tile_visual_rectangle(&self) -> Option<Rectangle<i32, Logical>> {
+        // FIXME: switch gesture.
+        self.active_workspace_ref().active_tile_visual_rectangle()
+    }
+
     pub fn window_under(
         &self,
         pos_within_output: Point<f64, Logical>,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -479,6 +479,10 @@ impl State {
             return false;
         }
 
+        if self.niri.tablet_cursor_location.is_some() {
+            return false;
+        }
+
         let Some(output) = self.niri.layout.active_output() else {
             return false;
         };

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -475,6 +475,10 @@ impl State {
     }
 
     pub fn move_cursor_to_focused_tile(&mut self, mode: CenterCoords) -> bool {
+        if !self.niri.keyboard_focus.is_layout() {
+            return false;
+        }
+
         let Some(output) = self.niri.layout.active_output() else {
             return false;
         };

--- a/src/protocols/foreign_toplevel.rs
+++ b/src/protocols/foreign_toplevel.rs
@@ -106,7 +106,7 @@ pub fn refresh(state: &mut State) {
                 .lock()
                 .unwrap();
 
-            if state.niri.keyboard_focus.as_ref() == Some(wl_surface) {
+            if state.niri.keyboard_focus.surface() == Some(wl_surface) {
                 focused = Some((window.clone(), output.cloned()));
             } else {
                 refresh_toplevel(protocol_state, wl_surface, &role, output, false);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -40,6 +40,10 @@ pub fn center(rect: Rectangle<i32, Logical>) -> Point<i32, Logical> {
     rect.loc + rect.size.downscale(2).to_point()
 }
 
+pub fn center_f64(rect: Rectangle<f64, Logical>) -> Point<f64, Logical> {
+    rect.loc + rect.size.downscale(2.0).to_point()
+}
+
 pub fn output_size(output: &Output) -> Size<i32, Logical> {
     let output_scale = output.current_scale().integer_scale();
     let output_transform = output.current_transform();


### PR DESCRIPTION
Adds a mouse warp (aka mouse-follows-focus) config option. It can be activated by adding `warp-mouse-to-focus` to the input section of the config files.
There are some minor issues with this basic implementation documented with `FIXME` comments in `input.rs`, in particular:
1. `queue_redraw_all()` is sometimes called twice, which is unnecessary. I've decided to not fix this for now as more granular updating of the display is planned anyway.
2. the cursor currently doesn't warp to the focused window when spawning, closing or resizing windows, as a naive implementation doesn't work. To fix this the mouse warp code would need to be executed after some delay (when resizing/spawning/closing has finished), or by pre-calculating the final layout.