### PR TITLE
Add `clickfinger` in touchpad config

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1492,14 +1492,13 @@ impl FromStr for ClickMethod {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "clickfinger" => Ok(Self::Clickfinger),
-            "button_areas" => Ok(Self::ButtonAreas),
+            "button-areas" => Ok(Self::ButtonAreas),
             _ => Err(miette!(
-                r#"invalid click method, can be "clickfinger" or "button_areas""#
+                r#"invalid click method, can be "clickfinger" or "button-areas""#
             )),
         }
     }
 }
-
 
 impl FromStr for AccelProfile {
     type Err = miette::Error;

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -142,6 +142,8 @@ pub struct Touchpad {
     pub dwtp: bool,
     #[knuffel(child)]
     pub natural_scroll: bool,
+    #[knuffel(child)]
+    pub clickfinger: bool,
     #[knuffel(child, unwrap(argument), default)]
     pub accel_speed: f64,
     #[knuffel(child, unwrap(argument, str))]
@@ -1534,6 +1536,7 @@ mod tests {
                     tap
                     dwt
                     dwtp
+                    clickfinger
                     accel-speed 0.2
                     accel-profile "flat"
                     tap-button-map "left-middle-right"
@@ -1677,6 +1680,7 @@ mod tests {
                         dwt: true,
                         dwtp: true,
                         natural_scroll: false,
+                        clickfinger: true,
                         accel_speed: 0.2,
                         accel_profile: Some(AccelProfile::Flat),
                         tap_button_map: Some(TapButtonMap::LeftMiddleRight),

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -175,14 +175,14 @@ pub struct Trackpoint {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClickMethod {
     Clickfinger,
-    BottomAreas,
+    ButtonAreas,
 }
 
 impl From<ClickMethod> for input::ClickMethod {
     fn from(value: ClickMethod) -> Self {
         match value {
             ClickMethod::Clickfinger => Self::Clickfinger,
-            ClickMethod::BottomAreas => Self::ButtonAreas,
+            ClickMethod::ButtonAreas => Self::ButtonAreas,
         }
     }
 }
@@ -1492,9 +1492,9 @@ impl FromStr for ClickMethod {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "clickfinger" => Ok(Self::Clickfinger),
-            "bottom_areas" => Ok(Self::BottomAreas),
+            "button_areas" => Ok(Self::ButtonAreas),
             _ => Err(miette!(
-                r#"invalid click method, can be "clickfinger" or "bottom_areas""#
+                r#"invalid click method, can be "clickfinger" or "button_areas""#
             )),
         }
     }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1494,7 +1494,7 @@ impl FromStr for ClickMethod {
             "clickfinger" => Ok(Self::Clickfinger),
             "button-areas" => Ok(Self::ButtonAreas),
             _ => Err(miette!(
-                r#"invalid click method, can be "clickfinger" or "button-areas""#
+                r#"invalid click method, can be "button-areas" or "clickfinger""#
             )),
         }
     }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -142,8 +142,8 @@ pub struct Touchpad {
     pub dwtp: bool,
     #[knuffel(child)]
     pub natural_scroll: bool,
-    #[knuffel(child)]
-    pub clickfinger: bool,
+    #[knuffel(child, unwrap(argument, str))]
+    pub click_method: Option<ClickMethod>,
     #[knuffel(child, unwrap(argument), default)]
     pub accel_speed: f64,
     #[knuffel(child, unwrap(argument, str))]
@@ -170,6 +170,21 @@ pub struct Trackpoint {
     pub accel_speed: f64,
     #[knuffel(child, unwrap(argument, str))]
     pub accel_profile: Option<AccelProfile>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClickMethod {
+    Clickfinger,
+    BottomAreas,
+}
+
+impl From<ClickMethod> for input::ClickMethod {
+    fn from(value: ClickMethod) -> Self {
+        match value {
+            ClickMethod::Clickfinger => Self::Clickfinger,
+            ClickMethod::BottomAreas => Self::ButtonAreas,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1471,6 +1486,21 @@ impl FromStr for Key {
     }
 }
 
+impl FromStr for ClickMethod {
+    type Err = miette::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "clickfinger" => Ok(Self::Clickfinger),
+            "bottom_areas" => Ok(Self::BottomAreas),
+            _ => Err(miette!(
+                r#"invalid click method, can be "clickfinger" or "bottom_areas""#
+            )),
+        }
+    }
+}
+
+
 impl FromStr for AccelProfile {
     type Err = miette::Error;
 
@@ -1536,7 +1566,7 @@ mod tests {
                     tap
                     dwt
                     dwtp
-                    clickfinger
+                    click-method "clickfinger"
                     accel-speed 0.2
                     accel-profile "flat"
                     tap-button-map "left-middle-right"
@@ -1679,8 +1709,8 @@ mod tests {
                         tap: true,
                         dwt: true,
                         dwtp: true,
+                        click_method: Some(ClickMethod::Clickfinger),
                         natural_scroll: false,
-                        clickfinger: true,
                         accel_speed: 0.2,
                         accel_profile: Some(AccelProfile::Flat),
                         tap_button_map: Some(TapButtonMap::LeftMiddleRight),

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -30,7 +30,7 @@ input {
         // dwt
         // dwtp
         natural-scroll
-        // clickfinger
+        // click-method "clickfinger"
         // accel-speed 0.2
         // accel-profile "flat"
         // tap-button-map "left-middle-right"

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -30,6 +30,7 @@ input {
         // dwt
         // dwtp
         natural-scroll
+        // clickfinger
         // accel-speed 0.2
         // accel-profile "flat"
         // tap-button-map "left-middle-right"

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -30,10 +30,10 @@ input {
         // dwt
         // dwtp
         natural-scroll
-        // click-method "clickfinger"
         // accel-speed 0.2
         // accel-profile "flat"
         // tap-button-map "left-middle-right"
+        // click-method "clickfinger"
     }
 
     mouse {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1775,10 +1775,10 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
             let _ = device.config_tap_set_button_map(default);
         }
 
-        if c.clickfinger {
-            let _ = device.config_click_set_method(input::ClickMethod::Clickfinger);
-        } else {
-            let _ = device.config_click_set_method(input::ClickMethod::ButtonAreas);
+        if let Some(method) = c.click_method {
+            let _ = device.config_click_set_method(method.into());
+        } else if let Some(default) = device.config_click_default_method() {
+            let _ = device.config_click_set_method(default);
         }
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1774,6 +1774,12 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
         } else if let Some(default) = device.config_tap_default_button_map() {
             let _ = device.config_tap_set_button_map(default);
         }
+
+        if c.clickfinger {
+            let _ = device.config_click_set_method(input::ClickMethod::Clickfinger);
+        } else {
+            let _ = device.config_click_set_method(input::ClickMethod::ButtonAreas);
+        }
     }
 
     // This is how Mutter tells apart mice.


### PR DESCRIPTION
This PR adds the [clickfinger behavior](https://wayland.freedesktop.org/libinput/doc/latest/clickpad-softbuttons.html#clickfinger-behavior) setting for touchpads.

I have tested live reload and it works well on my machine.