### PR TITLE
Add is_active_in_column

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -720,6 +720,8 @@ pub struct Match {
     pub is_active: Option<bool>,
     #[knuffel(property)]
     pub is_focused: Option<bool>,
+    #[knuffel(property)]
+    pub is_active_in_column: Option<bool>,
 }
 
 impl PartialEq for Match {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -121,6 +121,7 @@ pub trait LayoutElement {
     fn output_leave(&self, output: &Output);
     fn set_offscreen_element_id(&self, id: Option<Id>);
     fn set_activated(&mut self, active: bool);
+    fn set_active_in_column(&mut self, active: bool);
     fn set_bounds(&self, bounds: Size<i32, Logical>);
 
     fn send_pending_configure(&mut self);

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1976,6 +1976,8 @@ mod tests {
 
         fn send_pending_configure(&mut self) {}
 
+        fn set_active_in_column(&mut self, _active: bool) {}
+
         fn is_fullscreen(&self) -> bool {
             false
         }

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -2139,10 +2139,15 @@ impl<W: LayoutElement> Workspace<W> {
         for (col_idx, col) in self.columns.iter_mut().enumerate() {
             for (tile_idx, tile) in col.tiles.iter_mut().enumerate() {
                 let win = tile.window_mut();
+
+                let active_in_column =  col.active_tile_idx == tile_idx;
+                win.set_active_in_column(active_in_column);
+
                 let active = is_active
                     && self.active_column_idx == col_idx
-                    && col.active_tile_idx == tile_idx;
+                    && active_in_column;
                 win.set_activated(active);
+
 
                 win.set_bounds(bounds);
                 win.send_pending_configure();

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -2140,14 +2140,11 @@ impl<W: LayoutElement> Workspace<W> {
             for (tile_idx, tile) in col.tiles.iter_mut().enumerate() {
                 let win = tile.window_mut();
 
-                let active_in_column =  col.active_tile_idx == tile_idx;
+                let active_in_column = col.active_tile_idx == tile_idx;
                 win.set_active_in_column(active_in_column);
 
-                let active = is_active
-                    && self.active_column_idx == col_idx
-                    && active_in_column;
+                let active = is_active && self.active_column_idx == col_idx && active_in_column;
                 win.set_activated(active);
-
 
                 win.set_bounds(bounds);
                 win.send_pending_configure();

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -44,7 +44,7 @@ pub struct Mapped {
     /// Whether this window has the keyboard focus.
     is_focused: bool,
 
-    /// Whether this window is the active window in a column
+    /// Whether this window is the active window in its column.
     pub is_active_in_column: bool,
 
     /// Buffer to draw instead of the window when it should be blocked out.

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -44,6 +44,9 @@ pub struct Mapped {
     /// Whether this window has the keyboard focus.
     is_focused: bool,
 
+    /// Whether this window is the active window in a column
+    pub is_active_in_column: bool,
+
     /// Buffer to draw instead of the window when it should be blocked out.
     block_out_buffer: RefCell<SolidColorBuffer>,
 
@@ -68,6 +71,7 @@ impl Mapped {
             rules,
             need_to_recompute_rules: false,
             is_focused: false,
+            is_active_in_column: false,
             block_out_buffer: RefCell::new(SolidColorBuffer::new((0, 0), [0., 0., 0., 1.])),
             unmap_snapshot: RefCell::new(None),
             animate_next_configure: false,
@@ -341,6 +345,12 @@ impl LayoutElement for Mapped {
                 state.states.unset(xdg_toplevel::State::Activated)
             }
         });
+        self.need_to_recompute_rules |= changed;
+    }
+
+    fn set_active_in_column(&mut self, active: bool) {
+        let changed = self.is_active_in_column != active;
+        self.is_active_in_column = active;
         self.need_to_recompute_rules |= changed;
     }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -74,6 +74,13 @@ impl<'a> WindowRef<'a> {
             WindowRef::Mapped(mapped) => mapped.is_focused(),
         }
     }
+
+    pub fn is_active_in_column(self) -> bool {
+        match self {
+            WindowRef::Unmapped(_) => false,
+            WindowRef::Mapped(mapped) => mapped.is_active_in_column,
+        }
+    }
 }
 
 impl ResolvedWindowRules {
@@ -210,6 +217,12 @@ fn window_matches(window: WindowRef, role: &XdgToplevelSurfaceRoleAttributes, m:
             return false;
         };
         if !title_re.is_match(title) {
+            return false;
+        }
+    }
+
+    if let Some(is_active_in_column) = m.is_active_in_column {
+        if window.is_active_in_column() != is_active_in_column {
             return false;
         }
     }

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -158,12 +158,12 @@ window-rule {
 ```
 
 #### `is-active-in-column`
+
 Can be `true` or `false`.
-Matches any window that is the "active" window in a column.
-Contrary to
-`is-active` there is one `is-active-in-column` window per column. It is the
-window that was last focused in each column, i.e. the one that will gain focus
-if focus is moved to the column.
+Matches the window that is the "active" window in its column.
+
+Contrary to `is-active`, there is always one `is-active-in-column` window in each column.
+It is the window that was last focused in the column, i.e. the one that will gain focus if this column is focused.
 
 window-rule {
     match is-active-in-column=true

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -157,6 +157,19 @@ window-rule {
 }
 ```
 
+#### `is-active-in-column`
+Can be `true` or `false`.
+Matches any window that is the "active" window in a column.
+Contrary to
+`is-active` there is one `is-active-in-column` window per column. It is the
+window that was last focused in each column, i.e. the one that will gain focus
+if focus is moved to the column.
+
+window-rule {
+    match is-active-in-column=true
+}
+```
+
 ### Window Opening Properties
 
 These properties apply once, when a window first opens.


### PR DESCRIPTION
This adds a `is-active-in-column` window rule. My primary use case is to "minimize" windows in columns using

```
window-rule {
    match is-active-in-column=false
    max-height 50
    min-height 50
}
```

