### PR TITLE
niri-config: update wiki parses test to test all codeblocks

### DIFF
--- a/wiki/Configuration:-Overview.md
+++ b/wiki/Configuration:-Overview.md
@@ -90,8 +90,7 @@ input {
 }
 ```
 
-<!-- no-test -->
-```kdl
+```kdl,must-fail
 // This is NOT valid: input section appears twice.
 input {
     keyboard {
@@ -108,7 +107,7 @@ input {
 
 Exceptions are, for example, sections that configure different devices by name:
 
-<!-- no-test -->
+<!-- NOTE: this may break in the future -->
 ```kdl
 output "eDP-1" {
     // ...


### PR DESCRIPTION
This makes sure the failing codeblocks do fail.

This also optimizes the algorithm a bit by removing a `.collect()`.

Signed-off-by: Suyashtnt <suyashtnt@gmail.com>