### PR TITLE
Implement interactive move

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -99,43 +99,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "appendlist"
@@ -253,7 +253,7 @@ dependencies = [
  "futures-lite 2.3.0",
  "parking",
  "polling 3.7.3",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -292,7 +292,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "windows-sys 0.48.0",
 ]
 
@@ -304,7 +304,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -319,7 +319,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -339,7 +339,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -411,7 +411,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -501,7 +501,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -512,9 +512,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cairo-rs"
@@ -548,7 +548,7 @@ dependencies = [
  "bitflags 2.6.0",
  "log",
  "polling 3.7.3",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "slab",
  "thiserror",
 ]
@@ -563,7 +563,7 @@ dependencies = [
  "bitflags 2.6.0",
  "futures-io",
  "polling 3.7.3",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "slab",
  "tracing",
 ]
@@ -575,7 +575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop 0.13.0",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "wayland-backend",
  "wayland-client",
 ]
@@ -699,7 +699,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -710,9 +710,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -957,15 +957,16 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "drm"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d000ffcf7a146ee52444a31b78ac82f981ebba5de6fb19f0b1052d98c8e5f308"
+checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
  "drm-ffi",
  "drm-fourcc",
- "rustix 0.38.37",
+ "libc",
+ "rustix 0.38.38",
 ]
 
 [[package]]
@@ -975,7 +976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e41459d99a9b529845f6d2c909eb9adf3b6d2f82635ae40be8de0601726e8b"
 dependencies = [
  "drm-sys",
- "rustix 0.38.37",
+ "rustix 0.38.38",
 ]
 
 [[package]]
@@ -1024,7 +1025,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1149,7 +1150,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1251,7 +1252,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1462,7 +1463,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1513,7 +1514,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1627,7 +1628,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1854,7 +1855,7 @@ dependencies = [
  "libc",
  "proc-macro2",
  "regex",
- "syn 2.0.81",
+ "syn 2.0.85",
  "terminal_size 0.2.6",
 ]
 
@@ -1970,7 +1971,7 @@ checksum = "ea1cd31036b732a546d845f9485c56b1b606b5e476b0821c680dd66c8cd6fcee"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1991,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "3bda4c6077b0b08da2c48b172195795498381a7c8988c9e6212a6c55c5b9bd70"
 
 [[package]]
 name = "libredox"
