### PR TITLE
input: Add "AltGr" alias for ISO level3 shift modifier

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1574,6 +1574,7 @@ impl FromStr for Key {
                 modifiers |= Modifiers::SUPER;
             } else if part.eq_ignore_ascii_case("iso_level3_shift")
                 || part.eq_ignore_ascii_case("mod5")
+                || part.eq_ignore_ascii_case("altgr")
             {
                 modifiers |= Modifiers::ISO_LEVEL3_SHIFT;
             } else {
@@ -2145,19 +2146,14 @@ mod tests {
 
     #[test]
     fn parse_iso_level3_shift() {
-        assert_eq!(
-            "ISO_Level3_Shift+A".parse::<Key>().unwrap(),
-            Key {
-                trigger: Trigger::Keysym(Keysym::a),
-                modifiers: Modifiers::ISO_LEVEL3_SHIFT
-            },
-        );
-        assert_eq!(
-            "Mod5+A".parse::<Key>().unwrap(),
-            Key {
-                trigger: Trigger::Keysym(Keysym::a),
-                modifiers: Modifiers::ISO_LEVEL3_SHIFT
-            },
-        );
+        for input in ["ISO_Level3_Shift+A", "Mod5+A", "AltGr+A"] {
+            assert_eq!(
+                input.parse::<Key>().unwrap(),
+                Key {
+                    trigger: Trigger::Keysym(Keysym::a),
+                    modifiers: Modifiers::ISO_LEVEL3_SHIFT
+                },
+            );
+        }
     }
 }


### PR DESCRIPTION
It's what's written on keyboards, so perhaps a bit more accessible to users.