### PR TITLE
Basic Workspace IPC

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -31,6 +31,8 @@ pub enum Request {
         /// Configuration to apply.
         action: OutputAction,
     },
+    /// Request information about workspaces.
+    Workspaces,
     /// Respond with an error (for testing error handling).
     ReturnError,
 }
@@ -60,6 +62,8 @@ pub enum Response {
     FocusedWindow(Option<Window>),
     /// Output configuration change result.
     OutputConfigChanged(OutputConfigChanged),
+    /// Information about workspaces.
+    Workspaces(Vec<Workspace>),
 }
 
 /// Actions that niri can perform.
@@ -482,6 +486,23 @@ pub enum OutputConfigChanged {
     Applied,
     /// The target output was not found, the change will be applied when it is connected.
     OutputWasMissing,
+}
+
+/// A workspace.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Workspace {
+    /// Index of the workspace on its monitor.
+    ///
+    /// This is the same index you can use for requests like `niri msg action focus-workspace`.
+    pub idx: u8,
+    /// Optional name of the workspace.
+    pub name: Option<String>,
+    /// Name of the output that the workspace is on.
+    ///
+    /// Can be `None` if no outputs are currently connected.
+    pub output: Option<String>,
+    /// Whether the workspace is currently active on its output.
+    pub is_active: bool,
 }
 
 impl FromStr for WorkspaceReferenceArg {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,6 +78,8 @@ pub enum Msg {
         #[command(subcommand)]
         action: OutputAction,
     },
+    /// List workspaces.
+    Workspaces,
     /// Request an error from the running niri instance.
     RequestError,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,12 +32,6 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Sub {
-    /// Validate the config file.
-    Validate {
-        /// Path to config file (default: `$XDG_CONFIG_HOME/niri/config.kdl`).
-        #[arg(short, long)]
-        config: Option<PathBuf>,
-    },
     /// Communicate with the running niri instance.
     Msg {
         #[command(subcommand)]
@@ -46,16 +40,22 @@ pub enum Sub {
         #[arg(short, long)]
         json: bool,
     },
+    /// Validate the config file.
+    Validate {
+        /// Path to config file (default: `$XDG_CONFIG_HOME/niri/config.kdl`).
+        #[arg(short, long)]
+        config: Option<PathBuf>,
+    },
     /// Cause a panic to check if the backtraces are good.
     Panic,
 }
 
 #[derive(Subcommand)]
 pub enum Msg {
-    /// Print the version of the running niri instance.
-    Version,
     /// List connected outputs.
     Outputs,
+    /// List workspaces.
+    Workspaces,
     /// Print information about the focused window.
     FocusedWindow,
     /// Perform an action.
@@ -78,8 +78,8 @@ pub enum Msg {
         #[command(subcommand)]
         action: OutputAction,
     },
-    /// List workspaces.
-    Workspaces,
+    /// Print the version of the running niri instance.
+    Version,
     /// Request an error from the running niri instance.
     RequestError,
 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2278,6 +2278,41 @@ impl<W: LayoutElement> Layout<W> {
             }
         }
     }
+
+    pub fn ipc_workspaces(&self) -> Vec<niri_ipc::Workspace> {
+        match &self.monitor_set {
+            MonitorSet::Normal {
+                monitors,
+                primary_idx: _,
+                active_monitor_idx: _,
+            } => {
+                let mut workspaces = Vec::new();
+
+                for monitor in monitors {
+                    for (idx, workspace) in monitor.workspaces.iter().enumerate() {
+                        workspaces.push(niri_ipc::Workspace {
+                            idx: u8::try_from(idx + 1).unwrap_or(u8::MAX),
+                            name: workspace.name.clone(),
+                            output: Some(monitor.output.name()),
+                            is_active: monitor.active_workspace_idx == idx,
+                        })
+                    }
+                }
+
+                workspaces
+            }
+            MonitorSet::NoOutputs { workspaces } => workspaces
+                .iter()
+                .enumerate()
+                .map(|(idx, ws)| niri_ipc::Workspace {
+                    idx: u8::try_from(idx + 1).unwrap_or(u8::MAX),
+                    name: ws.name.clone(),
+                    output: None,
+                    is_active: false,
+                })
+                .collect(),
+        }
+    }
 }
 
 impl<W: LayoutElement> Default for MonitorSet<W> {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -12,6 +12,7 @@ use _server_decoration::server::org_kde_kwin_server_decoration_manager::Mode as 
 use anyhow::{ensure, Context};
 use calloop::futures::Scheduler;
 use niri_config::{Config, Key, Modifiers, PreviewRender, TrackLayout, WorkspaceReference};
+use niri_ipc::Workspace;
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::element::memory::MemoryRenderBufferRenderElement;
@@ -3933,6 +3934,10 @@ impl Niri {
             // FIXME: granular.
             self.queue_redraw_all();
         }
+    }
+
+    pub fn ipc_workspaces(&self) -> Vec<Workspace> {
+        self.layout.ipc_workspaces()
     }
 }
 


### PR DESCRIPTION
I just took a hack at getting monitor + workspace data via IPC to facilitate some scripting in AGS/EWW/Waybar. It is pretty sparse, but it has the basic information I wanted. If there is a better/different way to implement this functionality, I am more than willing to go back to the drawing board.

`niri msg -j workspaces | jq`:

```json
[
  {
    "id": 0,
    "display": 0,
    "active": true
  },
  {
    "id": 2,
    "display": 0,
    "active": false
  },
  {
    "id": 1,
    "display": 1,
    "active": true
  },
  {
    "id": 3,
    "display": 1,
    "active": false
  }
]
```