### PR TITLE
Add `libXcursor` and `libXi` to nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,8 @@
             wayland
             mesa
             libglvnd # For libEGL
+            xorg.libXcursor
+            xorg.libXi
           ];
 
           LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";


### PR DESCRIPTION
In my tests this was necessary to develop Niri using non-NixOS Nix. Otherwise Niri panics with this error message: called `Result::unwrap()` on an `Err` value: EventLoopCreation(NotSupported(NotSupportedError)).