### PR TITLE
input: Add support for ISO level3 shift modifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,7 +3088,7 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/Smithay/smithay.git#e61db794643190d4628fbb045634827e4619ffdf"
+source = "git+https://github.com/Smithay/smithay.git#e5f006818df7ebb92d206985f45e713ba1e9c1c9"
 dependencies = [
  "appendlist",
  "bitflags 2.4.2",
@@ -3160,7 +3160,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#e61db794643190d4628fbb045634827e4619ffdf"
+source = "git+https://github.com/Smithay/smithay.git#e5f006818df7ebb92d206985f45e713ba1e9c1c9"
 dependencies = [
  "drm",
  "edid-rs",

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -746,7 +746,8 @@ bitflags! {
         const SHIFT = 2;
         const ALT = 4;
         const SUPER = 8;
-        const COMPOSITOR = 16;
+        const ISO_LEVEL3_SHIFT = 16;
+        const COMPOSITOR = 32;
     }
 }
 
@@ -1542,6 +1543,10 @@ impl FromStr for Key {
                 modifiers |= Modifiers::ALT;
             } else if part.eq_ignore_ascii_case("super") || part.eq_ignore_ascii_case("win") {
                 modifiers |= Modifiers::SUPER;
+            } else if part.eq_ignore_ascii_case("iso_level3_shift")
+                || part.eq_ignore_ascii_case("mod5")
+            {
+                modifiers |= Modifiers::ISO_LEVEL3_SHIFT;
             } else {
                 return Err(miette!("invalid modifier: {part}"));
             }
@@ -2086,5 +2091,23 @@ mod tests {
 
         assert!("-".parse::<SizeChange>().is_err());
         assert!("10% ".parse::<SizeChange>().is_err());
+    }
+
+    #[test]
+    fn parse_iso_level3_shift() {
+        assert_eq!(
+            "ISO_Level3_Shift+A".parse::<Key>().unwrap(),
+            Key {
+                trigger: Trigger::Keysym(Keysym::a),
+                modifiers: Modifiers::ISO_LEVEL3_SHIFT
+            },
+        );
+        assert_eq!(
+            "Mod5+A".parse::<Key>().unwrap(),
+            Key {
+                trigger: Trigger::Keysym(Keysym::a),
+                modifiers: Modifiers::ISO_LEVEL3_SHIFT
+            },
+        );
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1849,6 +1849,9 @@ fn find_configured_bind(
     if mods.logo {
         modifiers |= Modifiers::SUPER;
     }
+    if mods.iso_level3_shift {
+        modifiers |= Modifiers::ISO_LEVEL3_SHIFT;
+    }
 
     let (mod_down, comp_mod) = match comp_mod {
         CompositorMod::Super => (mods.logo, Modifiers::SUPER),


### PR DESCRIPTION
This modifier is typically called `AltGr` on keyboards or `Mod5` in xkb layouts. Requires a Smithay update.

I went with hyphens for the name in config because kebab case is already used for other settings, but will happily change it to something else. I also added a `Mod5` alias because `ISO-level3-shift` is quite a mouthful.