### PR TITLE
Pin `smithay` version to prevent auto-updates from causing compilation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,7 +3355,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/Smithay/smithay.git#234586dbea6bc084cb72a32f164997e47ea36b2b"
+source = "git+https://github.com/Smithay/smithay.git?rev=234586dbea6bc084cb72a32f164997e47ea36b2b#234586dbea6bc084cb72a32f164997e47ea36b2b"
 dependencies = [
  "appendlist",
  "bitflags 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tracy-client = { version = "0.17.0", default-features = false }
 
 [workspace.dependencies.smithay]
 git = "https://github.com/Smithay/smithay.git"
+rev = "234586dbea6bc084cb72a32f164997e47ea36b2b"
 # path = "../smithay"
 default-features = false
 


### PR DESCRIPTION
When updating with `cargo install-update`, cargo tries to automatically update all dependencies to their latest 'compatible' versions (ignoring the lockfile). However, that means that the `smithay` dependency, since it's a git repo with no specified commit, will just get auto-updated to the latest revision, even if that's not compatible (since semver doesn't really apply to git revisions). So this just pins the version of `smithay` in Cargo.toml so that updating via `cargo install-update` doesn't automatically update `smithay` to an incompatible version from the git repo.