### PR TITLE
`niri_ipc::NiriSocket`; `niri msg version`; version checking on IPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,6 +2202,7 @@ version = "0.1.4"
 dependencies = [
  "clap",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.81"
 bitflags = "2.5.0"
 clap = { version = "~4.4.18", features = ["derive"] }
 serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.115"
 tracing = { version = "0.1.40", features = ["max_level_trace", "release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracy-client = { version = "0.17.0", default-features = false }
@@ -67,7 +68,7 @@ portable-atomic = { version = "1.6.0", default-features = false, features = ["fl
 profiling = "1.0.15"
 sd-notify = "0.4.1"
 serde.workspace = true
-serde_json = "1.0.115"
+serde_json.workspace = true
 smithay-drm-extras.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true

--- a/niri-ipc/Cargo.toml
+++ b/niri-ipc/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 clap = { workspace = true, optional = true }
 serde.workspace = true
+serde_json.workspace = true
 
 [features]
 clap = ["dep:clap"]

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -7,14 +7,11 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 mod socket;
-
-pub use socket::{NiriSocket, SOCKET_PATH_ENV};
+pub use socket::{Socket, SOCKET_PATH_ENV};
 
 /// Request from client to niri.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Request {
-    /// Always responds with an error. (For testing error handling)
-    ReturnError,
     /// Request the version string for the running niri instance.
     Version,
     /// Request information about connected outputs.
@@ -23,6 +20,8 @@ pub enum Request {
     FocusedWindow,
     /// Perform an action.
     Action(Action),
+    /// Respond with an error (for testing error handling).
+    ReturnError,
 }
 
 /// Reply from niri to client.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -6,12 +6,17 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-/// Name of the environment variable containing the niri IPC socket path.
-pub const SOCKET_PATH_ENV: &str = "NIRI_SOCKET";
+mod socket;
+
+pub use socket::{NiriSocket, SOCKET_PATH_ENV};
 
 /// Request from client to niri.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Request {
+    /// Always responds with an error. (For testing error handling)
+    ReturnError,
+    /// Request the version string for the running niri instance.
+    Version,
     /// Request information about connected outputs.
     Outputs,
     /// Request information about the focused window.
@@ -35,6 +40,8 @@ pub type Reply = Result<Response, String>;
 pub enum Response {
     /// A request that does not need a response was handled successfully.
     Handled,
+    /// The version string for the running niri instance.
+    Version(String),
     /// Information about connected outputs.
     ///
     /// Map from connector name to output info.

--- a/niri-ipc/src/socket.rs
+++ b/niri-ipc/src/socket.rs
@@ -1,0 +1,73 @@
+use std::io::{self, Write};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+
+use serde_json::de::IoRead;
+use serde_json::StreamDeserializer;
+
+use crate::{Reply, Request};
+
+/// Name of the environment variable containing the niri IPC socket path.
+pub const SOCKET_PATH_ENV: &str = "NIRI_SOCKET";
+
+/// A client for the niri IPC server.
+///
+/// This struct is used to communicate with the niri IPC server. It handles the socket connection
+/// and serialization/deserialization of messages.
+pub struct NiriSocket {
+    stream: UnixStream,
+    responses: StreamDeserializer<'static, IoRead<UnixStream>, Reply>,
+}
+
+impl TryFrom<UnixStream> for NiriSocket {
+    type Error = io::Error;
+    fn try_from(stream: UnixStream) -> io::Result<Self> {
+        let responses = serde_json::Deserializer::from_reader(stream.try_clone()?).into_iter();
+        Ok(Self { stream, responses })
+    }
+}
+
+impl NiriSocket {
+    /// Connects to the default niri IPC socket
+    ///
+    /// This is equivalent to calling [Self::connect] with the value of the [SOCKET_PATH_ENV]
+    /// environment variable.
+    pub fn new() -> io::Result<Self> {
+        let socket_path = std::env::var_os(SOCKET_PATH_ENV).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("{SOCKET_PATH_ENV} is not set, are you running this within niri?"),
+            )
+        })?;
+        Self::connect(socket_path)
+    }
+
+    /// Connect to the socket at the given path
+    ///
+    /// See also: [UnixStream::connect]
+    pub fn connect(path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::try_from(UnixStream::connect(path.as_ref())?)
+    }
+
+    /// Handle a request to the niri IPC server
+    ///
+    /// # Returns
+    /// Ok(Ok([Response](crate::Response))) corresponds to a successful response from the running
+    /// niri instance. Ok(Err([String])) corresponds to an error received from the running niri
+    /// instance. Err([std::io::Error]) corresponds to an error in the IPC communication.
+    pub fn send(mut self, request: Request) -> io::Result<Reply> {
+        let mut buf = serde_json::to_vec(&request).unwrap();
+        writeln!(buf).unwrap();
+        self.stream.write_all(&buf)?; // .context("error writing IPC request")?;
+        self.stream.flush()?;
+
+        if let Some(next) = self.responses.next() {
+            next.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "no response from server",
+            ))
+        }
+    }
+}

--- a/niri-ipc/src/socket.rs
+++ b/niri-ipc/src/socket.rs
@@ -1,73 +1,63 @@
-use std::io::{self, Write};
+//! Helper for blocking communication over the niri socket.
+
+use std::env;
+use std::io::{self, Read, Write};
+use std::net::Shutdown;
 use std::os::unix::net::UnixStream;
 use std::path::Path;
-
-use serde_json::de::IoRead;
-use serde_json::StreamDeserializer;
 
 use crate::{Reply, Request};
 
 /// Name of the environment variable containing the niri IPC socket path.
 pub const SOCKET_PATH_ENV: &str = "NIRI_SOCKET";
 
-/// A client for the niri IPC server.
+/// Helper for blocking communication over the niri socket.
 ///
 /// This struct is used to communicate with the niri IPC server. It handles the socket connection
 /// and serialization/deserialization of messages.
-pub struct NiriSocket {
+pub struct Socket {
     stream: UnixStream,
-    responses: StreamDeserializer<'static, IoRead<UnixStream>, Reply>,
 }
 
-impl TryFrom<UnixStream> for NiriSocket {
-    type Error = io::Error;
-    fn try_from(stream: UnixStream) -> io::Result<Self> {
-        let responses = serde_json::Deserializer::from_reader(stream.try_clone()?).into_iter();
-        Ok(Self { stream, responses })
-    }
-}
-
-impl NiriSocket {
-    /// Connects to the default niri IPC socket
+impl Socket {
+    /// Connects to the default niri IPC socket.
     ///
-    /// This is equivalent to calling [Self::connect] with the value of the [SOCKET_PATH_ENV]
-    /// environment variable.
-    pub fn new() -> io::Result<Self> {
-        let socket_path = std::env::var_os(SOCKET_PATH_ENV).ok_or_else(|| {
+    /// This is equivalent to calling [`Self::connect_to`] with the path taken from the
+    /// [`SOCKET_PATH_ENV`] environment variable.
+    pub fn connect() -> io::Result<Self> {
+        let socket_path = env::var_os(SOCKET_PATH_ENV).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
                 format!("{SOCKET_PATH_ENV} is not set, are you running this within niri?"),
             )
         })?;
-        Self::connect(socket_path)
+        Self::connect_to(socket_path)
     }
 
-    /// Connect to the socket at the given path
-    ///
-    /// See also: [UnixStream::connect]
-    pub fn connect(path: impl AsRef<Path>) -> io::Result<Self> {
-        Self::try_from(UnixStream::connect(path.as_ref())?)
+    /// Connects to the niri IPC socket at the given path.
+    pub fn connect_to(path: impl AsRef<Path>) -> io::Result<Self> {
+        let stream = UnixStream::connect(path.as_ref())?;
+        Ok(Self { stream })
     }
 
-    /// Handle a request to the niri IPC server
+    /// Sends a request to niri and returns the response.
     ///
-    /// # Returns
-    /// Ok(Ok([Response](crate::Response))) corresponds to a successful response from the running
-    /// niri instance. Ok(Err([String])) corresponds to an error received from the running niri
-    /// instance. Err([std::io::Error]) corresponds to an error in the IPC communication.
-    pub fn send(mut self, request: Request) -> io::Result<Reply> {
+    /// Return values:
+    ///
+    /// * `Ok(Ok(response))`: successful [`Response`](crate::Response) from niri
+    /// * `Ok(Err(message))`: error message from niri
+    /// * `Err(error)`: error communicating with niri
+    pub fn send(self, request: Request) -> io::Result<Reply> {
+        let Self { mut stream } = self;
+
         let mut buf = serde_json::to_vec(&request).unwrap();
-        writeln!(buf).unwrap();
-        self.stream.write_all(&buf)?; // .context("error writing IPC request")?;
-        self.stream.flush()?;
+        stream.write_all(&buf)?;
+        stream.shutdown(Shutdown::Write)?;
 
-        if let Some(next) = self.responses.next() {
-            next.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
-        } else {
-            Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "no response from server",
-            ))
-        }
+        buf.clear();
+        stream.read_to_end(&mut buf)?;
+
+        let reply = serde_json::from_slice(&buf)?;
+        Ok(reply)
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,6 +52,10 @@ pub enum Sub {
 
 #[derive(Subcommand)]
 pub enum Msg {
+    /// Print an error message.
+    Error,
+    /// Print the version string of the running niri instance.
+    Version,
     /// List connected outputs.
     Outputs,
     /// Print information about the focused window.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,9 +52,7 @@ pub enum Sub {
 
 #[derive(Subcommand)]
 pub enum Msg {
-    /// Print an error message.
-    Error,
-    /// Print the version string of the running niri instance.
+    /// Print the version of the running niri instance.
     Version,
     /// List connected outputs.
     Outputs,
@@ -65,4 +63,6 @@ pub enum Msg {
         #[command(subcommand)]
         action: Action,
     },
+    /// Request an error from the running niri instance.
+    RequestError,
 }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, bail, Context};
-use niri_ipc::{LogicalOutput, Mode, Output, Request, Response, Socket};
+use niri_ipc::{LogicalOutput, Mode, Output, Request, Response, Socket, Transform};
 use serde_json::json;
 
 use crate::cli::Msg;
@@ -168,18 +168,14 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                     println!("  Scale: {scale}");
 
                     let transform = match transform {
-                        niri_ipc::Transform::Normal => "normal",
-                        niri_ipc::Transform::_90 => "90° counter-clockwise",
-                        niri_ipc::Transform::_180 => "180°",
-                        niri_ipc::Transform::_270 => "270° counter-clockwise",
-                        niri_ipc::Transform::Flipped => "flipped horizontally",
-                        niri_ipc::Transform::Flipped90 => {
-                            "90° counter-clockwise, flipped horizontally"
-                        }
-                        niri_ipc::Transform::Flipped180 => "flipped vertically",
-                        niri_ipc::Transform::Flipped270 => {
-                            "270° counter-clockwise, flipped horizontally"
-                        }
+                        Transform::Normal => "normal",
+                        Transform::_90 => "90° counter-clockwise",
+                        Transform::_180 => "180°",
+                        Transform::_270 => "270° counter-clockwise",
+                        Transform::Flipped => "flipped horizontally",
+                        Transform::Flipped90 => "90° counter-clockwise, flipped horizontally",
+                        Transform::Flipped180 => "flipped vertically",
+                        Transform::Flipped270 => "270° counter-clockwise, flipped horizontally",
                     };
                     println!("  Transform: {transform}");
                 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -7,8 +8,8 @@ use anyhow::Context;
 use calloop::io::Async;
 use directories::BaseDirs;
 use futures_util::io::{AsyncReadExt, BufReader};
-use futures_util::{AsyncBufReadExt, AsyncWriteExt};
-use niri_ipc::{Request, Response};
+use futures_util::{AsyncBufReadExt, AsyncWriteExt, StreamExt};
+use niri_ipc::{Reply, Request, Response};
 use smithay::desktop::Window;
 use smithay::reexports::calloop::generic::Generic;
 use smithay::reexports::calloop::{Interest, LoopHandle, Mode, PostAction};
@@ -18,6 +19,7 @@ use smithay::wayland::shell::xdg::XdgToplevelSurfaceData;
 
 use crate::backend::IpcOutputMap;
 use crate::niri::State;
+use crate::utils::version;
 
 pub struct IpcServer {
     pub socket_path: PathBuf,
@@ -106,29 +108,43 @@ fn on_new_ipc_client(state: &mut State, stream: UnixStream) {
 
 async fn handle_client(ctx: ClientCtx, stream: Async<'_, UnixStream>) -> anyhow::Result<()> {
     let (read, mut write) = stream.split();
-    let mut buf = String::new();
 
-    // Read a single line to allow extensibility in the future to keep reading.
-    BufReader::new(read)
-        .read_line(&mut buf)
-        .await
-        .context("error reading request")?;
+    // note that we can't use the stream json deserializer here
+    // because the stream is asynchronous and the deserializer doesn't support that
+    // https://github.com/serde-rs/json/issues/575
 
-    let reply = process(&ctx, &buf).map_err(|err| {
+    let mut lines = BufReader::new(read).lines();
+
+    let line = match lines.next().await.unwrap_or(Err(io::Error::new(io::ErrorKind::UnexpectedEof, "Unreachable; BufReader returned None but when the stream ends, the connection should be reset"))) {
+        Ok(line) => line,
+        Err(err) if err.kind() == io::ErrorKind::ConnectionReset => return Ok(()),
+        Err(err) => return Err(err).context("error reading line"),
+    };
+
+    let reply: Reply = serde_json::from_str(&line)
+        .map_err(|err| format!("error parsing request: {err}"))
+        .and_then(|req| process(&ctx, req));
+
+    if let Err(err) = &reply {
         warn!("error processing IPC request: {err:?}");
-        err.to_string()
-    });
+    }
 
-    let buf = serde_json::to_vec(&reply).context("error formatting reply")?;
+    let mut buf = serde_json::to_vec(&reply).context("error formatting reply")?;
+    writeln!(buf).unwrap();
     write.write_all(&buf).await.context("error writing reply")?;
+    write.flush().await.context("error flushing reply")?;
+
+    // We do not check for more lines at this moment.
+    // Dropping the stream will reset the connection before we read them.
+    // For now, a client should not be sending more than one request per connection.
 
     Ok(())
 }
 
-fn process(ctx: &ClientCtx, buf: &str) -> anyhow::Result<Response> {
-    let request: Request = serde_json::from_str(buf).context("error parsing request")?;
-
+fn process(ctx: &ClientCtx, request: Request) -> Reply {
     let response = match request {
+        Request::ReturnError => return Err("client wanted an error".into()),
+        Request::Version => Response::Version(version()),
         Request::Outputs => {
             let ipc_outputs = ctx.ipc_outputs.lock().unwrap().clone();
             Response::Outputs(ipc_outputs)


### PR DESCRIPTION
~~This does *not* implement any sort of event stream, but rather implements basic support for the IPC client and server to handle multiple messages on each stream.~~

~~Previously, the server would ignore any additional events sent to it. This means every IPC request *must* start a new socket connection.~~

~~Now, with my changes, single IPC connection can handle arbitrarily many requests, separated by newlines.~~

~~The client can additionally handle them with arbitrary separation, as it relies on serde_json's `StreamDeserializer`. It cannot be used on the server-side, because it does not support async readers.~~

(no longer part of this PR)

A new API is made available in `niri_ipc`: `NiriSocket`. It handles the underlying `UnixStream` and allows a consumer to send multiple requests without closing it inbetween.

  - sidenote: wouldn't a more fitting API be that `Request` is a trait, with an associated type `Response`? That way, the request method could statically return the correct type (rather than an enum).
  
---

-  ### New command `niri msg version` to check the running compositor's version
  
    ![image](https://github.com/YaLTeR/niri/assets/37938646/5ca1c73a-f8eb-4cd5-87a7-a989e2a34fea)

- ### All `niri msg` commands will now check the running compositor's version.

- If it matches, output is identical to before.
    
    ![image](https://github.com/YaLTeR/niri/assets/37938646/6032f576-eacb-4dce-96ed-d945542a2c9a)

- If it does not match, additional output is printed upon each `niri msg` invocation, informing the user of the discrepancy so they can understand any potential problem more easily.
  
    ![image](https://github.com/YaLTeR/niri/assets/37938646/ca9ca4fe-49d1-4135-9c84-266f837cbc92)

- This does not break existing scripts.
  
    ![image](https://github.com/YaLTeR/niri/assets/37938646/55be9ef1-62d0-49c9-99dd-84020c73f889)

- The "Did you forget?" hint is also available for compositors prior to this commit
  
    ![image](https://github.com/YaLTeR/niri/assets/37938646/3b2c1525-5dd7-418f-a65d-733ae7e64883)

- The human-readable form of `niri msg version` does not duplicate the version information.
  
    ![image](https://github.com/YaLTeR/niri/assets/37938646/acad100b-277e-411a-902a-2d0bdf0a035f)

- "Did you forget?" can be filtered out just as with json output

    ![image](https://github.com/YaLTeR/niri/assets/37938646/d31f1b2b-e1e1-4148-8a6f-917b14314c5b)

- JSON output of `niri msg version` does duplicate the information, with rationale going that you may be piping its output into some other command that eventually discards the version numbers or puts it somewhere other than the terminal, but stderr should still be visible to the human

    ![image](https://github.com/YaLTeR/niri/assets/37938646/ba1f8c39-c807-4407-a1c0-ed5706f4ccf8)

- The exact wording of human-readable output in the screenshots above may vary from the real product.

---

Additionally, no attempt is made to do anything more than tell the user that the version string mismatches. This is because packagers can[1] and will[2] and do[3] overwrite the `version()` function with their own implementation, under the assumption that the result will only be shown to the user. This PR does not try to fundamentally change this assumption.

[1]: COPR at `yalter/niri/niri` \
[2]: Nix at `github:sodiboo/niri-flake` \
[3]: AUR at `niri-bin` depends on [1]

[1]: https://copr-dist-git.fedorainfracloud.org/cgit/yalter/niri/niri.git/tree/niri.spec?id=a22d516a8f477ae0e7ef0ae69dfc24878525eec6#n113
[2]: https://github.com/sodiboo/niri-flake/blob/a678ef2f4e4e95bff267823340c77df588bc5314/flake.nix#L139-L148
[3]: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=niri-bin#n29