### PR TITLE
per keyboard device config

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -82,7 +82,7 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn default_keyboard(&self) -> Keyboard {
+    pub fn fallback_keyboard(&self) -> Keyboard {
         self.keyboards
             .iter()
             .find(|keyboard| keyboard.name.is_none())
@@ -95,7 +95,7 @@ impl Input {
             .iter()
             .find(|keyboard| keyboard.name.as_deref() == Some(name.as_ref()))
             .cloned()
-            .unwrap_or_default()
+            .unwrap_or_else(|| self.fallback_keyboard())
     }
 }
 
@@ -2959,7 +2959,7 @@ mod tests {
     #[test]
     fn default_repeat_params() {
         let config = Config::parse("config.kdl", "").unwrap();
-        assert_eq!(config.input.default_keyboard().repeat_delay, 600);
-        assert_eq!(config.input.default_keyboard().repeat_rate, 25);
+        assert_eq!(config.input.fallback_keyboard().repeat_delay, 600);
+        assert_eq!(config.input.fallback_keyboard().repeat_rate, 25);
     }
 }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2368,6 +2368,16 @@ mod tests {
                     }
                 }
 
+                keyboard "test_keyboard" {
+                    repeat-delay 500
+                    repeat-rate 30
+                    track-layout "window"
+                    xkb {
+                        layout "us,ru"
+                        options "grp:win_space_toggle"
+                    }
+                }
+
                 touchpad {
                     tap
                     dwt
@@ -2530,17 +2540,30 @@ mod tests {
             "##,
             Config {
                 input: Input {
-                    keyboards: Keyboard {
-                        xkb: Xkb {
-                            layout: "us,ru".to_owned(),
-                            options: Some("grp:win_space_toggle".to_owned()),
+                    keyboards: vec![
+                        Keyboard {
+                            xkb: Xkb {
+                                layout: "us,ru".to_owned(),
+                                options: Some("grp:win_space_toggle".to_owned()),
+                                ..Default::default()
+                            },
+                            repeat_delay: 600,
+                            repeat_rate: 25,
+                            track_layout: TrackLayout::Window,
                             ..Default::default()
                         },
-                        repeat_delay: 600,
-                        repeat_rate: 25,
-                        track_layout: TrackLayout::Window,
-                        ..Default::default()
-                    },
+                        Keyboard {
+                            xkb: Xkb {
+                                layout: "us,ru".to_owned(),
+                                options: Some("grp:win_space_toggle".to_owned()),
+                                ..Default::default()
+                            },
+                            repeat_delay: 500,
+                            repeat_rate: 30,
+                            track_layout: TrackLayout::Window,
+                            name: Some("test_keyboard".to_owned()),
+                        },
+                    ],
                     touchpad: Touchpad {
                         off: false,
                         tap: true,
@@ -2936,7 +2959,7 @@ mod tests {
     #[test]
     fn default_repeat_params() {
         let config = Config::parse("config.kdl", "").unwrap();
-        assert_eq!(config.input.keyboard.repeat_delay, 600);
-        assert_eq!(config.input.keyboard.repeat_rate, 25);
+        assert_eq!(config.input.default_keyboard().repeat_delay, 600);
+        assert_eq!(config.input.default_keyboard().repeat_rate, 25);
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -271,19 +271,24 @@ impl State {
     fn on_keyboard<I: InputBackend>(&mut self, event: I::KeyboardKeyEvent) {
         {
             let device = event.device();
-            let xkb = self
+
+            let keyboard_config = self
                 .niri
                 .config
                 .borrow()
                 .input
-                .keyboard_named(device.name())
-                .xkb;
+                .keyboard_named(device.name());
 
             let keyboard = self.niri.seat.get_keyboard().unwrap();
 
-            if let Err(err) = keyboard.set_xkb_config(self, xkb.to_xkb_config()) {
+            if let Err(err) = keyboard.set_xkb_config(self, keyboard_config.xkb.to_xkb_config()) {
                 warn!("error updating xkb config: {err:?}");
             }
+
+            keyboard.change_repeat_info(
+                keyboard_config.repeat_rate.into(),
+                keyboard_config.repeat_delay.into(),
+            );
         }
 
         let comp_mod = self.backend.mod_key();

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -269,6 +269,23 @@ impl State {
     }
 
     fn on_keyboard<I: InputBackend>(&mut self, event: I::KeyboardKeyEvent) {
+        {
+            let device = event.device();
+            let xkb = self
+                .niri
+                .config
+                .borrow()
+                .input
+                .keyboard_named(device.name())
+                .xkb;
+
+            let keyboard = self.niri.seat.get_keyboard().unwrap();
+
+            if let Err(err) = keyboard.set_xkb_config(self, xkb.to_xkb_config()) {
+                warn!("error updating xkb config: {err:?}");
+            }
+        }
+
         let comp_mod = self.backend.mod_key();
 
         let serial = SERIAL_COUNTER.next_serial();

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -271,6 +271,8 @@ pub struct Niri {
     // Casts are dropped before PipeWire to prevent a double-free (yay).
     pub casts: Vec<Cast>,
     pub pipewire: Option<PipeWire>,
+
+    pub current_keyboard: niri_config::Keyboard,
 }
 
 pub struct OutputState {
@@ -1587,6 +1589,8 @@ impl Niri {
 
             pipewire,
             casts: vec![],
+
+            current_keyboard: Default::default(),
         }
     }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -184,6 +184,7 @@ pub struct Niri {
 
     pub current_keyboard: niri_config::Keyboard,
     pub devices: HashSet<input::Device>,
+    pub keyboard_device_cache: HashMap<input::Device, niri_config::Keyboard>,
     pub tablets: HashMap<input::Device, TabletData>,
     pub touch: HashSet<input::Device>,
 
@@ -1506,7 +1507,9 @@ impl Niri {
             root_surface: HashMap::new(),
             monitors_active: true,
 
+            current_keyboard: Default::default(),
             devices: HashSet::new(),
+            keyboard_device_cache: HashMap::new(),
             tablets: HashMap::new(),
             touch: HashSet::new(),
 
@@ -1588,8 +1591,6 @@ impl Niri {
 
             pipewire,
             casts: vec![],
-
-            current_keyboard: Default::default(),
         }
     }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -808,7 +808,15 @@ impl State {
                 }
             }
 
-            if self.niri.config.borrow().input.keyboard.track_layout == TrackLayout::Window {
+            if self
+                .niri
+                .config
+                .borrow()
+                .input
+                .default_keyboard()
+                .track_layout
+                == TrackLayout::Window
+            {
                 let current_layout =
                     keyboard.with_xkb_state(self, |context| context.active_layout());
 
@@ -908,19 +916,23 @@ impl State {
             self.niri.cursor_texture_cache.clear();
         }
 
+        let default_keyboard = config.input.default_keyboard();
+
+        let old_keyboard = old_config.input.default_keyboard();
+
         // We need &mut self to reload the xkb config, so just store it here.
-        if config.input.keyboard.xkb != old_config.input.keyboard.xkb {
-            reload_xkb = Some(config.input.keyboard.xkb.clone());
+        if default_keyboard.xkb != old_keyboard.xkb {
+            reload_xkb = Some(default_keyboard.xkb.clone());
         }
 
         // Reload the repeat info.
-        if config.input.keyboard.repeat_rate != old_config.input.keyboard.repeat_rate
-            || config.input.keyboard.repeat_delay != old_config.input.keyboard.repeat_delay
+        if default_keyboard.repeat_rate != old_keyboard.repeat_rate
+            || default_keyboard.repeat_delay != old_keyboard.repeat_delay
         {
             let keyboard = self.niri.seat.get_keyboard().unwrap();
             keyboard.change_repeat_info(
-                config.input.keyboard.repeat_rate.into(),
-                config.input.keyboard.repeat_delay.into(),
+                default_keyboard.repeat_rate.into(),
+                default_keyboard.repeat_delay.into(),
             );
         }
 
@@ -1375,9 +1387,9 @@ impl Niri {
 
         let mut seat: Seat<State> = seat_state.new_wl_seat(&display_handle, backend.seat_name());
         seat.add_keyboard(
-            config_.input.keyboard.xkb.to_xkb_config(),
-            config_.input.keyboard.repeat_delay.into(),
-            config_.input.keyboard.repeat_rate.into(),
+            config_.input.default_keyboard().xkb.to_xkb_config(),
+            config_.input.default_keyboard().repeat_delay.into(),
+            config_.input.default_keyboard().repeat_rate.into(),
         )
         .unwrap();
         seat.add_pointer();

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -810,15 +810,7 @@ impl State {
                 }
             }
 
-            if self
-                .niri
-                .config
-                .borrow()
-                .input
-                .fallback_keyboard()
-                .track_layout
-                == TrackLayout::Window
-            {
+            if self.niri.current_keyboard.track_layout == TrackLayout::Window {
                 let current_layout =
                     keyboard.with_xkb_state(self, |context| context.active_layout());
 
@@ -920,16 +912,16 @@ impl State {
 
         let default_keyboard = config.input.fallback_keyboard();
 
-        let old_keyboard = old_config.input.fallback_keyboard();
+        let current_keyboard = self.niri.current_keyboard.clone();
 
         // We need &mut self to reload the xkb config, so just store it here.
-        if default_keyboard.xkb != old_keyboard.xkb {
+        if default_keyboard.xkb != current_keyboard.xkb {
             reload_xkb = Some(default_keyboard.xkb.clone());
         }
 
         // Reload the repeat info.
-        if default_keyboard.repeat_rate != old_keyboard.repeat_rate
-            || default_keyboard.repeat_delay != old_keyboard.repeat_delay
+        if default_keyboard.repeat_rate != current_keyboard.repeat_rate
+            || default_keyboard.repeat_delay != current_keyboard.repeat_delay
         {
             let keyboard = self.niri.seat.get_keyboard().unwrap();
             keyboard.change_repeat_info(

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -182,6 +182,7 @@ pub struct Niri {
     // When false, we're idling with monitors powered off.
     pub monitors_active: bool,
 
+    pub current_keyboard: niri_config::Keyboard,
     pub devices: HashSet<input::Device>,
     pub tablets: HashMap<input::Device, TabletData>,
     pub touch: HashSet<input::Device>,
@@ -271,8 +272,6 @@ pub struct Niri {
     // Casts are dropped before PipeWire to prevent a double-free (yay).
     pub casts: Vec<Cast>,
     pub pipewire: Option<PipeWire>,
-
-    pub current_keyboard: niri_config::Keyboard,
 }
 
 pub struct OutputState {
@@ -815,7 +814,7 @@ impl State {
                 .config
                 .borrow()
                 .input
-                .default_keyboard()
+                .fallback_keyboard()
                 .track_layout
                 == TrackLayout::Window
             {
@@ -918,9 +917,9 @@ impl State {
             self.niri.cursor_texture_cache.clear();
         }
 
-        let default_keyboard = config.input.default_keyboard();
+        let default_keyboard = config.input.fallback_keyboard();
 
-        let old_keyboard = old_config.input.default_keyboard();
+        let old_keyboard = old_config.input.fallback_keyboard();
 
         // We need &mut self to reload the xkb config, so just store it here.
         if default_keyboard.xkb != old_keyboard.xkb {
@@ -1389,9 +1388,9 @@ impl Niri {
 
         let mut seat: Seat<State> = seat_state.new_wl_seat(&display_handle, backend.seat_name());
         seat.add_keyboard(
-            config_.input.default_keyboard().xkb.to_xkb_config(),
-            config_.input.default_keyboard().repeat_delay.into(),
-            config_.input.default_keyboard().repeat_rate.into(),
+            config_.input.fallback_keyboard().xkb.to_xkb_config(),
+            config_.input.fallback_keyboard().repeat_delay.into(),
+            config_.input.fallback_keyboard().repeat_rate.into(),
         )
         .unwrap();
         seat.add_pointer();


### PR DESCRIPTION
this PR allows keyboards to be configured by name. the following config sets my laptop's built in keyboard layout to colemak while allowing my external keyboard (already flashed with colemak) to work as expected.

```
input {
    keyboard "AT Translated Set 2 keyboard" {
        xkb {
            layout "us(colemak),us"
            options "caps:escape_shifted_capslock,lv3:menu_switch,lv3:ralt_alt"
        }
    }

    keyboard {
        xkb {
            // layout "us(colemak),us"
            // options "caps:escape_shifted_capslock,lv3:menu_switch,lv3:ralt_alt"
        }
    }
}
```

the last used configuration is cached between calls to `on_keyboard()` in an attempt to squeeze some performance gains. based on the feedback on this implementation, the same can be quickly done for all other supported input types.