### PR TITLE
Unconstrain InputMethod's PopupSurface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,13 +889,13 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drm"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0f8a69e60d75ae7dab4ef26a59ca99f2a89d4c142089b537775ae0c198bdcde"
+checksum = "98888c4bbd601524c11a7ed63f814b8825f420514f78e96f752c437ae9cbb5d1"
 dependencies = [
  "bitflags 2.5.0",
  "bytemuck",
- "drm-ffi",
+ "drm-ffi 0.8.0",
  "drm-fourcc",
  "rustix 0.38.32",
 ]
@@ -906,7 +906,17 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41334f8405792483e32ad05fbb9c5680ff4e84491883d2947a4757dc54cb2ac6"
 dependencies = [
- "drm-sys",
+ "drm-sys 0.6.1",
+ "rustix 0.38.32",
+]
+
+[[package]]
+name = "drm-ffi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c98727e48b7ccb4f4aea8cfe881e5b07f702d17b7875991881b41af7278d53"
+dependencies = [
+ "drm-sys 0.7.0",
  "rustix 0.38.32",
 ]
 
@@ -921,6 +931,16 @@ name = "drm-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d09ff881f92f118b11105ba5e34ff8f4adf27b30dae8f12e28c193af1c83176"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.6.4",
+]
+
+[[package]]
+name = "drm-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd39dde40b6e196c2e8763f23d119ddb1a8714534bf7d77fa97a65b0feda3986"
 dependencies = [
  "libc",
  "linux-raw-sys 0.6.4",
@@ -1239,11 +1259,11 @@ dependencies = [
 
 [[package]]
 name = "gbm"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313702b30cdeb83ddc72bc14dcee67803cd0ae2d12282ea06e368c25a900c844"
+checksum = "45bf55ba6dd53ad0ac115046ff999c5324c283444ee6e0be82454c4e8eb2f36a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "drm",
  "drm-fourcc",
  "gbm-sys",
@@ -2149,7 +2169,7 @@ dependencies = [
  "calloop 0.13.0",
  "clap",
  "directories",
- "drm-ffi",
+ "drm-ffi 0.7.1",
  "futures-util",
  "git-version",
  "glam",
@@ -3116,7 +3136,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/Smithay/smithay.git#c5e9a697e41f50dc56b918d9ef1e3d2e52c84ac0"
+source = "git+https://github.com/Smithay/smithay.git#40acc58b83400aa10fc62a51a235d1991ab46be5"
 dependencies = [
  "appendlist",
  "bitflags 2.5.0",
@@ -3126,7 +3146,7 @@ dependencies = [
  "cursor-icon",
  "downcast-rs",
  "drm",
- "drm-ffi",
+ "drm-ffi 0.8.0",
  "drm-fourcc",
  "errno",
  "gbm",
@@ -3188,7 +3208,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#c5e9a697e41f50dc56b918d9ef1e3d2e52c84ac0"
+source = "git+https://github.com/Smithay/smithay.git#40acc58b83400aa10fc62a51a235d1991ab46be5"
 dependencies = [
  "drm",
  "edid-rs",

--- a/src/handlers/layer_shell.rs
+++ b/src/handlers/layer_shell.rs
@@ -1,5 +1,5 @@
 use smithay::delegate_layer_shell;
-use smithay::desktop::{layer_map_for_output, LayerSurface, WindowSurfaceType};
+use smithay::desktop::{layer_map_for_output, LayerSurface, PopupKind, WindowSurfaceType};
 use smithay::output::Output;
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
@@ -55,7 +55,7 @@ impl WlrLayerShellHandler for State {
     }
 
     fn new_popup(&mut self, _parent: WlrLayerSurface, popup: PopupSurface) {
-        self.unconstrain_popup(&popup);
+        self.unconstrain_popup(&PopupKind::Xdg(popup));
     }
 }
 delegate_layer_shell!(State);

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -142,6 +142,7 @@ impl InputMethodHandler for State {
                 send_surface_state(wl_surface, data, scale, transform);
             });
         }
+
         if let Err(err) = self.niri.popups.track_popup(popup) {
             warn!("error tracking ime popup {err:?}");
         }

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -649,7 +649,7 @@ impl State {
                         popup.send_configure().expect("initial configure failed");
                     }
                 }
-                // Input method popup can arbitrary change its geometry, so we need to unconstraint
+                // Input method popup can arbitrary change its geometry, so we need to unconstrain
                 // it on commit.
                 PopupKind::InputMethod(_) => {
                     self.unconstrain_popup(&popup);

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -768,7 +768,7 @@ impl State {
                     );
 
                     grab.grab.ungrab(PopupUngrabStrategy::All);
-                    keyboard.unset_grab();
+                    keyboard.unset_grab(self);
                     self.niri.seat.get_pointer().unwrap().unset_grab(
                         self,
                         SERIAL_COUNTER.next_serial(),


### PR DESCRIPTION
Make IME popup to be visible inside the parent and not obscure the
text input rectangle region.

Fixes https://github.com/YaLTeR/niri/issues/221

--

depends on https://github.com/Smithay/smithay/pull/1397