### PR TITLE
fix `cargo run` on nixos

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722960479,
-        "narHash": "sha256-NhCkJJQhD5GUib8zN9JrmYGMwt4lCRp6ZVNzIiYCl0Y=",
+        "lastModified": 1724533099,
+        "narHash": "sha256-ZIDtvVQHoCkNoBlLUB3wmqbqCb0Es3DfdUGeDI/58aY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "4c6c77920b8d44cd6660c1621dea6b3fc4b4c4f4",
+        "rev": "7543c8d76f91b8844e0f3b3cc347a72d8fb4b49e",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723572004,
-        "narHash": "sha256-U5gKtbKuPahB02iGeGHFPlKr/HqrvSsHlEDEXoVyaPc=",
+        "lastModified": 1724395761,
+        "narHash": "sha256-zRkDV/nbrnp3Y8oCADf5ETl1sDrdmAW6/bBVJ8EbIdQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "19674872444bb3e0768249e724d99c8649c3bd78",
+        "rev": "ae815cee91b417be55d43781eb4b73ae1ecc396c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
this boils down to adding some extra dependencies to the shell environment. they're also inherited from craneArgs because the ones from the package are actually transformed into the WRONG outputs of the packages. also refactors to use craneLib.devShell because it's somewhat cleaner.

---

the formatting changes around L45-L47 are caused by `nix fmt`. this is what `alejandra` wants to format it like, [which is already the formatter set to be used for the nix flake](https://github.com/YaLTeR/niri/blob/b2c7d3ad401574a3db01ed20acd67ebc8d331cbc/flake.nix#L89)