### PR TITLE
add mod3 key binding support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,15 +2113,6 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memmap2"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
@@ -2403,7 +2394,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.72",
@@ -3486,7 +3477,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/Smithay/smithay.git#91bea4d1d20c1a59c48159994459ac86fc113607"
+source = "git+https://github.com/Smithay/smithay.git#de94e8f59e202b605c35dfe1fef1857bad427e8c"
 dependencies = [
  "appendlist",
  "bitflags 2.6.0",
@@ -3544,7 +3535,7 @@ dependencies = [
  "cursor-icon",
  "libc",
  "log",
- "memmap2 0.9.4",
+ "memmap2",
  "rustix 0.38.34",
  "thiserror",
  "wayland-backend",
@@ -3560,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#91bea4d1d20c1a59c48159994459ac86fc113607"
+source = "git+https://github.com/Smithay/smithay.git#de94e8f59e202b605c35dfe1fef1857bad427e8c"
 dependencies = [
  "drm",
  "edid-rs",
@@ -4649,7 +4640,7 @@ dependencies = [
  "dpi",
  "js-sys",
  "libc",
- "memmap2 0.9.4",
+ "memmap2",
  "ndk",
  "objc2",
  "objc2-app-kit",
@@ -4747,12 +4738,12 @@ dependencies = [
 
 [[package]]
 name = "xkbcommon"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e"
+checksum = "8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9"
 dependencies = [
  "libc",
- "memmap2 0.8.0",
+ "memmap2",
  "xkeysym",
 ]
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1004,11 +1004,12 @@ bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Modifiers : u8 {
         const CTRL = 1;
-        const SHIFT = 2;
-        const ALT = 4;
-        const SUPER = 8;
-        const ISO_LEVEL3_SHIFT = 16;
-        const COMPOSITOR = 32;
+        const SHIFT = 1 << 1;
+        const ALT = 1 << 2;
+        const SUPER = 1 << 3;
+        const ISO_LEVEL3_SHIFT = 1 << 4;
+        const ISO_LEVEL5_SHIFT = 1 << 5;
+        const COMPOSITOR = 1 << 6;
     }
 }
 
@@ -2509,6 +2510,10 @@ impl FromStr for Key {
                 || part.eq_ignore_ascii_case("mod5")
             {
                 modifiers |= Modifiers::ISO_LEVEL3_SHIFT;
+            } else if part.eq_ignore_ascii_case("iso_level5_shift")
+                || part.eq_ignore_ascii_case("mod3")
+            {
+                modifiers |= Modifiers::ISO_LEVEL5_SHIFT;
             } else {
                 return Err(miette!("invalid modifier: {part}"));
             }
@@ -3275,7 +3280,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_iso_level3_shift() {
+    fn parse_iso_level_shifts() {
         assert_eq!(
             "ISO_Level3_Shift+A".parse::<Key>().unwrap(),
             Key {
@@ -3288,6 +3293,21 @@ mod tests {
             Key {
                 trigger: Trigger::Keysym(Keysym::a),
                 modifiers: Modifiers::ISO_LEVEL3_SHIFT
+            },
+        );
+
+        assert_eq!(
+            "ISO_Level5_Shift+A".parse::<Key>().unwrap(),
+            Key {
+                trigger: Trigger::Keysym(Keysym::a),
+                modifiers: Modifiers::ISO_LEVEL5_SHIFT
+            },
+        );
+        assert_eq!(
+            "Mod3+A".parse::<Key>().unwrap(),
+            Key {
+                trigger: Trigger::Keysym(Keysym::a),
+                modifiers: Modifiers::ISO_LEVEL5_SHIFT
             },
         );
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2327,6 +2327,9 @@ fn modifiers_from_state(mods: ModifiersState) -> Modifiers {
     if mods.iso_level3_shift {
         modifiers |= Modifiers::ISO_LEVEL3_SHIFT;
     }
+    if mods.iso_level5_shift {
+        modifiers |= Modifiers::ISO_LEVEL5_SHIFT;
+    }
     modifiers
 }
 

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -403,6 +403,9 @@ fn key_name(comp_mod: CompositorMod, key: &Key) -> String {
     if key.modifiers.contains(Modifiers::ISO_LEVEL3_SHIFT) {
         name.push_str("ISO_Level3_Shift + ");
     }
+    if key.modifiers.contains(Modifiers::ISO_LEVEL5_SHIFT) {
+        name.push_str("ISO_Level5_Shift + ");
+    }
     if key.modifiers.contains(Modifiers::SHIFT) {
         name.push_str("Shift + ");
     }


### PR DESCRIPTION
This allows usage of Mod3, for example when using the following config:

```kdl
input {
    keyboard {
        xkb {
            // You can set rules, model, layout, variant and options.
            // For more information, see xkeyboard-config(7).
            options "lv5:ralt_switch"
        }
    }

binds {
    Mod+T { spawn "kitty"; }
    Mod3+T { spawn "foot"; }
}
```

This required plumbing both through smithay and xkbcommon-rs - see https://github.com/Smithay/smithay/pull/1471 to follow the chain.