@@ -2192,7 +2193,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2426,7 +2427,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2820,7 +2821,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2834,29 +2835,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -2964,7 +2965,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3045,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -3069,7 +3070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3100,7 +3101,7 @@ checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3212,9 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3291,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3356,7 +3357,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3379,22 +3380,22 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3405,7 +3406,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3428,7 +3429,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3511,7 +3512,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/Smithay/smithay.git#a226d00db9190db5c8d3a8b164443124d6e6aef0"
+source = "git+https://github.com/Smithay/smithay.git#6dce628920b5a0763b8cd4dd8c5ab524c78090a0"
 dependencies = [
  "appendlist",
  "bitflags 2.6.0",
@@ -3536,7 +3537,7 @@ dependencies = [
  "pkg-config",
  "profiling",
  "rand",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "smallvec",
  "tempfile",
  "thiserror",
@@ -3568,7 +3569,7 @@ dependencies = [
  "libc",
  "log",
  "memmap2",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "thiserror",
  "wayland-backend",
  "wayland-client",
@@ -3583,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#a226d00db9190db5c8d3a8b164443124d6e6aef0"
+source = "git+https://github.com/Smithay/smithay.git#6dce628920b5a0763b8cd4dd8c5ab524c78090a0"
 dependencies = [
  "drm",
  "libdisplay-info",
@@ -3661,9 +3662,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.81"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198514704ca887dd5a1e408c6c6cdcba43672f9b4062e1b24aa34e74e6d7faae"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3721,7 +3722,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.1.1",
  "once_cell",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "windows-sys 0.59.0",
 ]
 
@@ -3758,22 +3759,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3885,7 +3886,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3955,9 +3956,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udev"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba005bcd5b1158ae3cd815905990e8b6ee4ba9ee7adbab6d7b58d389ad09c93"
+checksum = "e3d5c197b95f1769931c89f85c33c407801d1fb7a311113bc0b39ad036f1bd81"
 dependencies = [
  "io-lifetimes 1.0.11",
  "libc",
@@ -4109,7 +4110,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -4143,7 +4144,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4162,7 +4163,7 @@ checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -4170,12 +4171,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f45d1222915ef1fd2057220c1d9d9624b7654443ea35c3877f7a52bd0a5a2d"
+checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
 dependencies = [
  "bitflags 2.6.0",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -4193,11 +4194,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a94697e66e76c85923b0d28a0c251e8f0666f58fc47d316c0f4da6da75d37cb"
+checksum = "32b08bc3aafdb0035e7fe0fdf17ba0c09c268732707dca4ae098f60cb28c9e4c"
 dependencies = [
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "wayland-client",
  "xcursor",
 ]
@@ -4214,9 +4215,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.4"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5755d77ae9040bb872a25026555ce4cb0ae75fd923e90d25fba07d81057de0"
+checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -4227,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-misc"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40dd9d2f7f2713724d84b920d6f73ff878f6a353712942f75f78f4dadb72886"
+checksum = "da2e42969764e469a115d4bb1c16e9588ef8b75b127ba7a2c9ddf1e140b25ca7"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -4240,9 +4241,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0a41a6875e585172495f7a96dfa42ca7e0213868f4f15c313f7c33221a7eff"
+checksum = "9b31cab548ee68c7eb155517f2212049dc151f7cd7910c2b66abfd31c3ee12bd"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -4253,9 +4254,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad87b5fd1b1d3ca2f792df8f686a2a11e3fe1077b71096f7a175ab699f89109"
+checksum = "782e12f6cd923c3c316130d56205ebab53f55d6666b7faddfad36cecaeeb4022"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -4278,14 +4279,14 @@ dependencies = [
 
 [[package]]
 name = "wayland-server"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f18d47038c0b10479e695d99ed073e400ccd9bdbb60e6e503c96f62adcb12b6"
+checksum = "c89532cc712a2adb119eb4d09694b402576052254d0bb284f82ac1c47fb786ad"
 dependencies = [
  "bitflags 2.6.0",
  "downcast-rs",
  "io-lifetimes 2.0.3",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -4405,7 +4406,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4416,7 +4417,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4684,7 +4685,7 @@ dependencies = [
  "pin-project",
  "raw-window-handle",
  "redox_syscall 0.4.1",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "smithay-client-toolkit",
  "smol_str",
  "tracing",
@@ -4743,7 +4744,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "x11rb-protocol",
 ]
 
@@ -4919,7 +4920,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -421,6 +421,8 @@ pub struct Layout {
     pub focus_ring: FocusRing,
     #[knuffel(child, default)]
     pub border: Border,
+    #[knuffel(child, default)]
+    pub insert_hint: InsertHint,
     #[knuffel(child, unwrap(children), default)]
     pub preset_column_widths: Vec<PresetSize>,
     #[knuffel(child)]
@@ -442,6 +444,7 @@ impl Default for Layout {
         Self {
             focus_ring: Default::default(),
             border: Default::default(),
+            insert_hint: Default::default(),
             preset_column_widths: Default::default(),
             default_column_width: Default::default(),
             center_focused_column: Default::default(),
@@ -584,6 +587,23 @@ impl From<FocusRing> for Border {
             inactive_color: value.inactive_color,
             active_gradient: value.active_gradient,
             inactive_gradient: value.inactive_gradient,
+        }
+    }
+}
+
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+pub struct InsertHint {
+    #[knuffel(child)]
+    pub off: bool,
+    #[knuffel(child, default = Self::default().color)]
+    pub color: Color,
+}
+
+impl Default for InsertHint {
+    fn default() -> Self {
+        Self {
+            off: false,
+            color: Color::from_rgba8_unpremul(127, 200, 255, 128),
         }
     }
 }
@@ -3028,6 +3048,10 @@ mod tests {
                 }
 
                 center-focused-column "on-overflow"
+
+                insert-hint {
+                    color "rgb(255, 200, 127)"
+                }
             }
 
             spawn-at-startup "alacritty" "-e" "fish"
@@ -3225,6 +3249,10 @@ mod tests {
                         inactive_color: Color::from_rgba8_unpremul(255, 200, 100, 0),
                         active_gradient: None,
                         inactive_gradient: None,
+                    },
+                    insert_hint: InsertHint {
+                        off: false,
+                        color: Color::from_rgba8_unpremul(255, 200, 127, 255),
                     },
                     preset_column_widths: vec![
                         PresetSize::Proportion(0.25),

--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -198,11 +198,7 @@ impl TestCase for Layout {
     }
 
     fn are_animations_ongoing(&self) -> bool {
-        self.layout
-            .monitor_for_output(&self.output)
-            .unwrap()
-            .are_animations_ongoing()
-            || !self.steps.is_empty()
+        self.layout.are_animations_ongoing(Some(&self.output)) || !self.steps.is_empty()
     }
 
     fn advance_animations(&mut self, mut current_time: Duration) {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -24,7 +24,10 @@ use smithay::input::pointer::{
     GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent,
     GrabStartData as PointerGrabStartData, MotionEvent, RelativeMotionEvent,
 };
-use smithay::input::touch::{DownEvent, MotionEvent as TouchMotionEvent, UpEvent};
+use smithay::input::touch::{
+    DownEvent, GrabStartData as TouchGrabStartData, MotionEvent as TouchMotionEvent, UpEvent,
+};
+use smithay::input::SeatHandler;
 use smithay::utils::{Logical, Point, Rectangle, Transform, SERIAL_COUNTER};
 use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraint};
 use smithay::wayland::tablet_manager::{TabletDescriptor, TabletSeatTrait};
@@ -42,6 +45,7 @@ pub mod resize_grab;
 pub mod scroll_tracker;
 pub mod spatial_movement_grab;
 pub mod swipe_tracker;
+pub mod touch_move_grab;
 
 pub const DOUBLE_CLICK_TIME: Duration = Duration::from_millis(400);
 
@@ -54,6 +58,20 @@ pub enum CompositorMod {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TabletData {
     pub aspect_ratio: f64,
+}
+
+pub enum PointerOrTouchStartData<D: SeatHandler> {
+    Pointer(PointerGrabStartData<D>),
+    Touch(TouchGrabStartData<D>),
+}
+
+impl<D: SeatHandler> PointerOrTouchStartData<D> {
+    pub fn location(&self) -> Point<f64, Logical> {
+        match self {
+            PointerOrTouchStartData::Pointer(x) => x.location,
+            PointerOrTouchStartData::Touch(x) => x.location,
+        }
+    }
 }
 
 impl State {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -46,6 +46,7 @@ pub mod scroll_tracker;
 pub mod spatial_movement_grab;
 pub mod swipe_tracker;
 pub mod touch_move_grab;
+pub mod touch_resize_grab;
 
 pub const DOUBLE_CLICK_TIME: Duration = Duration::from_millis(400);
 

--- a/src/input/move_grab.rs
+++ b/src/input/move_grab.rs
@@ -1,0 +1,223 @@
+use std::time::Duration;
+
+use smithay::backend::input::ButtonState;
+use smithay::desktop::Window;
+use smithay::input::pointer::{
+    AxisFrame, ButtonEvent, CursorImageStatus, GestureHoldBeginEvent, GestureHoldEndEvent,
+    GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent,
+    GestureSwipeEndEvent, GestureSwipeUpdateEvent, GrabStartData as PointerGrabStartData,
+    MotionEvent, PointerGrab, PointerInnerHandle, RelativeMotionEvent,
+};
+use smithay::input::SeatHandler;
+use smithay::utils::{IsAlive, Logical, Point};
+
+use crate::niri::State;
+
+pub struct MoveGrab {
+    start_data: PointerGrabStartData<State>,
+    last_location: Point<f64, Logical>,
+    window: Window,
+    is_moving: bool,
+}
+
+impl MoveGrab {
+    pub fn new(start_data: PointerGrabStartData<State>, window: Window) -> Self {
+        Self {
+            last_location: start_data.location,
+            start_data,
+            window,
+            is_moving: false,
+        }
+    }
+
+    fn on_ungrab(&mut self, state: &mut State) {
+        state.niri.layout.interactive_move_end(&self.window);
+        // FIXME: only redraw the window output.
+        state.niri.queue_redraw_all();
+        state.niri.pointer_grab_ongoing = false;
+        state
+            .niri
+            .cursor_manager
+            .set_cursor_image(CursorImageStatus::default_named());
+    }
+}
+
+impl PointerGrab<State> for MoveGrab {
+    fn motion(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        _focus: Option<(<State as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
+        event: &MotionEvent,
+    ) {
+        // While the grab is active, no client has pointer focus.
+        handle.motion(data, None, event);
+
+        if self.window.alive() {
+            if let Some((output, pos_within_output)) = data.niri.output_under(event.location) {
+                let output = output.clone();
+                let event_delta = event.location - self.last_location;
+                self.last_location = event.location;
+                let ongoing = data.niri.layout.interactive_move_update(
+                    &self.window,
+                    event_delta,
+                    output,
+                    pos_within_output,
+                );
+                if ongoing {
+                    let timestamp = Duration::from_millis(u64::from(event.time));
+                    if self.is_moving {
+                        data.niri.layout.view_offset_gesture_update(
+                            -event_delta.x,
+                            timestamp,
+                            false,
+                        );
+                    }
+                    return;
+                }
+            } else {
+                return;
+            }
+        }
+
+        // The move is no longer ongoing.
+        handle.unset_grab(self, data, event.serial, event.time, true);
+    }
+
+    fn relative_motion(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        _focus: Option<(<State as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
+        event: &RelativeMotionEvent,
+    ) {
+        // While the grab is active, no client has pointer focus.
+        handle.relative_motion(data, None, event);
+    }
+
+    fn button(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &ButtonEvent,
+    ) {
+        handle.button(data, event);
+
+        // MouseButton::Middle
+        if event.button == 0x112 {
+            if event.state == ButtonState::Pressed {
+                let output = data
+                    .niri
+                    .output_under(handle.current_location())
+                    .map(|(output, _)| output)
+                    .cloned();
+                // TODO: workspace switch gesture.
+                if let Some(output) = output {
+                    self.is_moving = true;
+                    data.niri.layout.view_offset_gesture_begin(&output, false);
+                }
+            } else if event.state == ButtonState::Released {
+                self.is_moving = false;
+                data.niri.layout.view_offset_gesture_end(false, None);
+            }
+        }
+
+        if handle.current_pressed().is_empty() {
+            // No more buttons are pressed, release the grab.
+            handle.unset_grab(self, data, event.serial, event.time, true);
+        }
+    }
+
+    fn axis(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        details: AxisFrame,
+    ) {
+        handle.axis(data, details);
+    }
+
+    fn frame(&mut self, data: &mut State, handle: &mut PointerInnerHandle<'_, State>) {
+        handle.frame(data);
+    }
+
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event);
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event);
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event);
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event);
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event);
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event);
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event);
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event);
+    }
+
+    fn start_data(&self) -> &PointerGrabStartData<State> {
+        &self.start_data
+    }
+
+    fn unset(&mut self, data: &mut State) {
+        self.on_ungrab(data);
+    }
+}

--- a/src/input/move_grab.rs
+++ b/src/input/move_grab.rs
@@ -73,6 +73,8 @@ impl PointerGrab<State> for MoveGrab {
                             false,
                         );
                     }
+                    // FIXME: only redraw the previous and the new output.
+                    data.niri.queue_redraw_all();
                     return;
                 }
             } else {

--- a/src/input/touch_move_grab.rs
+++ b/src/input/touch_move_grab.rs
@@ -1,0 +1,136 @@
+use smithay::desktop::Window;
+use smithay::input::touch::{
+    DownEvent, GrabStartData as TouchGrabStartData, MotionEvent, OrientationEvent, ShapeEvent,
+    TouchGrab, TouchInnerHandle, UpEvent,
+};
+use smithay::input::SeatHandler;
+use smithay::utils::{IsAlive, Logical, Point, Serial};
+
+use crate::niri::State;
+
+pub struct TouchMoveGrab {
+    start_data: TouchGrabStartData<State>,
+    last_location: Point<f64, Logical>,
+    window: Window,
+}
+
+impl TouchMoveGrab {
+    pub fn new(start_data: TouchGrabStartData<State>, window: Window) -> Self {
+        Self {
+            last_location: start_data.location,
+            start_data,
+            window,
+        }
+    }
+
+    fn on_ungrab(&mut self, state: &mut State) {
+        state.niri.layout.interactive_move_end(&self.window);
+        // FIXME: only redraw the window output.
+        state.niri.queue_redraw_all();
+    }
+}
+
+impl TouchGrab<State> for TouchMoveGrab {
+    fn down(
+        &mut self,
+        data: &mut State,
+        handle: &mut TouchInnerHandle<'_, State>,
+        _focus: Option<(<State as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
+        event: &DownEvent,
+        seq: Serial,
+    ) {
+        handle.down(data, None, event, seq);
+    }
+
+    fn up(
+        &mut self,
+        data: &mut State,
+        handle: &mut TouchInnerHandle<'_, State>,
+        event: &UpEvent,
+        seq: Serial,
+    ) {
+        handle.up(data, event, seq);
+
+        if event.slot != self.start_data.slot {
+            return;
+        }
+
+        handle.unset_grab(self, data);
+    }
+
+    fn motion(
+        &mut self,
+        data: &mut State,
+        handle: &mut TouchInnerHandle<'_, State>,
+        _focus: Option<(<State as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
+        event: &MotionEvent,
+        seq: Serial,
+    ) {
+        handle.motion(data, None, event, seq);
+
+        if event.slot != self.start_data.slot {
+            return;
+        }
+
+        if self.window.alive() {
+            if let Some((output, pos_within_output)) = data.niri.output_under(event.location) {
+                let output = output.clone();
+                let event_delta = event.location - self.last_location;
+                self.last_location = event.location;
+                let ongoing = data.niri.layout.interactive_move_update(
+                    &self.window,
+                    event_delta,
+                    output,
+                    pos_within_output,
+                );
+                if ongoing {
+                    // FIXME: only redraw the previous and the new output.
+                    data.niri.queue_redraw_all();
+                    return;
+                }
+            } else {
+                return;
+            }
+        }
+
+        // The move is no longer ongoing.
+        handle.unset_grab(self, data);
+    }
+
+    fn frame(&mut self, data: &mut State, handle: &mut TouchInnerHandle<'_, State>, seq: Serial) {
+        handle.frame(data, seq);
+    }
+
+    fn cancel(&mut self, data: &mut State, handle: &mut TouchInnerHandle<'_, State>, seq: Serial) {
+        handle.cancel(data, seq);
+        handle.unset_grab(self, data);
+    }
+
+    fn shape(
+        &mut self,
+        data: &mut State,
+        handle: &mut TouchInnerHandle<'_, State>,
+        event: &ShapeEvent,
+        seq: Serial,
+    ) {
+        handle.shape(data, event, seq);
+    }
+
+    fn orientation(
+        &mut self,
+        data: &mut State,
+        handle: &mut TouchInnerHandle<'_, State>,
+        event: &OrientationEvent,
+        seq: Serial,
+    ) {
+        handle.orientation(data, event, seq);
+    }
+
+    fn start_data(&self) -> &TouchGrabStartData<State> {
+        &self.start_data
+    }
+
+    fn unset(&mut self, data: &mut State) {
+        self.on_ungrab(data);
+    }
+}

--- a/src/input/touch_resize_grab.rs
+++ b/src/input/touch_resize_grab.rs
@@ -1,0 +1,119 @@
+use smithay::desktop::Window;
+use smithay::input::touch::{
+    DownEvent, GrabStartData as TouchGrabStartData, MotionEvent, OrientationEvent, ShapeEvent,
+    TouchGrab, TouchInnerHandle, UpEvent,
+};
+use smithay::input::SeatHandler;
+use smithay::utils::{IsAlive, Logical, Point, Serial};
+
+use crate::niri::State;
+
+pub struct TouchResizeGrab {
+    start_data: TouchGrabStartData<State>,
+    window: Window,
+}
+
+impl TouchResizeGrab {
+    pub fn new(start_data: TouchGrabStartData<State>, window: Window) -> Self {
+        Self { start_data, window }
+    }
+
+    fn on_ungrab(&mut self, state: &mut State) {
+        state.niri.layout.interactive_resize_end(&self.window);
+    }
+}
+
+impl TouchGrab<State> for TouchResizeGrab {
+    fn down(
+        &mut self,
+        data: &mut State,
+        handle: &mut TouchInnerHandle<'_, State>,
+        _focus: Option<(<State as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
+        event: &DownEvent,
+        seq: Serial,
+    ) {
+        handle.down(data, None, event, seq);
+    }
+
+    fn up(
+        &mut self,
+        data: &mut State,
+        handle: &mut TouchInnerHandle<'_, State>,
+        event: &UpEvent,
+        seq: Serial,
+    ) {
+        handle.up(data, event, seq);
+
+        if event.slot != self.start_data.slot {
+            return;
+        }
+
+        handle.unset_grab(self, data);
+    }
+
+    fn motion(
+        &mut self,
+        data: &mut State,
+        handle: &mut TouchInnerHandle<'_, State>,
+        _focus: Option<(<State as SeatHandler>::TouchFocus, Point<f64, Logical>)>,
+        event: &MotionEvent,
+        seq: Serial,
+    ) {
+        handle.motion(data, None, event, seq);
+
+        if event.slot != self.start_data.slot {
+            return;
+        }
+
+        if self.window.alive() {
+            let delta = event.location - self.start_data.location;
+            let ongoing = data
+                .niri
+                .layout
+                .interactive_resize_update(&self.window, delta);
+            if ongoing {
+                return;
+            }
+        }
+
+        // The resize is no longer ongoing.
+        handle.unset_grab(self, data);
+    }
+
+    fn frame(&mut self, data: &mut State, handle: &mut TouchInnerHandle<'_, State>, seq: Serial) {
+        handle.frame(data, seq);
+    }
+
+    fn cancel(&mut self, data: &mut State, handle: &mut TouchInnerHandle<'_, State>, seq: Serial) {
+        handle.cancel(data, seq);
+        handle.unset_grab(self, data);
+    }
+
+    fn shape(
+        &mut self,
+        data: &mut State,
+        handle: &mut TouchInnerHandle<'_, State>,
+        event: &ShapeEvent,
+        seq: Serial,
+    ) {
+        handle.shape(data, event, seq);
+    }
+
+    fn orientation(
+        &mut self,
+        data: &mut State,
+        handle: &mut TouchInnerHandle<'_, State>,
+        event: &OrientationEvent,
+        seq: Serial,
+    ) {
+        handle.orientation(data, event, seq);
+    }
+
+    fn start_data(&self) -> &TouchGrabStartData<State> {
+        &self.start_data
+    }
+
+    fn unset(&mut self, data: &mut State) {
+        self.on_ungrab(data);
+    }
+}

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -551,12 +551,12 @@ impl State {
             }
 
             let Some(ipc_win) = state.windows.get(&id) else {
-                let window = make_ipc_window(mapped, Some(ws_id));
+                let window = make_ipc_window(mapped, ws_id);
                 events.push(Event::WindowOpenedOrChanged { window });
                 return;
             };
 
-            let workspace_id = Some(ws_id.get());
+            let workspace_id = ws_id.map(|id| id.get());
             let mut changed = ipc_win.workspace_id != workspace_id;
 
             let wl_surface = mapped.toplevel().wl_surface();
@@ -572,7 +572,7 @@ impl State {
             });
 
             if changed {
-                let window = make_ipc_window(mapped, Some(ws_id));
+                let window = make_ipc_window(mapped, ws_id);
                 events.push(Event::WindowOpenedOrChanged { window });
                 return;
             }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -100,7 +100,7 @@ pub enum ConfigureIntent {
 
 pub trait LayoutElement {
     /// Type that can be used as a unique ID of this element.
-    type Id: PartialEq + std::fmt::Debug;
+    type Id: PartialEq + std::fmt::Debug + Clone;
 
     /// Unique ID of this element.
     fn id(&self) -> &Self::Id;

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -64,6 +64,9 @@ pub struct Tile<W: LayoutElement> {
     /// The animation of a tile visually moving vertically.
     move_y_animation: Option<MoveAnimation>,
 
+    /// Offset during the initial interactive move rubberband.
+    pub(super) interactive_move_offset: Point<f64, Logical>,
+
     /// Snapshot of the last render for use in the close animation.
     unmap_snapshot: Option<TileRenderSnapshot>,
 
@@ -90,7 +93,7 @@ niri_render_elements! {
     }
 }
 
-type TileRenderSnapshot =
+pub type TileRenderSnapshot =
     RenderSnapshot<TileRenderElement<GlesRenderer>, TileRenderElement<GlesRenderer>>;
 
 #[derive(Debug)]
@@ -123,6 +126,7 @@ impl<W: LayoutElement> Tile<W> {
             resize_animation: None,
             move_x_animation: None,
             move_y_animation: None,
+            interactive_move_offset: Point::from((0., 0.)),
             unmap_snapshot: None,
             rounded_corner_damage: Default::default(),
             scale,
@@ -305,6 +309,8 @@ impl<W: LayoutElement> Tile<W> {
             offset.y += move_.from * move_.anim.value();
         }
 
+        offset += self.interactive_move_offset;
+
         offset
     }
 
@@ -362,6 +368,11 @@ impl<W: LayoutElement> Tile<W> {
             anim,
             from: from + current_offset,
         });
+    }
+
+    pub fn stop_move_animations(&mut self) {
+        self.move_x_animation = None;
+        self.move_y_animation = None;
     }
 
     pub fn window(&self) -> &W {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -8,6 +8,7 @@ use niri_config::{
 };
 use niri_ipc::SizeChange;
 use ordered_float::NotNan;
+use smithay::backend::renderer::element::Kind;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::desktop::{layer_map_for_output, Window};
 use smithay::output::Output;
@@ -16,12 +17,13 @@ use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::{Logical, Point, Rectangle, Scale, Serial, Size, Transform};
 
 use super::closing_window::{ClosingWindow, ClosingWindowRenderElement};
-use super::tile::{Tile, TileRenderElement};
+use super::tile::{Tile, TileRenderElement, TileRenderSnapshot};
 use super::{ConfigureIntent, InteractiveResizeData, LayoutElement, Options, RemovedTile};
 use crate::animation::Animation;
 use crate::input::swipe_tracker::SwipeTracker;
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
+use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
 use crate::render_helpers::RenderTarget;
 use crate::utils::id::IdCounter;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
@@ -106,6 +108,12 @@ pub struct Workspace<W: LayoutElement> {
     /// Windows in the closing animation.
     closing_windows: Vec<ClosingWindow>,
 
+    /// Indication where an interactively-moved window is about to be placed.
+    insert_hint: Option<InsertHint>,
+
+    /// Buffer for the insert hint.
+    insert_hint_buffer: SolidColorBuffer,
+
     /// Configurable properties of the layout as received from the parent monitor.
     pub(super) base_options: Rc<Options>,
 
@@ -117,6 +125,19 @@ pub struct Workspace<W: LayoutElement> {
 
     /// Unique ID of this workspace.
     id: WorkspaceId,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum InsertPosition {
+    NewColumn(usize),
+    InColumn(usize, usize),
+}
+
+#[derive(Debug)]
+pub struct InsertHint {
+    pub position: InsertPosition,
+    pub width: ColumnWidth,
+    pub is_full_width: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -418,6 +439,8 @@ impl<W: LayoutElement> Workspace<W> {
             activate_prev_column_on_removal: None,
             view_offset_before_fullscreen: None,
             closing_windows: vec![],
+            insert_hint: None,
+            insert_hint_buffer: SolidColorBuffer::new((0., 0.), [0., 0., 0., 1.]),
             base_options,
             options,
             name: config.map(|c| c.name.0),
@@ -456,6 +479,8 @@ impl<W: LayoutElement> Workspace<W> {
             activate_prev_column_on_removal: None,
             view_offset_before_fullscreen: None,
             closing_windows: vec![],
+            insert_hint: None,
+            insert_hint_buffer: SolidColorBuffer::new((0., 0.), [0., 0., 0., 1.]),
             base_options,
             options,
             name: config.map(|c| c.name.0),
@@ -534,6 +559,13 @@ impl<W: LayoutElement> Workspace<W> {
             let view_rect = Rectangle::from_loc_and_size(col_pos, view_size);
             col.update_render_elements(is_active, view_rect);
         }
+
+        if let Some(insert_hint) = &self.insert_hint {
+            if let Some(area) = self.insert_hint_area(insert_hint) {
+                self.insert_hint_buffer
+                    .update(area.size, self.options.insert_hint.color.to_array_premul());
+            }
+        }
     }
 
     pub fn update_config(&mut self, base_options: Rc<Options>) {
@@ -565,10 +597,11 @@ impl<W: LayoutElement> Workspace<W> {
     }
 
     pub fn windows_mut(&mut self) -> impl Iterator<Item = &mut W> + '_ {
-        self.columns
-            .iter_mut()
-            .flat_map(|col| col.tiles.iter_mut())
-            .map(Tile::window_mut)
+        self.tiles_mut().map(Tile::window_mut)
+    }
+
+    pub fn tiles_mut(&mut self) -> impl Iterator<Item = &mut Tile<W>> + '_ {
+        self.columns.iter_mut().flat_map(|col| col.tiles.iter_mut())
     }
 
     pub fn current_output(&self) -> Option<&Output> {
@@ -731,13 +764,16 @@ impl<W: LayoutElement> Workspace<W> {
             });
     }
 
-    fn compute_new_view_offset_for_column_fit(&self, current_x: f64, idx: usize) -> f64 {
-        let col = &self.columns[idx];
-        if col.is_fullscreen {
+    fn compute_new_view_offset_fit(
+        &self,
+        current_x: f64,
+        col_x: f64,
+        width: f64,
+        is_fullscreen: bool,
+    ) -> f64 {
+        if is_fullscreen {
             return 0.;
         }
-
-        let new_col_x = self.column_x(idx);
 
         let final_x = if let Some(ViewOffsetAdjustment::Animation(anim)) = &self.view_offset_adj {
             current_x - self.view_offset + anim.to()
@@ -748,8 +784,8 @@ impl<W: LayoutElement> Workspace<W> {
         let new_offset = compute_new_view_offset(
             final_x + self.working_area.loc.x,
             self.working_area.size.w,
-            new_col_x,
-            col.width(),
+            col_x,
+            width,
             self.options.gaps,
         );
 
@@ -757,20 +793,43 @@ impl<W: LayoutElement> Workspace<W> {
         new_offset - self.working_area.loc.x
     }
 
-    fn compute_new_view_offset_for_column_centered(&self, current_x: f64, idx: usize) -> f64 {
-        let col = &self.columns[idx];
-        if col.is_fullscreen {
-            return self.compute_new_view_offset_for_column_fit(current_x, idx);
+    fn compute_new_view_offset_centered(
+        &self,
+        current_x: f64,
+        col_x: f64,
+        width: f64,
+        is_fullscreen: bool,
+    ) -> f64 {
+        if is_fullscreen {
+            return self.compute_new_view_offset_fit(current_x, col_x, width, is_fullscreen);
         }
-
-        let width = col.width();
 
         // Columns wider than the view are left-aligned (the fit code can deal with that).
         if self.working_area.size.w <= width {
-            return self.compute_new_view_offset_for_column_fit(current_x, idx);
+            return self.compute_new_view_offset_fit(current_x, col_x, width, is_fullscreen);
         }
 
         -(self.working_area.size.w - width) / 2. - self.working_area.loc.x
+    }
+
+    fn compute_new_view_offset_for_column_fit(&self, current_x: f64, idx: usize) -> f64 {
+        let col = &self.columns[idx];
+        self.compute_new_view_offset_fit(
+            current_x,
+            self.column_x(idx),
+            col.width(),
+            col.is_fullscreen,
+        )
+    }
+
+    fn compute_new_view_offset_for_column_centered(&self, current_x: f64, idx: usize) -> f64 {
+        let col = &self.columns[idx];
+        self.compute_new_view_offset_centered(
+            current_x,
+            self.column_x(idx),
+            col.width(),
+            col.is_fullscreen,
+        )
     }
 
     fn compute_new_view_offset_for_column(
@@ -958,6 +1017,71 @@ impl<W: LayoutElement> Workspace<W> {
         self.windows_mut().find(|win| win.is_wl_surface(wl_surface))
     }
 
+    pub fn set_insert_hint(&mut self, insert_hint: InsertHint) {
+        if self.options.insert_hint.off {
+            return;
+        }
+        self.insert_hint = Some(insert_hint);
+    }
+
+    pub fn clear_insert_hint(&mut self) {
+        self.insert_hint = None;
+    }
+
+    pub fn get_insert_position(&self, pos: Point<f64, Logical>) -> InsertPosition {
+        if self.columns.is_empty() {
+            return InsertPosition::NewColumn(0);
+        }
+
+        let x = pos.x + self.view_pos();
+
+        // Aim for the center of the gap.
+        let x = x + self.options.gaps / 2.;
+        let y = pos.y + self.options.gaps / 2.;
+
+        // Insert position is before the first column.
+        if x < 0. {
+            return InsertPosition::NewColumn(0);
+        }
+
+        // Find the closest gap between columns.
+        let (closest_col_idx, col_x) = self
+            .column_xs(self.data.iter().copied())
+            .enumerate()
+            .min_by_key(|(_, col_x)| NotNan::new((col_x - x).abs()).unwrap())
+            .unwrap();
+
+        // Find the column containing the position.
+        let (col_idx, _) = self
+            .column_xs(self.data.iter().copied())
+            .enumerate()
+            .take_while(|(_, col_x)| *col_x <= x)
+            .last()
+            .unwrap_or((0, 0.));
+
+        // Insert position is past the last column.
+        if col_idx == self.columns.len() {
+            return InsertPosition::NewColumn(closest_col_idx);
+        }
+
+        // Find the closest gap between tiles.
+        let col = &self.columns[col_idx];
+        let (closest_tile_idx, tile_off) = col
+            .tile_offsets()
+            .enumerate()
+            .min_by_key(|(_, tile_off)| NotNan::new((tile_off.y - y).abs()).unwrap())
+            .unwrap();
+
+        // Return the closest among the vertical and the horizontal gap.
+        let vert_dist = (col_x - x).abs();
+        let hor_dist = (tile_off.y - y).abs();
+        if vert_dist <= hor_dist {
+            InsertPosition::NewColumn(closest_col_idx)
+        } else {
+            InsertPosition::InColumn(col_idx, closest_tile_idx)
+        }
+    }
+
     pub fn add_window(
         &mut self,
         col_idx: Option<usize>,
@@ -970,7 +1094,7 @@ impl<W: LayoutElement> Workspace<W> {
         self.add_tile(col_idx, tile, activate, width, is_full_width, None);
     }
 
-    fn add_tile(
+    pub fn add_tile(
         &mut self,
         col_idx: Option<usize>,
         tile: Tile<W>,
@@ -1488,8 +1612,6 @@ impl<W: LayoutElement> Workspace<W> {
         window: &W::Id,
         blocker: TransactionBlocker,
     ) {
-        let output_scale = Scale::from(self.scale.fractional_scale());
-
         let (tile, mut tile_pos) = self
             .tiles_with_render_positions_mut(false)
             .find(|(tile, _)| tile.window().id() == window)
@@ -1537,6 +1659,19 @@ impl<W: LayoutElement> Workspace<W> {
             tile_pos.x -= offset;
         }
 
+        self.start_close_animation_for_tile(renderer, snapshot, tile_size, tile_pos, blocker);
+    }
+
+    pub fn start_close_animation_for_tile(
+        &mut self,
+        renderer: &mut GlesRenderer,
+        snapshot: TileRenderSnapshot,
+        tile_size: Size<f64, Logical>,
+        tile_pos: Point<f64, Logical>,
+        blocker: TransactionBlocker,
+    ) {
+        let output_scale = Scale::from(self.scale.fractional_scale());
+
         let anim = Animation::new(0., 1., 0., self.options.animations.window_close.anim);
 
         let blocker = if self.options.disable_transactions {
@@ -1565,7 +1700,7 @@ impl<W: LayoutElement> Workspace<W> {
     }
 
     #[cfg(test)]
-    pub fn verify_invariants(&self) {
+    pub fn verify_invariants(&self, move_win_id: Option<&W::Id>) {
         use approx::assert_abs_diff_eq;
 
         let scale = self.scale.fractional_scale();
@@ -1601,7 +1736,11 @@ impl<W: LayoutElement> Workspace<W> {
                 );
             }
 
-            for (_, tile_pos) in self.tiles_with_render_positions() {
+            for (tile, tile_pos) in self.tiles_with_render_positions() {
+                if Some(tile.window().id()) != move_win_id {
+                    assert_eq!(tile.interactive_move_offset, Point::from((0., 0.)));
+                }
+
                 let rounded_pos = tile_pos.to_physical_precise_round(scale).to_logical(scale);
 
                 // Tile positions must be rounded to physical pixels.
@@ -2046,7 +2185,7 @@ impl<W: LayoutElement> Workspace<W> {
         cancel_resize_for_column(&mut self.interactive_resize, col);
     }
 
-    fn view_pos(&self) -> f64 {
+    pub fn view_pos(&self) -> f64 {
         self.column_x(self.active_column_idx) + self.view_offset
     }
 
@@ -2123,7 +2262,9 @@ impl<W: LayoutElement> Workspace<W> {
         zip(tiles, offsets)
     }
 
-    fn tiles_with_render_positions(&self) -> impl Iterator<Item = (&Tile<W>, Point<f64, Logical>)> {
+    pub fn tiles_with_render_positions(
+        &self,
+    ) -> impl Iterator<Item = (&Tile<W>, Point<f64, Logical>)> {
         let scale = self.scale.fractional_scale();
         let view_off = Point::from((-self.view_pos(), 0.));
         self.columns_in_render_order()
@@ -2139,7 +2280,7 @@ impl<W: LayoutElement> Workspace<W> {
             })
     }
 
-    fn tiles_with_render_positions_mut(
+    pub fn tiles_with_render_positions_mut(
         &mut self,
         round: bool,
     ) -> impl Iterator<Item = (&mut Tile<W>, Point<f64, Logical>)> {
@@ -2160,6 +2301,96 @@ impl<W: LayoutElement> Workspace<W> {
                         (tile, pos)
                     })
             })
+    }
+
+    fn insert_hint_area(&self, insert_hint: &InsertHint) -> Option<Rectangle<f64, Logical>> {
+        let mut hint_area = match insert_hint.position {
+            InsertPosition::NewColumn(column_index) => {
+                if column_index == 0 || column_index == self.columns.len() {
+                    let size =
+                        Size::from((300., self.working_area.size.h - self.options.gaps * 2.));
+                    let mut loc = Point::from((
+                        self.column_x(column_index),
+                        self.working_area.loc.y + self.options.gaps,
+                    ));
+                    if column_index == 0 && !self.columns.is_empty() {
+                        loc.x -= size.w + self.options.gaps;
+                    }
+                    Rectangle::from_loc_and_size(loc, size)
+                } else if column_index > self.columns.len() {
+                    error!("insert hint column index is out of range");
+                    return None;
+                } else {
+                    let size =
+                        Size::from((300., self.working_area.size.h - self.options.gaps * 2.));
+                    let loc = Point::from((
+                        self.column_x(column_index) - size.w / 2. - self.options.gaps / 2.,
+                        self.working_area.loc.y + self.options.gaps,
+                    ));
+                    Rectangle::from_loc_and_size(loc, size)
+                }
+            }
+            InsertPosition::InColumn(column_index, tile_index) => {
+                if column_index > self.columns.len() {
+                    error!("insert hint column index is out of range");
+                    return None;
+                }
+                if tile_index > self.columns[column_index].tiles.len() {
+                    error!("insert hint tile index is out of range");
+                    return None;
+                }
+
+                let (height, y) = if tile_index == 0 {
+                    (150., self.columns[column_index].tile_offset(tile_index).y)
+                } else if tile_index == self.columns[column_index].tiles.len() {
+                    (
+                        150.,
+                        self.columns[column_index].tile_offset(tile_index).y
+                            - self.options.gaps
+                            - 150.,
+                    )
+                } else {
+                    (
+                        300.,
+                        self.columns[column_index].tile_offset(tile_index).y
+                            - self.options.gaps / 2.
+                            - 150.,
+                    )
+                };
+
+                let size = Size::from((self.data[column_index].width, height));
+                let loc = Point::from((self.column_x(column_index), y));
+                Rectangle::from_loc_and_size(loc, size)
+            }
+        };
+
+        // First window on an empty workspace will cancel out any view offset. Replicate this
+        // effect here.
+        if self.columns.is_empty() {
+            let view_offset = if self.is_centering_focused_column() {
+                self.compute_new_view_offset_centered(0., 0., hint_area.size.w, false)
+            } else {
+                self.compute_new_view_offset_fit(0., 0., hint_area.size.w, false)
+            };
+            hint_area.loc.x -= view_offset;
+        } else {
+            hint_area.loc.x -= self.view_pos();
+        }
+
+        let view_size = self.view_size();
+
+        // Make sure the hint is at least partially visible.
+        if matches!(insert_hint.position, InsertPosition::NewColumn(_)) {
+            hint_area.loc.x = hint_area.loc.x.max(-hint_area.size.w / 2.);
+            hint_area.loc.x = hint_area.loc.x.min(view_size.w - hint_area.size.w / 2.);
+        }
+
+        // Round to physical pixels.
+        hint_area = hint_area
+            .to_physical_precise_round(self.scale.fractional_scale())
+            .to_logical(self.scale.fractional_scale());
+
+        Some(hint_area)
     }
 
     /// Returns the geometry of the active tile relative to and clamped to the view.
@@ -2438,7 +2669,22 @@ impl<W: LayoutElement> Workspace<W> {
 
         let mut rv = vec![];
 
-        // Draw the closing windows on top.
+        // Draw the insert hint.
+        if let Some(insert_hint) = &self.insert_hint {
+            if let Some(area) = self.insert_hint_area(insert_hint) {
+                rv.push(
+                    TileRenderElement::SolidColor(SolidColorRenderElement::from_buffer(
+                        &self.insert_hint_buffer,
+                        area.loc,
+                        1.,
+                        Kind::Unspecified,
+                    ))
+                    .into(),
+                );
+            }
+        }
+
+        // Draw the closing windows on top of the other windows.
         let view_rect = Rectangle::from_loc_and_size((self.view_pos(), 0.), self.view_size);
         for closing in self.closing_windows.iter().rev() {
             let elem = closing.render(renderer.as_gles_renderer(), view_rect, output_scale, target);

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -2978,6 +2978,10 @@ impl<W: LayoutElement> Workspace<W> {
     }
 
     pub fn interactive_resize_begin(&mut self, window: W::Id, edges: ResizeEdge) -> bool {
+        if self.interactive_resize.is_some() {
+            return false;
+        }
+
         let col = self
             .columns
             .iter_mut()

--- a/wiki/Configuration:-Layout.md
+++ b/wiki/Configuration:-Layout.md
@@ -42,6 +42,11 @@ layout {
         // inactive-gradient from="#505050" to="#808080" angle=45 relative-to="workspace-view" in="srgb-linear"
     }
 
+    insert-hint {
+        // off
+        color "#ffc87f80"
+    }
+
     struts {
         // left 64
         // right 64
@@ -299,6 +304,25 @@ For example, `active-gradient from="#f00f" to="#0f05" angle=45 in="oklch longer 
 layout {
     border {
         active-gradient from="#f00f" to="#0f05" angle=45 in="oklch longer hue"
+    }
+}
+```
+
+### `insert-hint`
+
+<sup>Since: 0.1.10</sup> 
+
+Settings for the window insert position hint during an interactive window move.
+
+`off` disables the insert hint altogether.
+
+`color` lets you change the color of the hint and has the same syntax as colors in border and focus ring.
+
+```kdl
+layout {
+    insert-hint {
+        // off
+        color "#ffc87f80"
     }
 }
 ```

--- a/wiki/Gestures.md
+++ b/wiki/Gestures.md
@@ -4,6 +4,12 @@ There are several gestures in niri.
 
 ### Mouse
 
+#### Interactive Move
+
+<sup>Since: 0.1.10</sup>
+
+You can move windows by holding <kbd>Mod</kbd> and the left mouse button.
+
 #### Interactive Resize
 
 <sup>Since: 0.1.6</sup>


### PR DESCRIPTION
I've started working on interactive move support as I eventually want #122 but it's a little too big to start with. Interactive move feels smaller but still like a step towards it.

Currently implemented:
- [x] Can pickup with Mod+MouseLeft and dragging a titlebar
- [x] Windows follow cursor after pickup
- [x] Can drop as both new columns and in existing columns using the same 1/3 rule as interactive resize
- [x] Dragging to different monitors (or workspaces)
- [x] Some visual indication of where you'll drop
- [x] Animations and rerenders needs some more love
- [x] Some way to scroll workspaces while dragging (Press middle mouse button during the move)
- [x] Investigate if needing to prevent workspace actions during move (Tested actions work well during move)
- [x] Border/focus ring on moving window
- [x] Output updates during move