### PR TITLE
Handle KDE decorations in Mapped::has_ssd

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -62,6 +62,7 @@ use smithay::{
     delegate_virtual_keyboard_manager, delegate_xdg_activation,
 };
 
+pub use crate::handlers::xdg_shell::KdeDecorationsModeState;
 use crate::niri::{ClientState, State};
 use crate::protocols::foreign_toplevel::{
     self, ForeignToplevelHandler, ForeignToplevelManagerState,


### PR DESCRIPTION
This fixes an issue with default CSD border being drawn for SSD rendering firefox, because only xdg decorations were checked.