### PR TITLE
Add support for using a different amount of fingers for swiping.

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -77,6 +77,8 @@ pub struct Input {
     pub focus_follows_mouse: bool,
     #[knuffel(child)]
     pub workspace_auto_back_and_forth: bool,
+    #[knuffel(child, unwrap(argument), default = 3)]
+    pub gesture_swipe_fingers: u32,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq, Eq)]
@@ -1978,6 +1980,7 @@ mod tests {
                 warp-mouse-to-focus
                 focus-follows-mouse
                 workspace-auto-back-and-forth
+                gesture-swipe-fingers 3
             }
 
             output "eDP-1" {
@@ -2133,6 +2136,7 @@ mod tests {
                     warp_mouse_to_focus: true,
                     focus_follows_mouse: true,
                     workspace_auto_back_and_forth: true,
+                    gesture_swipe_fingers: 3,
                 },
                 outputs: vec![Output {
                     off: false,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1440,7 +1440,7 @@ impl State {
     }
 
     fn on_gesture_swipe_begin<I: InputBackend>(&mut self, event: I::GestureSwipeBeginEvent) {
-        if event.fingers() == 3 {
+        if event.fingers() == self.niri.config.borrow().input.gesture_swipe_fingers {
             self.niri.gesture_swipe_3f_cumulative = Some((0., 0.));
 
             // We handled this event.


### PR DESCRIPTION
This removes the hardcoded prerequisite of using three fingers to use the swipe gesture. Instead one can configure it by setting `gesture-swipe-fingers` in the `input` section.

A working example is:
```
input {
    gesture-swipe-fingers 4
}
```