### PR TITLE
Add "off" and "disabled-on-external-mouse" properties to input devices

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -156,6 +156,8 @@ pub enum TrackLayout {
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
 pub struct Touchpad {
     #[knuffel(child)]
+    pub off: bool,
+    #[knuffel(child)]
     pub tap: bool,
     #[knuffel(child)]
     pub dwt: bool,
@@ -175,10 +177,14 @@ pub struct Touchpad {
     pub tap_button_map: Option<TapButtonMap>,
     #[knuffel(child)]
     pub left_handed: bool,
+    #[knuffel(child)]
+    pub disabled_on_external_mouse: bool,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
 pub struct Mouse {
+    #[knuffel(child)]
+    pub off: bool,
     #[knuffel(child)]
     pub natural_scroll: bool,
     #[knuffel(child, unwrap(argument), default)]
@@ -193,6 +199,8 @@ pub struct Mouse {
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
 pub struct Trackpoint {
+    #[knuffel(child)]
+    pub off: bool,
     #[knuffel(child)]
     pub natural_scroll: bool,
     #[knuffel(child, unwrap(argument), default)]
@@ -269,6 +277,8 @@ impl From<TapButtonMap> for input::TapButtonMap {
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
 pub struct Tablet {
+    #[knuffel(child)]
+    pub off: bool,
     #[knuffel(child, unwrap(argument))]
     pub map_to_output: Option<String>,
     #[knuffel(child)]
@@ -2342,6 +2352,7 @@ mod tests {
                     accel-profile "flat"
                     scroll-method "two-finger"
                     tap-button-map "left-middle-right"
+                    disabled-on-external-mouse
                 }
 
                 mouse {
@@ -2352,6 +2363,7 @@ mod tests {
                 }
 
                 trackpoint {
+                    off
                     natural-scroll
                     accel-speed 0.0
                     accel-profile "flat"
@@ -2504,6 +2516,7 @@ mod tests {
                         track_layout: TrackLayout::Window,
                     },
                     touchpad: Touchpad {
+                        off: false,
                         tap: true,
                         dwt: true,
                         dwtp: true,
@@ -2514,8 +2527,10 @@ mod tests {
                         scroll_method: Some(ScrollMethod::TwoFinger),
                         tap_button_map: Some(TapButtonMap::LeftMiddleRight),
                         left_handed: false,
+                        disabled_on_external_mouse: true,
                     },
                     mouse: Mouse {
+                        off: false,
                         natural_scroll: true,
                         accel_speed: 0.4,
                         accel_profile: Some(AccelProfile::Flat),
@@ -2523,12 +2538,14 @@ mod tests {
                         left_handed: false,
                     },
                     trackpoint: Trackpoint {
+                        off: true,
                         natural_scroll: true,
                         accel_speed: 0.0,
                         accel_profile: Some(AccelProfile::Flat),
                         scroll_method: Some(ScrollMethod::OnButtonDown),
                     },
                     tablet: Tablet {
+                        off: false,
                         map_to_output: Some("eDP-1".to_owned()),
                         left_handed: false,
                     },

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -21,6 +21,7 @@ input {
     // Next sections include libinput settings.
     // Omitting settings disables them, or leaves them at their default values.
     touchpad {
+        // off
         tap
         // dwt
         // dwtp
@@ -28,9 +29,11 @@ input {
         // accel-speed 0.2
         // accel-profile "flat"
         // scroll-method "two-finger"
+        // disabled-on-external-mouse
     }
 
     mouse {
+        // off
         // natural-scroll
         // accel-speed 0.2
         // accel-profile "flat"

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2219,6 +2219,13 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
     let is_touchpad = device.config_tap_finger_count() > 0;
     if is_touchpad {
         let c = &config.touchpad;
+        let _ = device.config_send_events_set_mode(if c.off {
+            input::SendEventsMode::DISABLED
+        } else if c.disabled_on_external_mouse {
+            input::SendEventsMode::DISABLED_ON_EXTERNAL_MOUSE
+        } else {
+            input::SendEventsMode::ENABLED
+        });
         let _ = device.config_tap_set_enabled(c.tap);
         let _ = device.config_dwt_set_enabled(c.dwt);
         let _ = device.config_dwtp_set_enabled(c.dwtp);
@@ -2272,6 +2279,11 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
         && !is_trackpoint;
     if is_mouse {
         let c = &config.mouse;
+        let _ = device.config_send_events_set_mode(if c.off {
+            input::SendEventsMode::DISABLED
+        } else {
+            input::SendEventsMode::ENABLED
+        });
         let _ = device.config_scroll_set_natural_scroll_enabled(c.natural_scroll);
         let _ = device.config_accel_set_speed(c.accel_speed);
         let _ = device.config_left_handed_set(c.left_handed);
@@ -2291,6 +2303,11 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
 
     if is_trackpoint {
         let c = &config.trackpoint;
+        let _ = device.config_send_events_set_mode(if c.off {
+            input::SendEventsMode::DISABLED
+        } else {
+            input::SendEventsMode::ENABLED
+        });
         let _ = device.config_scroll_set_natural_scroll_enabled(c.natural_scroll);
         let _ = device.config_accel_set_speed(c.accel_speed);
 
@@ -2310,6 +2327,11 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
     let is_tablet = device.has_capability(input::DeviceCapability::TabletTool);
     if is_tablet {
         let c = &config.tablet;
+        let _ = device.config_send_events_set_mode(if c.off {
+            input::SendEventsMode::DISABLED
+        } else {
+            input::SendEventsMode::ENABLED
+        });
         let _ = device.config_left_handed_set(c.left_handed);
     }
 }

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -25,6 +25,7 @@ input {
     }
 
     touchpad {
+        // off
         tap
         // dwt
         // dwtp
@@ -35,9 +36,11 @@ input {
         // tap-button-map "left-middle-right"
         // click-method "clickfinger"
         // left-handed
+        // disabled-on-external-mouse
     }
 
     mouse {
+        // off
         // natural-scroll
         // accel-speed 0.2
         // accel-profile "flat"
@@ -46,6 +49,7 @@ input {
     }
 
     trackpoint {
+        // off
         // natural-scroll
         // accel-speed 0.2
         // accel-profile "flat"
@@ -53,6 +57,7 @@ input {
     }
 
     tablet {
+        // off
         map-to-output "eDP-1"
         // left-handed
     }
@@ -122,6 +127,10 @@ Most settings for the pointing devices are passed directly to libinput.
 Other Wayland compositors also use libinput, so it's likely you will find the same settings there.
 For flags like `tap`, omit them or comment them out to disable the setting.
 
+A few settings are common between input devices:
+
+- `off`: if set, no events will be sent from this device.
+
 A few settings are common between `touchpad`, `mouse` and `trackpoint`:
 
 - `natural-scroll`: if set, inverts the scrolling direction.
@@ -137,6 +146,7 @@ Settings specific to `touchpad`s:
 - `dwtp`: disable-when-trackpointing.
 - `tap-button-map`: can be `left-right-middle` or `left-middle-right`, controls which button corresponds to a two-finger tap and a three-finger tap.
 - `click-method`: can be `button-areas` or `clickfinger`, changes the [click method](https://wayland.freedesktop.org/libinput/doc/latest/clickpad-softbuttons.html).
+- `disabled-on-external-mouse`: do not send events while external pointer device is plugged in.
 
 Settings specific to `touchpad`, `mouse` and `tablet`:
 


### PR DESCRIPTION
This is called "events <mode>" in Sway, ~but I choose "send-events-mode" for consistency with libinput.~


I think this option also applies to keyboards, but I'm not going to add the one because we don't have libinput machinery for the keyboard config, and it's unlikely that user wants to disable _all_ keyboards. OTOH, pointer devices can be disabled per type. Perhaps, this should be revisited after implementing #371.