### PR TITLE
Event stream IPC

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1233,6 +1233,7 @@ impl From<niri_ipc::Action> for Action {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum WorkspaceReference {
+    Id(u64),
     Index(u8),
     Name(String),
 }
@@ -1240,6 +1241,7 @@ pub enum WorkspaceReference {
 impl From<WorkspaceReferenceArg> for WorkspaceReference {
     fn from(reference: WorkspaceReferenceArg) -> WorkspaceReference {
         match reference {
+            WorkspaceReferenceArg::Id(id) => Self::Id(id),
             WorkspaceReferenceArg::Index(i) => Self::Index(i),
             WorkspaceReferenceArg::Name(n) => Self::Name(n),
         }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -308,10 +308,12 @@ pub enum SizeChange {
     AdjustProportion(f64),
 }
 
-/// Workspace reference (index or name) to operate on.
+/// Workspace reference (id, index or name) to operate on.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum WorkspaceReferenceArg {
+    /// Id of the workspace.
+    Id(u64),
     /// Index of the workspace.
     Index(u8),
     /// Name of the workspace.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -21,6 +21,8 @@ pub enum Request {
     Outputs,
     /// Request information about workspaces.
     Workspaces,
+    /// Request information about open windows.
+    Windows,
     /// Request information about the configured keyboard layouts.
     KeyboardLayouts,
     /// Request information about the focused output.
@@ -73,6 +75,8 @@ pub enum Response {
     Outputs(HashMap<String, Output>),
     /// Information about workspaces.
     Workspaces(Vec<Workspace>),
+    /// Information about open windows.
+    Windows(Vec<Window>),
     /// Information about the keyboard layout.
     KeyboardLayouts(KeyboardLayouts),
     /// Information about the focused output.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -19,6 +19,12 @@ pub enum Request {
     Version,
     /// Request information about connected outputs.
     Outputs,
+    /// Request information about workspaces.
+    Workspaces,
+    /// Request information about the configured keyboard layouts.
+    KeyboardLayouts,
+    /// Request information about the focused output.
+    FocusedOutput,
     /// Request information about the focused window.
     FocusedWindow,
     /// Perform an action.
@@ -34,12 +40,6 @@ pub enum Request {
         /// Configuration to apply.
         action: OutputAction,
     },
-    /// Request information about workspaces.
-    Workspaces,
-    /// Request information about the focused output.
-    FocusedOutput,
-    /// Request information about the keyboard layout.
-    KeyboardLayouts,
     /// Start continuously receiving events from the compositor.
     ///
     /// The compositor should reply with `Reply::Ok(Response::Handled)`, then continuously send
@@ -71,16 +71,16 @@ pub enum Response {
     ///
     /// Map from connector name to output info.
     Outputs(HashMap<String, Output>),
+    /// Information about workspaces.
+    Workspaces(Vec<Workspace>),
+    /// Information about the keyboard layout.
+    KeyboardLayouts(KeyboardLayouts),
+    /// Information about the focused output.
+    FocusedOutput(Option<Output>),
     /// Information about the focused window.
     FocusedWindow(Option<Window>),
     /// Output configuration change result.
     OutputConfigChanged(OutputConfigChanged),
-    /// Information about workspaces.
-    Workspaces(Vec<Workspace>),
-    /// Information about the focused output.
-    FocusedOutput(Option<Output>),
-    /// Information about the keyboard layout.
-    KeyboardLayouts(KeyboardLayouts),
 }
 
 /// Actions that niri can perform.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -690,7 +690,7 @@ impl FromStr for WorkspaceReferenceArg {
             if let Ok(idx) = u8::try_from(index) {
                 Self::Index(idx)
             } else {
-                return Err("workspace indexes must be between 0 and 255");
+                return Err("workspace index must be between 0 and 255");
             }
         } else {
             Self::Name(s.to_string())

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -1,0 +1,188 @@
+//! Helpers for keeping track of the event stream state.
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+
+use crate::{Event, KeyboardLayouts, Window, Workspace};
+
+/// Part of the state communicated via the event stream.
+pub trait EventStreamStatePart {
+    /// Returns a sequence of events that replicates this state from default initialization.
+    fn replicate(&self) -> Vec<Event>;
+
+    /// Applies the event to this state.
+    ///
+    /// Returns `None` after applying the event, and `Some(event)` if the event is ignored by this
+    /// part of the state.
+    fn apply(&mut self, event: Event) -> Option<Event>;
+}
+
+/// The full state communicated over the event stream.
+///
+/// Different parts of the state are not guaranteed to be consistent across every single event
+/// sent by niri. For example, you may receive the first [`Event::WindowOpenedOrChanged`] for a
+/// just-opened window *after* an [`Event::WorkspaceActiveWindowChanged`] for that window. Between
+/// these two events, the workspace active window id refers to a window that does not yet exist in
+/// the windows state part.
+#[derive(Debug, Default)]
+pub struct EventStreamState {
+    /// State of workspaces.
+    pub workspaces: WorkspacesState,
+
+    /// State of workspaces.
+    pub windows: WindowsState,
+
+    /// State of the keyboard layouts.
+    pub keyboard_layouts: KeyboardLayoutsState,
+}
+
+/// The workspaces state communicated over the event stream.
+#[derive(Debug, Default)]
+pub struct WorkspacesState {
+    /// Map from a workspace id to the workspace.
+    pub workspaces: HashMap<u64, Workspace>,
+}
+
+/// The windows state communicated over the event stream.
+#[derive(Debug, Default)]
+pub struct WindowsState {
+    /// Map from a window id to the window.
+    pub windows: HashMap<u64, Window>,
+}
+
+/// The keyboard layout state communicated over the event stream.
+#[derive(Debug, Default)]
+pub struct KeyboardLayoutsState {
+    /// Configured keyboard layouts.
+    pub keyboard_layouts: Option<KeyboardLayouts>,
+}
+
+impl EventStreamStatePart for EventStreamState {
+    fn replicate(&self) -> Vec<Event> {
+        let mut events = Vec::new();
+        events.extend(self.workspaces.replicate());
+        events.extend(self.windows.replicate());
+        events.extend(self.keyboard_layouts.replicate());
+        events
+    }
+
+    fn apply(&mut self, event: Event) -> Option<Event> {
+        let event = self.workspaces.apply(event)?;
+        let event = self.windows.apply(event)?;
+        let event = self.keyboard_layouts.apply(event)?;
+        Some(event)
+    }
+}
+
+impl EventStreamStatePart for WorkspacesState {
+    fn replicate(&self) -> Vec<Event> {
+        let workspaces = self.workspaces.values().cloned().collect();
+        vec![Event::WorkspacesChanged { workspaces }]
+    }
+
+    fn apply(&mut self, event: Event) -> Option<Event> {
+        match event {
+            Event::WorkspacesChanged { workspaces } => {
+                self.workspaces = workspaces.into_iter().map(|ws| (ws.id, ws)).collect();
+            }
+            Event::WorkspaceActivated { id, focused } => {
+                let ws = self.workspaces.get(&id);
+                let ws = ws.expect("activated workspace was missing from the map");
+                let output = ws.output.clone();
+
+                for ws in self.workspaces.values_mut() {
+                    let got_activated = ws.id == id;
+                    if ws.output == output {
+                        ws.is_active = got_activated;
+                    }
+
+                    if focused {
+                        ws.is_focused = got_activated;
+                    }
+                }
+            }
+            Event::WorkspaceActiveWindowChanged {
+                workspace_id,
+                active_window_id,
+            } => {
+                let ws = self.workspaces.get_mut(&workspace_id);
+                let ws = ws.expect("changed workspace was missing from the map");
+                ws.active_window_id = active_window_id;
+            }
+            event => return Some(event),
+        }
+        None
+    }
+}
+
+impl EventStreamStatePart for WindowsState {
+    fn replicate(&self) -> Vec<Event> {
+        let windows = self.windows.values().cloned().collect();
+        vec![Event::WindowsChanged { windows }]
+    }
+
+    fn apply(&mut self, event: Event) -> Option<Event> {
+        match event {
+            Event::WindowsChanged { windows } => {
+                self.windows = windows.into_iter().map(|win| (win.id, win)).collect();
+            }
+            Event::WindowOpenedOrChanged { window } => {
+                let (id, is_focused) = match self.windows.entry(window.id) {
+                    Entry::Occupied(mut entry) => {
+                        let entry = entry.get_mut();
+                        *entry = window;
+                        (entry.id, entry.is_focused)
+                    }
+                    Entry::Vacant(entry) => {
+                        let entry = entry.insert(window);
+                        (entry.id, entry.is_focused)
+                    }
+                };
+
+                if is_focused {
+                    for win in self.windows.values_mut() {
+                        if win.id != id {
+                            win.is_focused = false;
+                        }
+                    }
+                }
+            }
+            Event::WindowClosed { id } => {
+                let win = self.windows.remove(&id);
+                win.expect("closed window was missing from the map");
+            }
+            Event::WindowFocusChanged { id } => {
+                for win in self.windows.values_mut() {
+                    win.is_focused = Some(win.id) == id;
+                }
+            }
+            event => return Some(event),
+        }
+        None
+    }
+}
+
+impl EventStreamStatePart for KeyboardLayoutsState {
+    fn replicate(&self) -> Vec<Event> {
+        if let Some(keyboard_layouts) = self.keyboard_layouts.clone() {
+            vec![Event::KeyboardLayoutsChanged { keyboard_layouts }]
+        } else {
+            vec![]
+        }
+    }
+
+    fn apply(&mut self, event: Event) -> Option<Event> {
+        match event {
+            Event::KeyboardLayoutsChanged { keyboard_layouts } => {
+                self.keyboard_layouts = Some(keyboard_layouts);
+            }
+            Event::KeyboardLayoutSwitched { idx } => {
+                let kb = self.keyboard_layouts.as_mut();
+                let kb = kb.expect("keyboard layouts must be set before a layout can be switched");
+                kb.current_idx = idx;
+            }
+            event => return Some(event),
+        }
+        None
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -44,8 +44,8 @@ impl OutputId {
         OutputId(OUTPUT_ID_COUNTER.next())
     }
 
-    pub fn get(self) -> u32 {
-        self.0
+    pub fn get(self) -> u64 {
+        u64::from(self.0)
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -37,7 +37,7 @@ pub type IpcOutputMap = HashMap<OutputId, niri_ipc::Output>;
 static OUTPUT_ID_COUNTER: IdCounter = IdCounter::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct OutputId(u32);
+pub struct OutputId(u64);
 
 impl OutputId {
     fn next() -> OutputId {
@@ -45,7 +45,7 @@ impl OutputId {
     }
 
     pub fn get(self) -> u64 {
-        u64::from(self.0)
+        self.0
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,6 +88,8 @@ pub enum Msg {
     },
     /// Get the configured keyboard layouts.
     KeyboardLayouts,
+    /// Start continuously receiving events from the compositor.
+    EventStream,
     /// Print the version of the running niri instance.
     Version,
     /// Request an error from the running niri instance.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,10 +62,12 @@ pub enum Msg {
     Outputs,
     /// List workspaces.
     Workspaces,
-    /// Print information about the focused window.
-    FocusedWindow,
+    /// Get the configured keyboard layouts.
+    KeyboardLayouts,
     /// Print information about the focused output.
     FocusedOutput,
+    /// Print information about the focused window.
+    FocusedWindow,
     /// Perform an action.
     Action {
         #[command(subcommand)]
@@ -86,8 +88,6 @@ pub enum Msg {
         #[command(subcommand)]
         action: OutputAction,
     },
-    /// Get the configured keyboard layouts.
-    KeyboardLayouts,
     /// Start continuously receiving events from the compositor.
     EventStream,
     /// Print the version of the running niri instance.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,6 +62,8 @@ pub enum Msg {
     Outputs,
     /// List workspaces.
     Workspaces,
+    /// List open windows.
+    Windows,
     /// Get the configured keyboard layouts.
     KeyboardLayouts,
     /// Print information about the focused output.

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -216,7 +216,7 @@ impl CompositorHandler for State {
                     #[cfg(feature = "xdp-gnome-screencast")]
                     self.niri
                         .stop_casts_for_target(crate::pw_utils::CastTarget::Window {
-                            id: u64::from(id.get()),
+                            id: id.get(),
                         });
 
                     self.niri.layout.remove_window(&window, transaction.clone());

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -480,7 +480,7 @@ impl XdgShellHandler for State {
         #[cfg(feature = "xdp-gnome-screencast")]
         self.niri
             .stop_casts_for_target(crate::pw_utils::CastTarget::Window {
-                id: u64::from(mapped.id().get()),
+                id: mapped.id().get(),
             });
 
         self.backend.with_primary_renderer(|renderer| {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -255,6 +255,17 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let outputs = ipc_outputs.values().cloned().map(|o| (o.name.clone(), o));
             Response::Outputs(outputs.collect())
         }
+        Request::Workspaces => {
+            let state = ctx.event_stream_state.borrow();
+            let workspaces = state.workspaces.workspaces.values().cloned().collect();
+            Response::Workspaces(workspaces)
+        }
+        Request::KeyboardLayouts => {
+            let state = ctx.event_stream_state.borrow();
+            let layout = state.keyboard_layouts.keyboard_layouts.clone();
+            let layout = layout.expect("keyboard layouts should be set at startup");
+            Response::KeyboardLayouts(layout)
+        }
         Request::FocusedWindow => {
             let state = ctx.event_stream_state.borrow();
             let windows = &state.windows.windows;
@@ -294,11 +305,6 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
 
             Response::OutputConfigChanged(response)
         }
-        Request::Workspaces => {
-            let state = ctx.event_stream_state.borrow();
-            let workspaces = state.workspaces.workspaces.values().cloned().collect();
-            Response::Workspaces(workspaces)
-        }
         Request::FocusedOutput => {
             let (tx, rx) = async_channel::bounded(1);
             ctx.event_loop.insert_idle(move |state| {
@@ -324,12 +330,6 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let result = rx.recv().await;
             let output = result.map_err(|_| String::from("error getting active output info"))?;
             Response::FocusedOutput(output)
-        }
-        Request::KeyboardLayouts => {
-            let state = ctx.event_stream_state.borrow();
-            let layout = state.keyboard_layouts.keyboard_layouts.clone();
-            let layout = layout.expect("keyboard layouts should be set at startup");
-            Response::KeyboardLayouts(layout)
         }
         Request::EventStream => Response::Handled,
     };

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -375,7 +375,7 @@ fn make_ipc_window(mapped: &Mapped, workspace_id: Option<WorkspaceId>) -> niri_i
             .unwrap();
 
         niri_ipc::Window {
-            id: u64::from(mapped.id().get()),
+            id: mapped.id().get(),
             title: role.title.clone(),
             app_id: role.app_id.clone(),
             workspace_id: workspace_id.map(|id| u64::from(id.0)),
@@ -449,7 +449,7 @@ impl State {
                 break;
             }
 
-            let active_window_id = ws.active_window().map(|win| u64::from(win.id().get()));
+            let active_window_id = ws.active_window().map(|win| win.id().get());
             if ipc_ws.active_window_id != active_window_id {
                 events.push(Event::WorkspaceActiveWindowChanged {
                     workspace_id: id,
@@ -490,7 +490,7 @@ impl State {
                         output: mon.map(|mon| mon.output_name().clone()),
                         is_active: mon.map_or(false, |mon| mon.active_workspace_idx == ws_idx),
                         is_focused: Some(id) == focused_ws_id,
-                        active_window_id: ws.active_window().map(|win| u64::from(win.id().get())),
+                        active_window_id: ws.active_window().map(|win| win.id().get()),
                     }
                 })
                 .collect();
@@ -521,7 +521,7 @@ impl State {
         let mut seen = HashSet::new();
         let mut focused_id = None;
         layout.with_windows(|mapped, _, ws_id| {
-            let id = u64::from(mapped.id().get());
+            let id = mapped.id().get();
             seen.insert(id);
 
             if mapped.is_focused() {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -260,6 +260,11 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let workspaces = state.workspaces.workspaces.values().cloned().collect();
             Response::Workspaces(workspaces)
         }
+        Request::Windows => {
+            let state = ctx.event_stream_state.borrow();
+            let windows = state.windows.windows.values().cloned().collect();
+            Response::Windows(windows)
+        }
         Request::KeyboardLayouts => {
             let state = ctx.event_stream_state.borrow();
             let layout = state.keyboard_layouts.keyboard_layouts.clone();

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -132,7 +132,8 @@ async fn handle_client(ctx: ClientCtx, stream: Async<'_, UnixStream>) -> anyhow:
         }
     }
 
-    let buf = serde_json::to_vec(&reply).context("error formatting reply")?;
+    let mut buf = serde_json::to_vec(&reply).context("error formatting reply")?;
+    buf.push(b'\n');
     write.write_all(&buf).await.context("error writing reply")?;
 
     Ok(())

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -378,7 +378,7 @@ fn make_ipc_window(mapped: &Mapped, workspace_id: Option<WorkspaceId>) -> niri_i
             id: mapped.id().get(),
             title: role.title.clone(),
             app_id: role.app_id.clone(),
-            workspace_id: workspace_id.map(|id| u64::from(id.0)),
+            workspace_id: workspace_id.map(|id| id.get()),
             is_focused: mapped.is_focused(),
         }
     })
@@ -424,13 +424,13 @@ impl State {
 
         let mut events = Vec::new();
         let layout = &self.niri.layout;
-        let focused_ws_id = layout.active_workspace().map(|ws| u64::from(ws.id().0));
+        let focused_ws_id = layout.active_workspace().map(|ws| ws.id().get());
 
         // Check for workspace changes.
         let mut seen = HashSet::new();
         let mut need_workspaces_changed = false;
         for (mon, ws_idx, ws) in layout.workspaces() {
-            let id = u64::from(ws.id().0);
+            let id = ws.id().get();
             seen.insert(id);
 
             let Some(ipc_ws) = state.workspaces.get(&id) else {
@@ -482,7 +482,7 @@ impl State {
             let workspaces = layout
                 .workspaces()
                 .map(|(mon, ws_idx, ws)| {
-                    let id = u64::from(ws.id().0);
+                    let id = ws.id().get();
                     Workspace {
                         id,
                         idx: u8::try_from(ws_idx + 1).unwrap_or(u8::MAX),
@@ -534,7 +534,7 @@ impl State {
                 return;
             };
 
-            let workspace_id = Some(u64::from(ws_id.0));
+            let workspace_id = Some(ws_id.get());
             let mut changed = ipc_win.workspace_id != workspace_id;
 
             let wl_surface = mapped.toplevel().wl_surface();

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1011,7 +1011,7 @@ impl<W: LayoutElement> Layout<W> {
                         Some(WorkspaceSwitch::Gesture(gesture))
                             if gesture.current_idx.floor() == workspace_idx as f64
                                 || gesture.current_idx.ceil() == workspace_idx as f64 => {}
-                        _ => mon.switch_workspace(workspace_idx, true),
+                        _ => mon.switch_workspace(workspace_idx),
                     }
 
                     break;
@@ -1532,7 +1532,7 @@ impl<W: LayoutElement> Layout<W> {
         let Some(monitor) = self.active_monitor() else {
             return;
         };
-        monitor.switch_workspace(idx, false);
+        monitor.switch_workspace(idx);
     }
 
     pub fn switch_workspace_auto_back_and_forth(&mut self, idx: usize) {
@@ -3762,38 +3762,6 @@ mod tests {
                 min_max_size: Default::default(),
             },
             Op::MoveWindowToWorkspace(2),
-        ];
-
-        let mut layout = Layout::default();
-        for op in ops {
-            op.apply(&mut layout);
-        }
-
-        let MonitorSet::Normal { monitors, .. } = layout.monitor_set else {
-            unreachable!()
-        };
-
-        assert!(monitors[0].workspaces[0].has_windows());
-    }
-
-    #[test]
-    fn focus_workspace_by_idx_does_not_leave_empty_workspaces() {
-        let ops = [
-            Op::AddOutput(1),
-            Op::AddWindow {
-                id: 0,
-                bbox: Rectangle::from_loc_and_size((0, 0), (100, 200)),
-                min_max_size: Default::default(),
-            },
-            Op::FocusWorkspaceDown,
-            Op::AddWindow {
-                id: 1,
-                bbox: Rectangle::from_loc_and_size((0, 0), (100, 200)),
-                min_max_size: Default::default(),
-            },
-            Op::FocusWorkspaceUp,
-            Op::CloseWindow(0),
-            Op::FocusWorkspace(3),
         ];
 
         let mut layout = Layout::default();

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1854,7 +1854,7 @@ impl<W: LayoutElement> Layout<W> {
                     .map(|name| {
                         monitors
                             .iter_mut()
-                            .position(|monitor| monitor.output.name().eq_ignore_ascii_case(name))
+                            .position(|monitor| monitor.output_name().eq_ignore_ascii_case(name))
                             .unwrap_or(*primary_idx)
                     })
                     .unwrap_or(*active_monitor_idx);

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -836,6 +836,32 @@ impl<W: LayoutElement> Layout<W> {
         None
     }
 
+    pub fn find_workspace_by_id(&self, id: WorkspaceId) -> Option<(usize, &Workspace<W>)> {
+        match &self.monitor_set {
+            MonitorSet::Normal { ref monitors, .. } => {
+                for mon in monitors {
+                    if let Some((index, workspace)) = mon
+                        .workspaces
+                        .iter()
+                        .enumerate()
+                        .find(|(_, w)| w.id() == id)
+                    {
+                        return Some((index, workspace));
+                    }
+                }
+            }
+            MonitorSet::NoOutputs { workspaces } => {
+                if let Some((index, workspace)) =
+                    workspaces.iter().enumerate().find(|(_, w)| w.id() == id)
+                {
+                    return Some((index, workspace));
+                }
+            }
+        }
+
+        None
+    }
+
     pub fn find_workspace_by_name(&self, workspace_name: &str) -> Option<(usize, &Workspace<W>)> {
         match &self.monitor_set {
             MonitorSet::Normal { ref monitors, .. } => {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -594,13 +594,8 @@ impl<W: LayoutElement> Monitor<W> {
         self.workspaces.iter().position(|w| w.id() == id)
     }
 
-    pub fn switch_workspace(&mut self, idx: usize, animate: bool) {
+    pub fn switch_workspace(&mut self, idx: usize) {
         self.activate_workspace(min(idx, self.workspaces.len() - 1));
-
-        if !animate {
-            self.workspace_switch = None;
-            self.clean_up_workspaces();
-        }
     }
 
     pub fn switch_workspace_auto_back_and_forth(&mut self, idx: usize) {
@@ -608,16 +603,16 @@ impl<W: LayoutElement> Monitor<W> {
 
         if idx == self.active_workspace_idx {
             if let Some(prev_idx) = self.previous_workspace_idx() {
-                self.switch_workspace(prev_idx, false);
+                self.switch_workspace(prev_idx);
             }
         } else {
-            self.switch_workspace(idx, false);
+            self.switch_workspace(idx);
         }
     }
 
     pub fn switch_workspace_previous(&mut self) {
         if let Some(idx) = self.previous_workspace_idx() {
-            self.switch_workspace(idx, false);
+            self.switch_workspace(idx);
         }
     }
 

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -34,6 +34,8 @@ const WORKSPACE_GESTURE_RUBBER_BAND: RubberBand = RubberBand {
 pub struct Monitor<W: LayoutElement> {
     /// Output for this monitor.
     pub output: Output,
+    /// Cached name of the output.
+    output_name: String,
     // Must always contain at least one.
     pub workspaces: Vec<Workspace<W>>,
     /// Index of the currently active workspace.
@@ -93,6 +95,7 @@ impl WorkspaceSwitch {
 impl<W: LayoutElement> Monitor<W> {
     pub fn new(output: Output, workspaces: Vec<Workspace<W>>, options: Rc<Options>) -> Self {
         Self {
+            output_name: output.name(),
             output,
             workspaces,
             active_workspace_idx: 0,
@@ -100,6 +103,10 @@ impl<W: LayoutElement> Monitor<W> {
             workspace_switch: None,
             options,
         }
+    }
+
+    pub fn output_name(&self) -> &String {
+        &self.output_name
     }
 
     pub fn active_workspace_ref(&self) -> &Workspace<W> {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -123,7 +123,7 @@ pub struct OutputId(String);
 static WORKSPACE_ID_COUNTER: IdCounter = IdCounter::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct WorkspaceId(u32);
+pub struct WorkspaceId(pub u32);
 
 impl WorkspaceId {
     fn next() -> WorkspaceId {
@@ -526,6 +526,15 @@ impl<W: LayoutElement> Workspace<W> {
 
     pub fn current_output(&self) -> Option<&Output> {
         self.output.as_ref()
+    }
+
+    pub fn active_window(&self) -> Option<&W> {
+        if self.columns.is_empty() {
+            return None;
+        }
+
+        let col = &self.columns[self.active_column_idx];
+        Some(col.tiles[col.active_tile_idx].window())
     }
 
     pub fn set_output(&mut self, output: Option<Output>) {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -133,6 +133,10 @@ impl WorkspaceId {
     pub fn get(self) -> u64 {
         self.0
     }
+
+    pub fn specific(id: u64) -> Self {
+        Self(id)
+    }
 }
 
 niri_render_elements! {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -123,11 +123,15 @@ pub struct OutputId(String);
 static WORKSPACE_ID_COUNTER: IdCounter = IdCounter::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct WorkspaceId(pub u32);
+pub struct WorkspaceId(u32);
 
 impl WorkspaceId {
     fn next() -> WorkspaceId {
         WorkspaceId(WORKSPACE_ID_COUNTER.next())
+    }
+
+    pub fn get(self) -> u64 {
+        u64::from(self.0)
     }
 }
 

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -123,7 +123,7 @@ pub struct OutputId(String);
 static WORKSPACE_ID_COUNTER: IdCounter = IdCounter::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct WorkspaceId(u32);
+pub struct WorkspaceId(u64);
 
 impl WorkspaceId {
     fn next() -> WorkspaceId {
@@ -131,7 +131,7 @@ impl WorkspaceId {
     }
 
     pub fn get(self) -> u64 {
-        u64::from(self.0)
+        self.0
     }
 }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -16,7 +16,6 @@ use niri_config::{
     Config, FloatOrInt, Key, Modifiers, PreviewRender, TrackLayout, WorkspaceReference,
     DEFAULT_BACKGROUND_COLOR,
 };
-use niri_ipc::Workspace;
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::element::memory::MemoryRenderBufferRenderElement;
@@ -4658,10 +4657,6 @@ impl Niri {
             // FIXME: granular.
             self.queue_redraw_all();
         }
-    }
-
-    pub fn ipc_workspaces(&self) -> Vec<Workspace> {
-        self.layout.ipc_workspaces()
     }
 }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1379,7 +1379,7 @@ impl State {
                     StreamTargetId::Window { id } => {
                         let mut window = None;
                         self.niri.layout.with_windows(|mapped, _, _| {
-                            if u64::from(mapped.id().get()) != id {
+                            if mapped.id().get() != id {
                                 return;
                             }
 
@@ -1502,7 +1502,7 @@ impl State {
                 .expect("no X11 support")
                 .wl_surface();
 
-            let id = u64::from(mapped.id().get());
+            let id = mapped.id().get();
             let props = with_states(wl_surface, |states| {
                 let role = states
                     .data_map
@@ -2841,9 +2841,7 @@ impl Niri {
         let mut to_stop = vec![];
         for (id, out) in output_changed {
             let refresh = out.current_mode().unwrap().refresh as u32;
-            let target = CastTarget::Window {
-                id: u64::from(id.get()),
-            };
+            let target = CastTarget::Window { id: id.get() };
             for cast in self.casts.iter_mut().filter(|cast| cast.target == target) {
                 if let Err(err) = cast.set_refresh(refresh) {
                     warn!("error changing cast FPS: {err:?}");
@@ -3712,7 +3710,7 @@ impl Niri {
             };
 
             let mut windows = self.layout.windows_for_output(output);
-            let Some(mapped) = windows.find(|win| u64::from(win.id().get()) == id) else {
+            let Some(mapped) = windows.find(|win| win.id().get() == id) else {
                 continue;
             };
 
@@ -3759,7 +3757,7 @@ impl Niri {
 
         let mut window = None;
         self.layout.with_windows(|mapped, _, _| {
-            if u64::from(mapped.id().get()) != window_id {
+            if mapped.id().get() != window_id {
                 return;
             }
 
@@ -3778,7 +3776,7 @@ impl Niri {
 
         let mut windows = self.layout.windows_for_output(output);
         let mapped = windows
-            .find(|mapped| u64::from(mapped.id().get()) == window_id)
+            .find(|mapped| mapped.id().get() == window_id)
             .unwrap();
 
         let scale = Scale::from(output.current_scale().fractional_scale());

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -115,6 +115,7 @@ use crate::input::{
     apply_libinput_settings, mods_with_finger_scroll_binds, mods_with_wheel_binds, TabletData,
 };
 use crate::ipc::server::IpcServer;
+use crate::layout::workspace::WorkspaceId;
 use crate::layout::{Layout, LayoutElement as _, MonitorRenderElement};
 use crate::protocols::foreign_toplevel::{self, ForeignToplevelManagerState};
 use crate::protocols::gamma_control::GammaControlManagerState;
@@ -2422,15 +2423,16 @@ impl Niri {
         &self,
         workspace_reference: WorkspaceReference,
     ) -> Option<(Option<Output>, usize)> {
-        let workspace_name = match workspace_reference {
+        let (target_workspace_index, target_workspace) = match workspace_reference {
             WorkspaceReference::Index(index) => {
                 return Some((None, index.saturating_sub(1) as usize));
             }
-            WorkspaceReference::Name(name) => name,
+            WorkspaceReference::Name(name) => self.layout.find_workspace_by_name(&name)?,
+            WorkspaceReference::Id(id) => {
+                let id = WorkspaceId::specific(id);
+                self.layout.find_workspace_by_id(id)?
+            }
         };
-
-        let (target_workspace_index, target_workspace) =
-            self.layout.find_workspace_by_name(&workspace_name)?;
 
         // FIXME: when we do fixes for no connected outputs, this will need fixing too.
         let active_workspace = self.layout.active_workspace()?;

--- a/src/protocols/foreign_toplevel.rs
+++ b/src/protocols/foreign_toplevel.rs
@@ -95,7 +95,7 @@ pub fn refresh(state: &mut State) {
     // Save the focused window for last, this way when the focus changes, we will first deactivate
     // the previous window and only then activate the newly focused window.
     let mut focused = None;
-    state.niri.layout.with_windows(|mapped, output| {
+    state.niri.layout.with_windows(|mapped, output, _| {
         let wl_surface = mapped.toplevel().wl_surface();
 
         with_states(wl_surface, |states| {

--- a/src/utils/id.rs
+++ b/src/utils/id.rs
@@ -18,7 +18,7 @@ impl IdCounter {
     }
 
     pub fn next(&self) -> u32 {
-        self.value.fetch_add(1, Ordering::SeqCst)
+        self.value.fetch_add(1, Ordering::Relaxed)
     }
 }
 

--- a/src/utils/id.rs
+++ b/src/utils/id.rs
@@ -1,11 +1,8 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Counter that returns unique IDs.
-///
-/// Under the hood it uses a `u32` that will eventually wrap around. When incrementing it once a
-/// second, it will wrap around after about 136 years.
 pub struct IdCounter {
-    value: AtomicU32,
+    value: AtomicU64,
 }
 
 impl IdCounter {
@@ -13,11 +10,11 @@ impl IdCounter {
         Self {
             // Start from 1 to reduce the possibility that some other code that uses these IDs will
             // get confused.
-            value: AtomicU32::new(1),
+            value: AtomicU64::new(1),
         }
     }
 
-    pub fn next(&self) -> u32 {
+    pub fn next(&self) -> u64 {
         self.value.fetch_add(1, Ordering::Relaxed)
     }
 }

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -98,7 +98,7 @@ niri_render_elements! {
 static MAPPED_ID_COUNTER: IdCounter = IdCounter::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct MappedId(u32);
+pub struct MappedId(u64);
 
 impl MappedId {
     fn next() -> MappedId {
@@ -106,7 +106,7 @@ impl MappedId {
     }
 
     pub fn get(self) -> u64 {
-        u64::from(self.0)
+        self.0
     }
 }
 

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -105,8 +105,8 @@ impl MappedId {
         MappedId(MAPPED_ID_COUNTER.next())
     }
 
-    pub fn get(self) -> u32 {
-        self.0
+    pub fn get(self) -> u64 {
+        u64::from(self.0)
     }
 }
 

--- a/wiki/IPC.md
+++ b/wiki/IPC.md
@@ -11,6 +11,26 @@ The communication over the IPC socket happens in JSON.
 > If you're getting parsing errors from `niri msg` after upgrading niri, make sure that you've restarted niri itself.
 > You might be trying to run a newer `niri msg` against an older `niri` compositor.
 
+### Event Stream
+
+<sup>Since: 0.1.9</sup>
+
+While most niri IPC requests return a single response, the event stream request will make niri continuously stream events into the IPC connection until it is closed.
+This is useful for implementing various bars and indicators that update as soon as something happens, without continuous polling.
+
+The event stream IPC is designed to give you the complete current state up-front, then follow up with updates to that state.
+This way, your state can never "desync" from niri, and you don't need to make any other IPC information requests.
+
+Where reasonable, event stream state updates are atomic, though this is not always the case.
+For example, a window may end up with a workspace id for a workspace that had already been removed.
+This can happen if the corresponding workspaces-changed event arrives before the corresponding window-changed event.
+
+To get a taste of the events, run `niri msg event-stream`.
+Though, this is more of a debug function than anything.
+You can get raw events from `niri msg --json event-stream`, or by connecting to the niri socket and requesting an event stream manually.
+
+You can find the full list of events along with documentation in the [niri-ipc sub-crate](./niri-ipc/).
+
 ### Backwards Compatibility
 
 The JSON output *should* remain stable, as in:


### PR DESCRIPTION
Some basic scaffolding for an event stream IPC.

1. Changed the client to read only a single line worth of response.

    This mirrors how the server works, and will be necessary to tell apart further messages. Events will arrive at one per line.
2. Added `Request::EventStream` that replies with `Response::Handled` and then proceeds to write one `Event` per line as they occur.
3. Events will be designed in such a way that the initial burst will synchronize the current state to the client, then subsequent events will modify that state in a consistent way. E.g. the initial burst of events will create all current outputs and workspaces.
4. Compositor-side, event stream clients have a buffer of events for sending. If this buffer runs too large (the client hanged and isn't reading), this client will be dropped. This is kinda similar to what Wayland itself does.

The events are all subject to change until this PR is merged. Currently only the WindowFocused is actually implemented, and I'm planning to change its type too.