### PR TITLE
Initial implementation of named workspaces

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -146,11 +146,11 @@ pub enum Action {
     FocusWorkspaceDown,
     /// Focus the workspace above.
     FocusWorkspaceUp,
-    /// Focus a workspace by index.
+    /// Focus a workspace by reference (index or name).
     FocusWorkspace {
-        /// Index of the workspace to focus.
+        /// Reference (index or name) of the workspace to focus.
         #[cfg_attr(feature = "clap", arg())]
-        index: u8,
+        reference: WorkspaceReferenceArg,
     },
     /// Focus the previous workspace.
     FocusWorkspacePrevious,
@@ -158,21 +158,21 @@ pub enum Action {
     MoveWindowToWorkspaceDown,
     /// Move the focused window to the workspace above.
     MoveWindowToWorkspaceUp,
-    /// Move the focused window to a workspace by index.
+    /// Move the focused window to a workspace by reference (index or name).
     MoveWindowToWorkspace {
-        /// Index of the target workspace.
+        /// Reference (index or name) of the workspace to move the window to.
         #[cfg_attr(feature = "clap", arg())]
-        index: u8,
+        reference: WorkspaceReferenceArg,
     },
     /// Move the focused column to the workspace below.
     MoveColumnToWorkspaceDown,
     /// Move the focused column to the workspace above.
     MoveColumnToWorkspaceUp,
-    /// Move the focused column to a workspace by index.
+    /// Move the focused column to a workspace by reference (index or name).
     MoveColumnToWorkspace {
-        /// Index of the target workspace.
+        /// Reference (index or name) of the workspace to move the column to.
         #[cfg_attr(feature = "clap", arg())]
-        index: u8,
+        reference: WorkspaceReferenceArg,
     },
     /// Move the focused workspace down.
     MoveWorkspaceDown,
@@ -255,6 +255,15 @@ pub enum SizeChange {
     AdjustFixed(i32),
     /// Add or subtract to the current size as a proportion of the working area.
     AdjustProportion(f64),
+}
+
+/// Workspace reference (index or name) to operate on.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceReferenceArg {
+    /// Index of the workspace.
+    Index(u8),
+    /// Name of the workspace.
+    Name(String),
 }
 
 /// Layout to switch to.
@@ -473,6 +482,24 @@ pub enum OutputConfigChanged {
     Applied,
     /// The target output was not found, the change will be applied when it is connected.
     OutputWasMissing,
+}
+
+impl FromStr for WorkspaceReferenceArg {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let reference = if let Ok(index) = s.parse::<i32>() {
+            if let Ok(idx) = u8::try_from(index) {
+                Self::Index(idx)
+            } else {
+                return Err("workspace indexes must be between 0 and 255");
+            }
+        } else {
+            Self::Name(s.to_string())
+        };
+
+        Ok(reference)
+    }
 }
 
 impl FromStr for SizeChange {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -104,15 +104,19 @@ impl<W: LayoutElement> Monitor<W> {
     }
 
     pub fn find_named_workspace(&self, workspace_name: &str) -> Option<&Workspace<W>> {
-        self.workspaces
-            .iter()
-            .find(|w| w.name.as_deref() == Some(workspace_name))
+        self.workspaces.iter().find(|ws| {
+            ws.name
+                .as_ref()
+                .map_or(false, |name| name.eq_ignore_ascii_case(workspace_name))
+        })
     }
 
     pub fn find_named_workspace_index(&self, workspace_name: &str) -> Option<usize> {
-        self.workspaces
-            .iter()
-            .position(|w| w.name.as_deref() == Some(workspace_name))
+        self.workspaces.iter().position(|ws| {
+            ws.name
+                .as_ref()
+                .map_or(false, |name| name.eq_ignore_ascii_case(workspace_name))
+        })
     }
 
     pub fn active_workspace(&mut self) -> &mut Workspace<W> {
@@ -227,7 +231,11 @@ impl<W: LayoutElement> Monitor<W> {
 
     pub fn unname_workspace(&mut self, workspace_name: &str) -> bool {
         for ws in &mut self.workspaces {
-            if ws.name.as_deref() == Some(workspace_name) {
+            if ws
+                .name
+                .as_ref()
+                .map_or(false, |name| name.eq_ignore_ascii_case(workspace_name))
+            {
                 ws.unname();
                 return true;
             }

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -103,6 +103,18 @@ impl<W: LayoutElement> Monitor<W> {
         &self.workspaces[self.active_workspace_idx]
     }
 
+    pub fn find_named_workspace(&self, workspace_name: &str) -> Option<&Workspace<W>> {
+        self.workspaces
+            .iter()
+            .find(|w| w.name.as_deref() == Some(workspace_name))
+    }
+
+    pub fn find_named_workspace_index(&self, workspace_name: &str) -> Option<usize> {
+        self.workspaces
+            .iter()
+            .position(|w| w.name.as_deref() == Some(workspace_name))
+    }
+
     pub fn active_workspace(&mut self) -> &mut Workspace<W> {
         &mut self.workspaces[self.active_workspace_idx]
     }
@@ -204,13 +216,23 @@ impl<W: LayoutElement> Monitor<W> {
                 continue;
             }
 
-            if !self.workspaces[idx].has_windows() {
+            if !self.workspaces[idx].has_windows() && self.workspaces[idx].name.is_none() {
                 self.workspaces.remove(idx);
                 if self.active_workspace_idx > idx {
                     self.active_workspace_idx -= 1;
                 }
             }
         }
+    }
+
+    pub fn unname_workspace(&mut self, workspace_name: &str) -> bool {
+        for ws in &mut self.workspaces {
+            if ws.name.as_deref() == Some(workspace_name) {
+                ws.unname();
+                return true;
+            }
+        }
+        false
     }
 
     pub fn move_left(&mut self) {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -33,6 +33,9 @@ pub struct ResolvedWindowRules {
     /// Output to open this window on.
     pub open_on_output: Option<String>,
 
+    /// Workspace to open this window on.
+    pub open_on_workspace: Option<String>,
+
     /// Whether the window should open full-width.
     pub open_maximized: Option<bool>,
 
@@ -99,6 +102,7 @@ impl ResolvedWindowRules {
         Self {
             default_width: None,
             open_on_output: None,
+            open_on_workspace: None,
             open_maximized: None,
             open_fullscreen: None,
             min_width: None,
@@ -151,6 +155,7 @@ impl ResolvedWindowRules {
             }
 
             let mut open_on_output = None;
+            let mut open_on_workspace = None;
 
             for rule in rules {
                 let matches = |m| window_matches(window, &role, m);
@@ -173,6 +178,10 @@ impl ResolvedWindowRules {
 
                 if let Some(x) = rule.open_on_output.as_deref() {
                     open_on_output = Some(x);
+                }
+
+                if let Some(x) = rule.open_on_workspace.as_deref() {
+                    open_on_workspace = Some(x);
                 }
 
                 if let Some(x) = rule.open_maximized {
@@ -217,6 +226,7 @@ impl ResolvedWindowRules {
             }
 
             resolved.open_on_output = open_on_output.map(|x| x.to_owned());
+            resolved.open_on_workspace = open_on_workspace.map(|x| x.to_owned());
         });
 
         resolved

--- a/src/window/unmapped.rs
+++ b/src/window/unmapped.rs
@@ -11,6 +11,7 @@ pub struct Unmapped {
     pub state: InitialConfigureState,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum InitialConfigureState {
     /// The window has not been initially configured yet.
@@ -42,6 +43,9 @@ pub enum InitialConfigureState {
         /// - This is a dialog with a parent, and there was no explicit output set, so this dialog
         ///   should fetch the parent's current output again upon mapping.
         output: Option<Output>,
+
+        /// Workspace to open this window on.
+        workspace_name: Option<String>,
     },
 }
 

--- a/wiki/Configuration:-Named-Workspaces.md
+++ b/wiki/Configuration:-Named-Workspaces.md
@@ -1,0 +1,36 @@
+### Overview
+
+You can declare named workspaces at the top level of the config:
+
+```
+workspace "browser"
+
+workspace "chat" {
+    open-on-output "DP-2"
+}
+```
+
+Contrary to normal dynamic workspaces, named workspaces always exist, even when they have no windows.
+Otherwise, they behave like any other workspace: you can move them around, move to a different monitor, and so on.
+
+Actions like `focus-workspace` or `move-column-to-workspace` can refer to workspaces by name.
+Also, you can use an `open-on-workspace` window rule to make a window open on a specific named workspace:
+
+```
+// Declare a workspace named "chat" that opens on the "DP-2" output.
+workspace "chat" {
+    open-on-output "DP-2"
+}
+
+// Open Telegram on the "chat" workspace at niri startup.
+window-rule {
+    match at-startup=true app-id=r#"^org\.telegram\.desktop$"#
+    open-on-workspace "chat"
+}
+```
+
+Named workspaces initially appear in the order they are declared in the config file.
+When editing the config while niri is running, newly declared named workspaces will appear at the very top of a monitor.
+
+If you delete some named workspace from the config, the workspace will become normal (unnamed), and if there are no windows on it, it will be removed (as any other normal workspace).
+There's no way to give a name to an already existing workspace, but you can simply move windows that you want to a new, empty named workspace.

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -37,6 +37,7 @@ window-rule {
     // Properties that apply once upon window opening.
     default-column-width { proportion 0.75; }
     open-on-output "eDP-1"
+    open-on-workspace "chat"
     open-maximized true
     open-fullscreen true
 
@@ -231,6 +232,23 @@ window-rule {
     exclude app-id=r#"^org\.telegram\.desktop$"# title="^Media viewer$"
 
     open-on-output "HDMI-A-1"
+}
+```
+
+#### `open-on-workspace`
+
+Make the window open on a specific [named workspace](./Configuration:-Named-Workspaces.md).
+
+If such a workspace does not exist, the window will open on the currently focused workspace as usual.
+
+If the window opens on an output that is not currently focused, the window will not be automatically focused.
+
+```
+// Open Telegram on the "chat" workspace.
+window-rule {
+    match app-id=r#"^org\.telegram\.desktop$"#
+
+    open-on-workspace "chat"
 }
 ```
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -15,6 +15,7 @@
 * [Outputs](./Configuration:-Outputs.md)
 * [Key Bindings](./Configuration:-Key-Bindings.md)
 * [Layout](./Configuration:-Layout.md)
+* [Named Workspaces](./Configuration:-Named-Workspaces.md)
 * [Miscellaneous](./Configuration:-Miscellaneous.md)
 * [Window Rules](./Configuration:-Window-Rules.md)
 * [Animations](./Configuration:-Animations.md)


### PR DESCRIPTION
This is an implementation of named, pre-declared workspaces. With this implementation, workspaces can be declared in the configuration file by name:

```
workspace "name" {
  open-on-output "winit"
}
```

The `open-on-output` property is optional, and can be skipped, in which case the workspace will open on the primary output.

All actions that were able to target a workspace by index can now target them by either an index, or a name. In case of the command line, where we do not have types available, this means that workspace names that also pass as `u8` cannot be switched to by name, only by index.

Unlike dynamic workspaces, named workspaces do not close when they are empty, they remain static. Like dynamic workspaces, named workspaces are bound to a particular output. Switching to a named workspace, or moving a window or column to one will also switch to, or move the thing in question to the output of the workspace.

When reloading the configuration, newly added named workspaces will be created, and removed ones will lose their name. If any such orphaned workspace was empty, they will be removed. If they weren't, they'll remain as a dynamic workspace, without a name. Re-declaring a workspace with the same name later will create a new one.

Additionally, this also implements a `open-on-workspace "<name>"` window rule. Matching windows will open on the given workspace (or the current one, if the named workspace does not exist).