### PR TITLE
implement `keyboard-shortcuts-inhibit` and `wlr-virtual-pointer`

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1191,6 +1191,7 @@ pub struct Bind {
     pub repeat: bool,
     pub cooldown: Option<Duration>,
     pub allow_when_locked: bool,
+    pub allow_inhibiting: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -3015,6 +3016,7 @@ where
         let mut cooldown = None;
         let mut allow_when_locked = false;
         let mut allow_when_locked_node = None;
+        let mut allow_inhibiting = true;
         for (name, val) in &node.properties {
             match &***name {
                 "repeat" => {
@@ -3028,6 +3030,9 @@ where
                 "allow-when-locked" => {
                     allow_when_locked = knuffel::traits::DecodeScalar::decode(val, ctx)?;
                     allow_when_locked_node = Some(name);
+                }
+                "allow-inhibiting" => {
+                    allow_inhibiting = knuffel::traits::DecodeScalar::decode(val, ctx)?;
                 }
                 name_str => {
                     ctx.emit_error(DecodeError::unexpected(
@@ -3050,6 +3055,7 @@ where
             repeat: true,
             cooldown: None,
             allow_when_locked: false,
+            allow_inhibiting: true,
         };
 
         if let Some(child) = children.next() {
@@ -3078,6 +3084,7 @@ where
                         repeat,
                         cooldown,
                         allow_when_locked,
+                        allow_inhibiting,
                     })
                 }
                 Err(e) => {
@@ -3470,7 +3477,7 @@ mod tests {
                 Mod+Comma { consume-window-into-column; }
                 Mod+1 { focus-workspace 1; }
                 Mod+Shift+1 { focus-workspace "workspace-1"; }
-                Mod+Shift+E { quit skip-confirmation=true; }
+                Mod+Shift+E allow-inhibiting=false { quit skip-confirmation=true; }
                 Mod+WheelScrollDown cooldown-ms=150 { focus-workspace-down; }
             }
 
@@ -3788,6 +3795,7 @@ mod tests {
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: true,
+                        allow_inhibiting: true,
                     },
                     Bind {
                         key: Key {
@@ -3798,6 +3806,7 @@ mod tests {
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
+                        allow_inhibiting: true,
                     },
                     Bind {
                         key: Key {
@@ -3808,6 +3817,7 @@ mod tests {
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
+                        allow_inhibiting: true,
                     },
                     Bind {
                         key: Key {
@@ -3818,6 +3828,7 @@ mod tests {
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
+                        allow_inhibiting: true,
                     },
                     Bind {
                         key: Key {
@@ -3828,6 +3839,7 @@ mod tests {
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
+                        allow_inhibiting: true,
                     },
                     Bind {
                         key: Key {
@@ -3838,6 +3850,7 @@ mod tests {
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
+                        allow_inhibiting: true,
                     },
                     Bind {
                         key: Key {
@@ -3850,6 +3863,7 @@ mod tests {
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
+                        allow_inhibiting: true,
                     },
                     Bind {
                         key: Key {
@@ -3860,6 +3874,7 @@ mod tests {
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,
+                        allow_inhibiting: false,
                     },
                     Bind {
                         key: Key {
@@ -3870,6 +3885,7 @@ mod tests {
                         repeat: true,
                         cooldown: Some(Duration::from_millis(150)),
                         allow_when_locked: false,
+                        allow_inhibiting: true,
                     },
                 ]),
                 switch_events: SwitchBinds {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1279,6 +1279,7 @@ pub enum Action {
         id: u64,
         write_to_disk: bool,
     },
+    ToggleKeyboardShortcutsInhibit,
     CloseWindow,
     #[knuffel(skip)]
     CloseWindowById(u64),
@@ -3078,6 +3079,12 @@ where
                         }
                     }
 
+                    // The toggle-inhibit action must always be uninhibitable.
+                    // Otherwise, it would be impossible to trigger it.
+                    if matches!(action, Action::ToggleKeyboardShortcutsInhibit) {
+                        allow_inhibiting = false;
+                    }
+
                     Ok(Self {
                         key,
                         action,
@@ -3470,6 +3477,8 @@ mod tests {
             }
 
             binds {
+                Mod+Escape { toggle-keyboard-shortcuts-inhibit; }
+                Mod+Shift+Escape allow-inhibiting=true { toggle-keyboard-shortcuts-inhibit; }
                 Mod+T allow-when-locked=true { spawn "alacritty"; }
                 Mod+Q { close-window; }
                 Mod+Shift+H { focus-monitor-left; }
@@ -3786,6 +3795,28 @@ mod tests {
                     },
                 ],
                 binds: Binds(vec![
+                    Bind {
+                        key: Key {
+                            trigger: Trigger::Keysym(Keysym::Escape),
+                            modifiers: Modifiers::COMPOSITOR,
+                        },
+                        action: Action::ToggleKeyboardShortcutsInhibit,
+                        repeat: true,
+                        cooldown: None,
+                        allow_when_locked: false,
+                        allow_inhibiting: false,
+                    },
+                    Bind {
+                        key: Key {
+                            trigger: Trigger::Keysym(Keysym::Escape),
+                            modifiers: Modifiers::COMPOSITOR | Modifiers::SHIFT,
+                        },
+                        action: Action::ToggleKeyboardShortcutsInhibit,
+                        repeat: true,
+                        cooldown: None,
+                        allow_when_locked: false,
+                        allow_inhibiting: false,
+                    },
                     Bind {
                         key: Key {
                             trigger: Trigger::Keysym(Keysym::t),

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -536,6 +536,16 @@ binds {
     Ctrl+Print { screenshot-screen; }
     Alt+Print { screenshot-window; }
 
+    // Applications such as remote-desktop clients and software KVM switches may
+    // request that niri stops processing the keyboard shortcuts defined here
+    // so they may, for example, forward the key presses as-is to a remote machine.
+    // It's a good idea to bind an escape hatch to toggle the inhibitor,
+    // so a buggy application can't hold your session hostage.
+    //
+    // The allow-inhibiting=false property can be applied to other binds as well,
+    // which ensures niri always processes them, even when an inhibitor is active.
+    Mod+Escape allow-inhibiting=false { toggle-keyboard-shortcuts-inhibit; }
+
     // The quit action will show a confirmation dialog to avoid accidental exits.
     Mod+Shift+E { quit; }
     Ctrl+Alt+Delete { quit; }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::drm::DrmNode;
-use smithay::backend::input::TabletToolDescriptor;
+use smithay::backend::input::{InputEvent, TabletToolDescriptor};
 use smithay::desktop::{PopupKind, PopupManager};
 use smithay::input::pointer::{
     CursorIcon, CursorImageStatus, CursorImageSurfaceData, PointerHandle,
@@ -79,7 +79,11 @@ use crate::protocols::gamma_control::{GammaControlHandler, GammaControlManagerSt
 use crate::protocols::mutter_x11_interop::MutterX11InteropHandler;
 use crate::protocols::output_management::{OutputManagementHandler, OutputManagementManagerState};
 use crate::protocols::screencopy::{Screencopy, ScreencopyHandler, ScreencopyManagerState};
-use crate::protocols::virtual_pointer::{VirtualPointerHandler, VirtualPointerManagerState};
+use crate::protocols::virtual_pointer::{
+    VirtualPointerAxisEvent, VirtualPointerButtonEvent, VirtualPointerHandler,
+    VirtualPointerInputBackend, VirtualPointerManagerState, VirtualPointerMotionAbsoluteEvent,
+    VirtualPointerMotionEvent,
+};
 use crate::utils::{output_size, send_scale_transform, with_toplevel_role};
 use crate::{
     delegate_foreign_toplevel, delegate_gamma_control, delegate_mutter_x11_interop,
@@ -591,6 +595,24 @@ delegate_screencopy!(State);
 impl VirtualPointerHandler for State {
     fn virtual_pointer_manager_state(&mut self) -> &mut VirtualPointerManagerState {
         &mut self.niri.virtual_pointer_state
+    }
+
+    fn on_virtual_pointer_motion(&mut self, event: VirtualPointerMotionEvent) {
+        self.process_input_event(InputEvent::<VirtualPointerInputBackend>::PointerMotion { event });
+    }
+
+    fn on_virtual_pointer_motion_absolute(&mut self, event: VirtualPointerMotionAbsoluteEvent) {
+        self.process_input_event(
+            InputEvent::<VirtualPointerInputBackend>::PointerMotionAbsolute { event },
+        );
+    }
+
+    fn on_virtual_pointer_button(&mut self, event: VirtualPointerButtonEvent) {
+        self.process_input_event(InputEvent::<VirtualPointerInputBackend>::PointerButton { event });
+    }
+
+    fn on_virtual_pointer_axis(&mut self, event: VirtualPointerAxisEvent) {
+        self.process_input_event(InputEvent::<VirtualPointerInputBackend>::PointerAxis { event });
     }
 }
 delegate_virtual_pointer!(State);

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -254,11 +254,17 @@ impl KeyboardShortcutsInhibitHandler for State {
     }
 
     fn new_inhibitor(&mut self, inhibitor: KeyboardShortcutsInhibitor) {
-        info!("new inhibitor: {inhibitor:?}");
+        // FIXME: show a confirmation dialog with a "remember for this application" kind of toggle.
+        inhibitor.activate();
+        self.niri
+            .keyboard_shortcuts_inhibiting_surfaces
+            .insert(inhibitor.wl_surface().clone(), inhibitor);
     }
 
     fn inhibitor_destroyed(&mut self, inhibitor: KeyboardShortcutsInhibitor) {
-        info!("inhibitor destroyed: {inhibitor:?}");
+        self.niri
+            .keyboard_shortcuts_inhibiting_surfaces
+            .remove(&inhibitor.wl_surface().clone());
     }
 }
 

--- a/src/input/backend_ext.rs
+++ b/src/input/backend_ext.rs
@@ -3,6 +3,7 @@ use smithay::backend::input;
 use smithay::backend::winit::WinitVirtualDevice;
 use smithay::output::Output;
 
+use crate::niri::State;
 use crate::protocols::virtual_pointer::VirtualPointer;
 
 pub trait NiriInputBackend: input::InputBackend<Device = Self::NiriDevice> {
@@ -16,29 +17,35 @@ where
 }
 
 pub trait NiriInputDevice: input::Device {
-    // FIXME: should this be per-event? logically yes,
-    // but right now we only use it for virtual pointers, which have static outputs.
-    fn output(&self) -> Option<Output>;
+    // FIXME: this should maybe be per-event, not per-device,
+    // but it's not clear that this matters in practice?
+    // it might be more obvious once we implement it for libinput
+    fn output(&self, state: &State) -> Option<Output>;
 }
 
 impl NiriInputDevice for libinput::Device {
-    fn output(&self) -> Option<Output> {
+    fn output(&self, _state: &State) -> Option<Output> {
         // FIXME: Allow specifying the output per-device?
-        // In that case, change the method to take a reference to our state or config or something
-        // (because we can't easily change the libinput Device struct)
         None
     }
 }
 
 impl NiriInputDevice for WinitVirtualDevice {
-    fn output(&self) -> Option<Output> {
-        // here it's actually *correct* to return None, because there is only one output.
+    fn output(&self, _state: &State) -> Option<Output> {
+        // FIXME: we should be returning the single output that the winit backend creates,
+        // but for now, that will cause issues because the output is normally upside down,
+        // so we apply Transform::Flipped180 to it and that would also cause
+        // the cursor position to be flipped, which is not what we want.
+        //
+        // instead, we just return None and rely on the fact that it has only one output.
+        // doing so causes the cursor to be placed in *global* output coordinates,
+        // which are not flipped, and happen to be what we want.
         None
     }
 }
 
 impl NiriInputDevice for VirtualPointer {
-    fn output(&self) -> Option<Output> {
+    fn output(&self, _: &State) -> Option<Output> {
         self.output().cloned()
     }
 }

--- a/src/input/backend_ext.rs
+++ b/src/input/backend_ext.rs
@@ -1,0 +1,44 @@
+use ::input as libinput;
+use smithay::backend::input;
+use smithay::backend::winit::WinitVirtualDevice;
+use smithay::output::Output;
+
+use crate::protocols::virtual_pointer::VirtualPointer;
+
+pub trait NiriInputBackend: input::InputBackend<Device = Self::NiriDevice> {
+    type NiriDevice: NiriInputDevice;
+}
+impl<T: input::InputBackend> NiriInputBackend for T
+where
+    Self::Device: NiriInputDevice,
+{
+    type NiriDevice = Self::Device;
+}
+
+pub trait NiriInputDevice: input::Device {
+    // FIXME: should this be per-event? logically yes,
+    // but right now we only use it for virtual pointers, which have static outputs.
+    fn output(&self) -> Option<Output>;
+}
+
+impl NiriInputDevice for libinput::Device {
+    fn output(&self) -> Option<Output> {
+        // FIXME: Allow specifying the output per-device?
+        // In that case, change the method to take a reference to our state or config or something
+        // (because we can't easily change the libinput Device struct)
+        None
+    }
+}
+
+impl NiriInputDevice for WinitVirtualDevice {
+    fn output(&self) -> Option<Output> {
+        // here it's actually *correct* to return None, because there is only one output.
+        None
+    }
+}
+
+impl NiriInputDevice for VirtualPointer {
+    fn output(&self) -> Option<Output> {
+        self.output().cloned()
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -29,6 +29,7 @@ use smithay::input::touch::{
 };
 use smithay::input::SeatHandler;
 use smithay::utils::{Logical, Point, Rectangle, Transform, SERIAL_COUNTER};
+use smithay::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitor;
 use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraint};
 use smithay::wayland::tablet_manager::{TabletDescriptor, TabletSeatTrait};
 use touch_move_grab::TouchMoveGrab;
@@ -318,6 +319,18 @@ impl State {
         Some(pos + target_geo.loc.to_f64())
     }
 
+    fn is_inhibiting_shortcuts(&self) -> bool {
+        self.niri
+            .keyboard_focus
+            .surface()
+            .and_then(|surface| {
+                self.niri
+                    .keyboard_shortcuts_inhibiting_surfaces
+                    .get(surface)
+            })
+            .is_some_and(KeyboardShortcutsInhibitor::is_active)
+    }
+
     fn on_keyboard<I: InputBackend>(&mut self, event: I::KeyboardKeyEvent) {
         let comp_mod = self.backend.mod_key();
 
@@ -341,6 +354,8 @@ impl State {
         if pressed {
             self.hide_cursor_if_needed();
         }
+
+        let is_inhibiting_shortcuts = self.is_inhibiting_shortcuts();
 
         let Some(Some(bind)) = self.niri.seat.get_keyboard().unwrap().input(
             self,
@@ -372,6 +387,7 @@ impl State {
                     *mods,
                     &this.niri.screenshot_ui,
                     this.niri.config.borrow().input.disable_power_key_handling,
+                    is_inhibiting_shortcuts,
                 )
             },
         ) else {
@@ -2780,6 +2796,7 @@ fn should_intercept_key(
     mods: ModifiersState,
     screenshot_ui: &ScreenshotUi,
     disable_power_key_handling: bool,
+    is_inhibiting_shortcuts: bool,
 ) -> FilterResult<Option<Bind>> {
     // Actions are only triggered on presses, release of the key
     // shouldn't try to intercept anything unless we have marked
@@ -2823,6 +2840,18 @@ fn should_intercept_key(
                 });
             }
         }
+    }
+
+    if is_inhibiting_shortcuts
+        && !matches!(
+            final_bind,
+            Some(Bind {
+                action: Action::ChangeVt(_),
+                ..
+            })
+        )
+    {
+        return FilterResult::Forward;
     }
 
     match (final_bind, pressed) {
@@ -3356,6 +3385,7 @@ mod tests {
                 mods,
                 &screenshot_ui,
                 disable_power_key_handling,
+                false,
             )
         };
 
@@ -3372,6 +3402,7 @@ mod tests {
                 mods,
                 &screenshot_ui,
                 disable_power_key_handling,
+                false,
             )
         };
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -626,6 +626,19 @@ impl State {
                     });
                 }
             }
+            Action::ToggleKeyboardShortcutsInhibit => {
+                if let Some(inhibitor) = self.niri.keyboard_focus.surface().and_then(|surface| {
+                    self.niri
+                        .keyboard_shortcuts_inhibiting_surfaces
+                        .get(surface)
+                }) {
+                    if inhibitor.is_active() {
+                        inhibitor.inactivate();
+                    } else {
+                        inhibitor.activate();
+                    }
+                }
+            }
             Action::CloseWindow => {
                 if let Some(mapped) = self.niri.layout.focus() {
                     mapped.toplevel().send_close();
@@ -3071,6 +3084,7 @@ fn allowed_when_locked(action: &Action) -> bool {
             | Action::PowerOffMonitors
             | Action::PowerOnMonitors
             | Action::SwitchLayout(_)
+            | Action::ToggleKeyboardShortcutsInhibit
     )
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -269,7 +269,7 @@ impl State {
     where
         I::Device: 'static,
     {
-        let device_output = event.device().output();
+        let device_output = event.device().output(self);
         let device_output = device_output.as_ref();
         let (target_geo, keep_ratio, px, transform) =
             if let Some(output) = device_output.or_else(|| self.niri.output_for_tablet()) {
@@ -2655,7 +2655,7 @@ impl State {
         evt: &impl AbsolutePositionEvent<I>,
         fallback_output: Option<&Output>,
     ) -> Option<Point<f64, Logical>> {
-        let output = evt.device().output();
+        let output = evt.device().output(self);
         let output = output.as_ref().or(fallback_output)?;
         let output_geo = self.niri.global_space.output_geometry(output).unwrap();
         let transform = output.current_transform();

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -77,7 +77,9 @@ use smithay::wayland::fractional_scale::FractionalScaleManagerState;
 use smithay::wayland::idle_inhibit::IdleInhibitManagerState;
 use smithay::wayland::idle_notify::IdleNotifierState;
 use smithay::wayland::input_method::{InputMethodManagerState, InputMethodSeat};
-use smithay::wayland::keyboard_shortcuts_inhibit::{KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor};
+use smithay::wayland::keyboard_shortcuts_inhibit::{
+    KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
+};
 use smithay::wayland::output::OutputManagerState;
 use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraintsState};
 use smithay::wayland::pointer_gestures::PointerGesturesState;

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -77,7 +77,7 @@ use smithay::wayland::fractional_scale::FractionalScaleManagerState;
 use smithay::wayland::idle_inhibit::IdleInhibitManagerState;
 use smithay::wayland::idle_notify::IdleNotifierState;
 use smithay::wayland::input_method::{InputMethodManagerState, InputMethodSeat};
-use smithay::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitState;
+use smithay::wayland::keyboard_shortcuts_inhibit::{KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor};
 use smithay::wayland::output::OutputManagerState;
 use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraintsState};
 use smithay::wayland::pointer_gestures::PointerGesturesState;
@@ -294,6 +294,7 @@ pub struct Niri {
     pub previously_focused_window: Option<Window>,
     pub idle_inhibiting_surfaces: HashSet<WlSurface>,
     pub is_fdo_idle_inhibited: Arc<AtomicBool>,
+    pub keyboard_shortcuts_inhibiting_surfaces: HashMap<WlSurface, KeyboardShortcutsInhibitor>,
 
     pub cursor_manager: CursorManager,
     pub cursor_texture_cache: CursorTextureCache,
@@ -2060,6 +2061,7 @@ impl Niri {
             previously_focused_window: None,
             idle_inhibiting_surfaces: HashSet::new(),
             is_fdo_idle_inhibited: Arc::new(AtomicBool::new(false)),
+            keyboard_shortcuts_inhibiting_surfaces: HashMap::new(),
             cursor_manager,
             cursor_texture_cache: Default::default(),
             cursor_shape_manager_state,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -77,6 +77,7 @@ use smithay::wayland::fractional_scale::FractionalScaleManagerState;
 use smithay::wayland::idle_inhibit::IdleInhibitManagerState;
 use smithay::wayland::idle_notify::IdleNotifierState;
 use smithay::wayland::input_method::{InputMethodManagerState, InputMethodSeat};
+use smithay::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitState;
 use smithay::wayland::output::OutputManagerState;
 use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraintsState};
 use smithay::wayland::pointer_gestures::PointerGesturesState;
@@ -131,6 +132,7 @@ use crate::protocols::gamma_control::GammaControlManagerState;
 use crate::protocols::mutter_x11_interop::MutterX11InteropManagerState;
 use crate::protocols::output_management::OutputManagementManagerState;
 use crate::protocols::screencopy::{Screencopy, ScreencopyBuffer, ScreencopyManagerState};
+use crate::protocols::virtual_pointer::VirtualPointerManagerState;
 use crate::pw_utils::{Cast, PipeWire};
 #[cfg(feature = "xdp-gnome-screencast")]
 use crate::pw_utils::{CastSizeChange, CastTarget, PwToNiri};
@@ -252,7 +254,9 @@ pub struct Niri {
     pub tablet_state: TabletManagerState,
     pub text_input_state: TextInputManagerState,
     pub input_method_state: InputMethodManagerState,
+    pub keyboard_shortcuts_inhibit_state: KeyboardShortcutsInhibitState,
     pub virtual_keyboard_state: VirtualKeyboardManagerState,
+    pub virtual_pointer_state: VirtualPointerManagerState,
     pub pointer_gestures_state: PointerGesturesState,
     pub relative_pointer_state: RelativePointerManagerState,
     pub pointer_constraints_state: PointerConstraintsState,
@@ -1818,11 +1822,16 @@ impl Niri {
             InputMethodManagerState::new::<State, _>(&display_handle, |client| {
                 !client.get_data::<ClientState>().unwrap().restricted
             });
+        let keyboard_shortcuts_inhibit_state =
+            KeyboardShortcutsInhibitState::new::<State>(&display_handle);
         let virtual_keyboard_state =
             VirtualKeyboardManagerState::new::<State, _>(&display_handle, |client| {
                 !client.get_data::<ClientState>().unwrap().restricted
             });
-
+        let virtual_pointer_state =
+            VirtualPointerManagerState::new::<State, _>(&display_handle, |client| {
+                !client.get_data::<ClientState>().unwrap().restricted
+            });
         let foreign_toplevel_state =
             ForeignToplevelManagerState::new::<State, _>(&display_handle, |client| {
                 !client.get_data::<ClientState>().unwrap().restricted
@@ -2014,7 +2023,9 @@ impl Niri {
             xdg_foreign_state,
             text_input_state,
             input_method_state,
+            keyboard_shortcuts_inhibit_state,
             virtual_keyboard_state,
+            virtual_pointer_state,
             shm_state,
             output_manager_state,
             dmabuf_state,

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -3,5 +3,6 @@ pub mod gamma_control;
 pub mod mutter_x11_interop;
 pub mod output_management;
 pub mod screencopy;
+pub mod virtual_pointer;
 
 pub mod raw;

--- a/src/protocols/virtual_pointer.rs
+++ b/src/protocols/virtual_pointer.rs
@@ -1,0 +1,193 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+
+use smithay::output::Output;
+use smithay::reexports::wayland_protocols_wlr;
+use smithay::reexports::wayland_server::backend::ClientId;
+use smithay::reexports::wayland_server::{
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+};
+use wayland_protocols_wlr::virtual_pointer::v1::server::{
+    zwlr_virtual_pointer_manager_v1, zwlr_virtual_pointer_v1,
+};
+use zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1;
+use zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1;
+
+const VERSION: u32 = 2;
+
+pub struct VirtualPointerManagerState {
+    virtual_pointers: Vec<ZwlrVirtualPointerV1>,
+}
+
+pub struct VirtualPointerManagerGlobalData {
+    filter: Box<dyn for<'c> Fn(&'c Client) -> bool + Send + Sync>,
+}
+
+pub trait VirtualPointerHandler {
+    fn virtual_pointer_manager_state(&mut self) -> &mut VirtualPointerManagerState;
+}
+
+pub struct VirtualPointerState {}
+
+impl VirtualPointerManagerState {
+    pub fn new<D, F>(display: &DisplayHandle, filter: F) -> Self
+    where
+        D: GlobalDispatch<ZwlrVirtualPointerManagerV1, VirtualPointerManagerGlobalData>,
+        D: Dispatch<ZwlrVirtualPointerManagerV1, ()>,
+        D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerState>,
+        D: VirtualPointerHandler,
+        D: 'static,
+        F: for<'c> Fn(&'c Client) -> bool + Send + Sync + 'static,
+    {
+        let global_data = VirtualPointerManagerGlobalData {
+            filter: Box::new(filter),
+        };
+        display.create_global::<D, ZwlrVirtualPointerManagerV1, _>(VERSION, global_data);
+
+        Self {
+            virtual_pointers: Vec::new(),
+        }
+    }
+}
+
+impl<D> GlobalDispatch<ZwlrVirtualPointerManagerV1, VirtualPointerManagerGlobalData, D>
+    for VirtualPointerManagerState
+where
+    D: GlobalDispatch<ZwlrVirtualPointerManagerV1, VirtualPointerManagerGlobalData>,
+    D: Dispatch<ZwlrVirtualPointerManagerV1, ()>,
+    D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerState>,
+    D: VirtualPointerHandler,
+    D: 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        manager: New<ZwlrVirtualPointerManagerV1>,
+        _manager_state: &VirtualPointerManagerGlobalData,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(manager, ());
+    }
+
+    fn can_view(client: Client, global_data: &VirtualPointerManagerGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+impl<D> Dispatch<ZwlrVirtualPointerManagerV1, (), D> for VirtualPointerManagerState
+where
+    D: Dispatch<ZwlrVirtualPointerManagerV1, ()>,
+    D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerState>,
+    D: VirtualPointerHandler,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        _resource: &ZwlrVirtualPointerManagerV1,
+        request: <ZwlrVirtualPointerManagerV1 as Resource>::Request,
+        _data: &(),
+        _dhandle: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            zwlr_virtual_pointer_manager_v1::Request::CreateVirtualPointer { seat, id } => {
+                let virtual_pointer = data_init.init(id, VirtualPointerState {});
+                state.virtual_pointer_manager_state().virtual_pointers.push(virtual_pointer);
+            }
+            zwlr_virtual_pointer_manager_v1::Request::CreateVirtualPointerWithOutput {
+                seat,
+                output,
+                id,
+            } => {
+                info!("CreateVirtualPointerWithOutput");
+                let virtual_pointer = data_init.init(id, VirtualPointerState {});
+                state.virtual_pointer_manager_state().virtual_pointers.push(virtual_pointer);
+            }
+            zwlr_virtual_pointer_manager_v1::Request::Destroy => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> Dispatch<ZwlrVirtualPointerV1, VirtualPointerState, D> for VirtualPointerManagerState
+where
+    D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerState>,
+    D: VirtualPointerHandler,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        resource: &ZwlrVirtualPointerV1,
+        request: <ZwlrVirtualPointerV1 as Resource>::Request,
+        data: &VirtualPointerState,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            zwlr_virtual_pointer_v1::Request::Motion { time, dx, dy } => {
+                info!("Motion: {dx},{dy}");
+            }
+            zwlr_virtual_pointer_v1::Request::MotionAbsolute {
+                time,
+                x,
+                y,
+                x_extent,
+                y_extent,
+            } => {
+                info!("MotionAbsolute: {x}({x_extent}),{y}({y_extent})");
+            }
+            zwlr_virtual_pointer_v1::Request::Button {
+                time,
+                button,
+                state,
+            } => {
+                info!("Button: {button} / {state:?}");
+            }
+            zwlr_virtual_pointer_v1::Request::Axis { time, axis, value } => {
+                info!("Axis: {axis:?} / {value}");
+            }
+            zwlr_virtual_pointer_v1::Request::Frame => {
+                info!("Frame");
+            }
+            zwlr_virtual_pointer_v1::Request::AxisSource { axis_source } => {
+                info!("AxisSource: {axis_source:?}");
+            }
+            zwlr_virtual_pointer_v1::Request::AxisStop { time, axis } => {
+                info!("AxisStop: {axis:?}");
+            }
+            zwlr_virtual_pointer_v1::Request::AxisDiscrete {
+                time,
+                axis,
+                value,
+                discrete,
+            } => {
+                info!("AxisDiscrete: {axis:?} / {value} / {discrete}");
+            }
+            zwlr_virtual_pointer_v1::Request::Destroy => {
+                info!("Destroy");
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_virtual_pointer {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        smithay::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::virtual_pointer::v1::server::zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1: $crate::protocols::virtual_pointer::VirtualPointerManagerGlobalData
+        ] => $crate::protocols::virtual_pointer::VirtualPointerManagerState);
+
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::virtual_pointer::v1::server::zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1: ()
+        ] => $crate::protocols::virtual_pointer::VirtualPointerManagerState);
+
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::virtual_pointer::v1::server::zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1:  $crate::protocols::virtual_pointer::VirtualPointerState
+        ] => $crate::protocols::virtual_pointer::VirtualPointerManagerState);
+    };
+}

--- a/src/protocols/virtual_pointer.rs
+++ b/src/protocols/virtual_pointer.rs
@@ -7,8 +7,8 @@ use smithay::backend::input::{
     PointerMotionAbsoluteEvent, PointerMotionEvent, UnusedEvent,
 };
 use smithay::input::pointer::AxisFrame;
+use smithay::output::Output;
 use smithay::reexports::wayland_protocols_wlr;
-use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
 use smithay::reexports::wayland_server::protocol::wl_pointer;
 use smithay::reexports::wayland_server::protocol::wl_seat::WlSeat;
 use smithay::reexports::wayland_server::{
@@ -41,7 +41,7 @@ pub struct VirtualPointer {
 #[derive(Debug)]
 pub struct VirtualPointerUserData {
     seat: Option<WlSeat>,
-    output: Option<WlOutput>,
+    output: Option<Output>,
 
     axis_frame: Mutex<Option<AxisFrame>>,
 }
@@ -55,7 +55,7 @@ impl VirtualPointer {
         self.data().seat.as_ref()
     }
 
-    pub fn output(&self) -> Option<&WlOutput> {
+    pub fn output(&self) -> Option<&Output> {
         self.data().output.as_ref()
     }
 
@@ -355,7 +355,7 @@ where
                 seat,
                 output,
                 id,
-            } => (id, seat, output),
+            } => (id, seat, output.as_ref().and_then(Output::from_resource)),
             zwlr_virtual_pointer_manager_v1::Request::Destroy => return,
             _ => unreachable!(),
         };

--- a/src/protocols/virtual_pointer.rs
+++ b/src/protocols/virtual_pointer.rs
@@ -1,13 +1,20 @@
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
+use std::collections::HashSet;
+use std::sync::Mutex;
 
-use smithay::output::Output;
+use smithay::backend::input::{
+    AbsolutePositionEvent, Axis, AxisRelativeDirection, AxisSource, ButtonState, Device,
+    DeviceCapability, Event, InputBackend, PointerAxisEvent, PointerButtonEvent,
+    PointerMotionAbsoluteEvent, PointerMotionEvent, UnusedEvent,
+};
+use smithay::input::pointer::AxisFrame;
 use smithay::reexports::wayland_protocols_wlr;
-use smithay::reexports::wayland_server::backend::ClientId;
+use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
+use smithay::reexports::wayland_server::protocol::wl_pointer;
+use smithay::reexports::wayland_server::protocol::wl_seat::WlSeat;
 use smithay::reexports::wayland_server::{
     Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
 };
+use wayland_backend::protocol::WEnum;
 use wayland_protocols_wlr::virtual_pointer::v1::server::{
     zwlr_virtual_pointer_manager_v1, zwlr_virtual_pointer_v1,
 };
@@ -17,25 +24,273 @@ use zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1;
 const VERSION: u32 = 2;
 
 pub struct VirtualPointerManagerState {
-    virtual_pointers: Vec<ZwlrVirtualPointerV1>,
+    virtual_pointers: HashSet<ZwlrVirtualPointerV1>,
 }
 
 pub struct VirtualPointerManagerGlobalData {
     filter: Box<dyn for<'c> Fn(&'c Client) -> bool + Send + Sync>,
 }
 
-pub trait VirtualPointerHandler {
-    fn virtual_pointer_manager_state(&mut self) -> &mut VirtualPointerManagerState;
+pub struct VirtualPointerInputBackend;
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct VirtualPointer {
+    pointer: ZwlrVirtualPointerV1,
 }
 
-pub struct VirtualPointerState {}
+#[derive(Debug)]
+pub struct VirtualPointerUserData {
+    seat: Option<WlSeat>,
+    output: Option<WlOutput>,
+
+    axis_frame: Mutex<Option<AxisFrame>>,
+}
+
+impl VirtualPointer {
+    fn data(&self) -> &VirtualPointerUserData {
+        self.pointer.data().unwrap()
+    }
+
+    pub fn seat(&self) -> Option<&WlSeat> {
+        self.data().seat.as_ref()
+    }
+
+    pub fn output(&self) -> Option<&WlOutput> {
+        self.data().output.as_ref()
+    }
+
+    fn finish_axis_frame(&self) -> Option<AxisFrame> {
+        self.data().axis_frame.lock().unwrap().take()
+    }
+
+    fn mutate_axis_frame(&self, time: Option<u32>, f: impl FnOnce(AxisFrame) -> AxisFrame) {
+        let mut frame = self.data().axis_frame.lock().unwrap();
+
+        *frame = frame.or(time.map(AxisFrame::new)).map(f);
+    }
+}
+
+impl Device for VirtualPointer {
+    fn id(&self) -> String {
+        format!("wlr virtual pointer {}", self.pointer.id())
+    }
+
+    fn name(&self) -> String {
+        String::from("virtual pointer")
+    }
+
+    fn has_capability(&self, capability: DeviceCapability) -> bool {
+        matches!(capability, DeviceCapability::Pointer)
+    }
+
+    fn usb_id(&self) -> Option<(u32, u32)> {
+        None
+    }
+
+    fn syspath(&self) -> Option<std::path::PathBuf> {
+        None
+    }
+}
+
+pub struct VirtualPointerMotionEvent {
+    pointer: VirtualPointer,
+    time: u32,
+    dx: f64,
+    dy: f64,
+}
+
+impl Event<VirtualPointerInputBackend> for VirtualPointerMotionEvent {
+    fn time(&self) -> u64 {
+        self.time as u64 * 1000 // millis to micros
+    }
+
+    fn device(&self) -> VirtualPointer {
+        self.pointer.clone()
+    }
+}
+
+impl PointerMotionEvent<VirtualPointerInputBackend> for VirtualPointerMotionEvent {
+    fn delta_x(&self) -> f64 {
+        self.dx
+    }
+
+    fn delta_y(&self) -> f64 {
+        self.dy
+    }
+
+    fn delta_x_unaccel(&self) -> f64 {
+        self.dx
+    }
+
+    fn delta_y_unaccel(&self) -> f64 {
+        self.dy
+    }
+}
+
+pub struct VirtualPointerMotionAbsoluteEvent {
+    pointer: VirtualPointer,
+    time: u32,
+    x: u32,
+    y: u32,
+    x_extent: u32,
+    y_extent: u32,
+}
+
+impl Event<VirtualPointerInputBackend> for VirtualPointerMotionAbsoluteEvent {
+    fn time(&self) -> u64 {
+        self.time as u64 * 1000 // millis to micros
+    }
+
+    fn device(&self) -> VirtualPointer {
+        self.pointer.clone()
+    }
+}
+
+impl AbsolutePositionEvent<VirtualPointerInputBackend> for VirtualPointerMotionAbsoluteEvent {
+    fn x(&self) -> f64 {
+        self.x as f64 / self.x_extent as f64
+    }
+
+    fn y(&self) -> f64 {
+        self.y as f64 / self.y_extent as f64
+    }
+
+    fn x_transformed(&self, width: i32) -> f64 {
+        (self.x as i64 * width as i64) as f64 / self.x_extent as f64
+    }
+
+    fn y_transformed(&self, height: i32) -> f64 {
+        (self.y as i64 * height as i64) as f64 / self.y_extent as f64
+    }
+}
+
+pub struct VirtualPointerButtonEvent {
+    pointer: VirtualPointer,
+    time: u32,
+    button: u32,
+    state: ButtonState,
+}
+
+impl Event<VirtualPointerInputBackend> for VirtualPointerButtonEvent {
+    fn time(&self) -> u64 {
+        self.time as u64 * 1000 // millis to micros
+    }
+
+    fn device(&self) -> VirtualPointer {
+        self.pointer.clone()
+    }
+}
+
+impl PointerButtonEvent<VirtualPointerInputBackend> for VirtualPointerButtonEvent {
+    fn button_code(&self) -> u32 {
+        self.button
+    }
+
+    fn state(&self) -> ButtonState {
+        self.state
+    }
+}
+
+pub struct VirtualPointerAxisEvent {
+    pointer: VirtualPointer,
+    frame: AxisFrame,
+}
+
+impl Event<VirtualPointerInputBackend> for VirtualPointerAxisEvent {
+    fn time(&self) -> u64 {
+        self.frame.time as u64 * 1000 // millis to micros
+    }
+
+    fn device(&self) -> VirtualPointer {
+        self.pointer.clone()
+    }
+}
+
+fn tuple_axis<T>(tuple: (T, T), axis: Axis) -> T {
+    match axis {
+        Axis::Horizontal => tuple.0,
+        Axis::Vertical => tuple.1,
+    }
+}
+
+impl PointerAxisEvent<VirtualPointerInputBackend> for VirtualPointerAxisEvent {
+    fn amount(&self, axis: Axis) -> Option<f64> {
+        Some(tuple_axis(self.frame.axis, axis))
+    }
+
+    fn amount_v120(&self, axis: Axis) -> Option<f64> {
+        self.frame.v120.map(|v120| tuple_axis(v120, axis) as f64)
+    }
+
+    fn source(&self) -> AxisSource {
+        self.frame.source.unwrap_or_else(|| {
+            warn!("AxisSource: no source set, giving bogus value");
+            AxisSource::Continuous
+        })
+    }
+
+    fn relative_direction(&self, axis: Axis) -> AxisRelativeDirection {
+        tuple_axis(self.frame.relative_direction, axis)
+    }
+}
+
+impl PointerMotionAbsoluteEvent<VirtualPointerInputBackend> for VirtualPointerMotionAbsoluteEvent {}
+
+impl InputBackend for VirtualPointerInputBackend {
+    type Device = VirtualPointer;
+
+    type KeyboardKeyEvent = UnusedEvent;
+    type PointerAxisEvent = VirtualPointerAxisEvent;
+    type PointerButtonEvent = VirtualPointerButtonEvent;
+    type PointerMotionEvent = VirtualPointerMotionEvent;
+    type PointerMotionAbsoluteEvent = VirtualPointerMotionAbsoluteEvent;
+
+    type GestureSwipeBeginEvent = UnusedEvent;
+    type GestureSwipeUpdateEvent = UnusedEvent;
+    type GestureSwipeEndEvent = UnusedEvent;
+    type GesturePinchBeginEvent = UnusedEvent;
+    type GesturePinchUpdateEvent = UnusedEvent;
+    type GesturePinchEndEvent = UnusedEvent;
+    type GestureHoldBeginEvent = UnusedEvent;
+    type GestureHoldEndEvent = UnusedEvent;
+
+    type TouchDownEvent = UnusedEvent;
+    type TouchUpEvent = UnusedEvent;
+    type TouchMotionEvent = UnusedEvent;
+    type TouchCancelEvent = UnusedEvent;
+    type TouchFrameEvent = UnusedEvent;
+    type TabletToolAxisEvent = UnusedEvent;
+    type TabletToolProximityEvent = UnusedEvent;
+    type TabletToolTipEvent = UnusedEvent;
+    type TabletToolButtonEvent = UnusedEvent;
+
+    type SwitchToggleEvent = UnusedEvent;
+
+    type SpecialEvent = UnusedEvent;
+}
+
+pub trait VirtualPointerHandler {
+    fn virtual_pointer_manager_state(&mut self) -> &mut VirtualPointerManagerState;
+
+    fn create_virtual_pointer(&mut self, pointer: VirtualPointer) {
+        let _ = pointer;
+    }
+    fn destroy_virtual_pointer(&mut self, pointer: VirtualPointer) {
+        let _ = pointer;
+    }
+
+    fn on_virtual_pointer_motion(&mut self, event: VirtualPointerMotionEvent);
+    fn on_virtual_pointer_motion_absolute(&mut self, event: VirtualPointerMotionAbsoluteEvent);
+    fn on_virtual_pointer_button(&mut self, event: VirtualPointerButtonEvent);
+    fn on_virtual_pointer_axis(&mut self, event: VirtualPointerAxisEvent);
+}
 
 impl VirtualPointerManagerState {
     pub fn new<D, F>(display: &DisplayHandle, filter: F) -> Self
     where
         D: GlobalDispatch<ZwlrVirtualPointerManagerV1, VirtualPointerManagerGlobalData>,
         D: Dispatch<ZwlrVirtualPointerManagerV1, ()>,
-        D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerState>,
+        D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerUserData>,
         D: VirtualPointerHandler,
         D: 'static,
         F: for<'c> Fn(&'c Client) -> bool + Send + Sync + 'static,
@@ -46,7 +301,7 @@ impl VirtualPointerManagerState {
         display.create_global::<D, ZwlrVirtualPointerManagerV1, _>(VERSION, global_data);
 
         Self {
-            virtual_pointers: Vec::new(),
+            virtual_pointers: HashSet::new(),
         }
     }
 }
@@ -56,7 +311,7 @@ impl<D> GlobalDispatch<ZwlrVirtualPointerManagerV1, VirtualPointerManagerGlobalD
 where
     D: GlobalDispatch<ZwlrVirtualPointerManagerV1, VirtualPointerManagerGlobalData>,
     D: Dispatch<ZwlrVirtualPointerManagerV1, ()>,
-    D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerState>,
+    D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerUserData>,
     D: VirtualPointerHandler,
     D: 'static,
 {
@@ -79,7 +334,7 @@ where
 impl<D> Dispatch<ZwlrVirtualPointerManagerV1, (), D> for VirtualPointerManagerState
 where
     D: Dispatch<ZwlrVirtualPointerManagerV1, ()>,
-    D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerState>,
+    D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerUserData>,
     D: VirtualPointerHandler,
     D: 'static,
 {
@@ -92,44 +347,63 @@ where
         _dhandle: &DisplayHandle,
         data_init: &mut DataInit<'_, D>,
     ) {
-        match request {
+        let (id, seat, output) = match request {
             zwlr_virtual_pointer_manager_v1::Request::CreateVirtualPointer { seat, id } => {
-                let virtual_pointer = data_init.init(id, VirtualPointerState {});
-                state.virtual_pointer_manager_state().virtual_pointers.push(virtual_pointer);
+                (id, seat, None)
             }
             zwlr_virtual_pointer_manager_v1::Request::CreateVirtualPointerWithOutput {
                 seat,
                 output,
                 id,
-            } => {
-                info!("CreateVirtualPointerWithOutput");
-                let virtual_pointer = data_init.init(id, VirtualPointerState {});
-                state.virtual_pointer_manager_state().virtual_pointers.push(virtual_pointer);
-            }
-            zwlr_virtual_pointer_manager_v1::Request::Destroy => {}
+            } => (id, seat, output),
+            zwlr_virtual_pointer_manager_v1::Request::Destroy => return,
             _ => unreachable!(),
-        }
+        };
+
+        let pointer = data_init.init(
+            id,
+            VirtualPointerUserData {
+                seat,
+                output,
+                axis_frame: Mutex::new(None),
+            },
+        );
+        state
+            .virtual_pointer_manager_state()
+            .virtual_pointers
+            .insert(pointer.clone());
+
+        state.create_virtual_pointer(VirtualPointer { pointer });
     }
 }
 
-impl<D> Dispatch<ZwlrVirtualPointerV1, VirtualPointerState, D> for VirtualPointerManagerState
+impl<D> Dispatch<ZwlrVirtualPointerV1, VirtualPointerUserData, D> for VirtualPointerManagerState
 where
-    D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerState>,
+    D: Dispatch<ZwlrVirtualPointerV1, VirtualPointerUserData>,
     D: VirtualPointerHandler,
     D: 'static,
 {
     fn request(
-        state: &mut D,
+        handler: &mut D,
         _client: &Client,
         resource: &ZwlrVirtualPointerV1,
         request: <ZwlrVirtualPointerV1 as Resource>::Request,
-        data: &VirtualPointerState,
+        _data: &VirtualPointerUserData,
         _dhandle: &DisplayHandle,
         _data_init: &mut DataInit<'_, D>,
     ) {
+        let pointer = VirtualPointer {
+            pointer: resource.clone(),
+        };
         match request {
             zwlr_virtual_pointer_v1::Request::Motion { time, dx, dy } => {
-                info!("Motion: {dx},{dy}");
+                let event = VirtualPointerMotionEvent {
+                    pointer,
+                    time,
+                    dx,
+                    dy,
+                };
+                handler.on_virtual_pointer_motion(event);
             }
             zwlr_virtual_pointer_v1::Request::MotionAbsolute {
                 time,
@@ -138,26 +412,93 @@ where
                 x_extent,
                 y_extent,
             } => {
-                info!("MotionAbsolute: {x}({x_extent}),{y}({y_extent})");
+                let event = VirtualPointerMotionAbsoluteEvent {
+                    pointer,
+                    time,
+                    x,
+                    y,
+                    x_extent,
+                    y_extent,
+                };
+                handler.on_virtual_pointer_motion_absolute(event);
             }
             zwlr_virtual_pointer_v1::Request::Button {
                 time,
                 button,
                 state,
             } => {
-                info!("Button: {button} / {state:?}");
+                // state is an enum but wlroots treats it as a C boolean (zero or nonzero)
+                // so we emulate that behaviour too. ButtonState::Pressed and any invalid value
+                // counts as pressed.
+                // https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/3187479c07c34a4de82c06a316a763a36a0499da/types/wlr_virtual_pointer_v1.c#L74
+                let state = match state {
+                    WEnum::Value(wl_pointer::ButtonState::Released) => ButtonState::Released,
+                    _ => ButtonState::Pressed,
+                };
+                let event = VirtualPointerButtonEvent {
+                    pointer,
+                    time,
+                    button,
+                    state,
+                };
+                handler.on_virtual_pointer_button(event);
             }
             zwlr_virtual_pointer_v1::Request::Axis { time, axis, value } => {
-                info!("Axis: {axis:?} / {value}");
+                let axis = match axis {
+                    WEnum::Value(wl_pointer::Axis::VerticalScroll) => Axis::Vertical,
+                    WEnum::Value(wl_pointer::Axis::HorizontalScroll) => Axis::Horizontal,
+                    _ => {
+                        warn!("Axis: invalid axis");
+                        resource.post_error(
+                            zwlr_virtual_pointer_v1::Error::InvalidAxis,
+                            "invalid axis",
+                        );
+                        return;
+                    }
+                };
+
+                pointer.mutate_axis_frame(Some(time), |frame| frame.value(axis, value));
             }
             zwlr_virtual_pointer_v1::Request::Frame => {
-                info!("Frame");
+                if let Some(frame) = pointer.finish_axis_frame() {
+                    let event = VirtualPointerAxisEvent { pointer, frame };
+                    handler.on_virtual_pointer_axis(event);
+                }
             }
             zwlr_virtual_pointer_v1::Request::AxisSource { axis_source } => {
-                info!("AxisSource: {axis_source:?}");
+                let axis_source = match axis_source {
+                    WEnum::Value(wl_pointer::AxisSource::Wheel) => AxisSource::Wheel,
+                    WEnum::Value(wl_pointer::AxisSource::Finger) => AxisSource::Finger,
+                    WEnum::Value(wl_pointer::AxisSource::Continuous) => AxisSource::Continuous,
+                    WEnum::Value(wl_pointer::AxisSource::WheelTilt) => AxisSource::WheelTilt,
+
+                    _ => {
+                        warn!("AxisSource: invalid axis source");
+                        resource.post_error(
+                            zwlr_virtual_pointer_v1::Error::InvalidAxisSource,
+                            "invalid axis source",
+                        );
+                        return;
+                    }
+                };
+
+                pointer.mutate_axis_frame(None, |frame| frame.source(axis_source));
             }
             zwlr_virtual_pointer_v1::Request::AxisStop { time, axis } => {
-                info!("AxisStop: {axis:?}");
+                let axis = match axis {
+                    WEnum::Value(wl_pointer::Axis::VerticalScroll) => Axis::Vertical,
+                    WEnum::Value(wl_pointer::Axis::HorizontalScroll) => Axis::Horizontal,
+                    _ => {
+                        warn!("AxisStop: invalid axis");
+                        resource.post_error(
+                            zwlr_virtual_pointer_v1::Error::InvalidAxis,
+                            "invalid axis",
+                        );
+                        return;
+                    }
+                };
+
+                pointer.mutate_axis_frame(Some(time), |frame| frame.stop(axis));
             }
             zwlr_virtual_pointer_v1::Request::AxisDiscrete {
                 time,
@@ -165,13 +506,42 @@ where
                 value,
                 discrete,
             } => {
-                info!("AxisDiscrete: {axis:?} / {value} / {discrete}");
+                let axis = match axis {
+                    WEnum::Value(wl_pointer::Axis::VerticalScroll) => Axis::Vertical,
+                    WEnum::Value(wl_pointer::Axis::HorizontalScroll) => Axis::Horizontal,
+                    _ => {
+                        warn!("AxisDiscrete: invalid axis");
+                        resource.post_error(
+                            zwlr_virtual_pointer_v1::Error::InvalidAxis,
+                            "invalid axis",
+                        );
+                        return;
+                    }
+                };
+                pointer.mutate_axis_frame(Some(time), |frame| {
+                    frame.value(axis, value).v120(axis, discrete)
+                });
             }
-            zwlr_virtual_pointer_v1::Request::Destroy => {
-                info!("Destroy");
-            }
+            zwlr_virtual_pointer_v1::Request::Destroy => {}
             _ => unreachable!(),
         }
+    }
+
+    fn destroyed(
+        handler: &mut D,
+        _client: wayland_backend::server::ClientId,
+        resource: &ZwlrVirtualPointerV1,
+        _data: &VirtualPointerUserData,
+    ) {
+        let pointer = VirtualPointer {
+            pointer: resource.clone(),
+        };
+
+        handler.destroy_virtual_pointer(pointer);
+        handler
+            .virtual_pointer_manager_state()
+            .virtual_pointers
+            .remove(resource);
     }
 }
 
@@ -180,14 +550,14 @@ macro_rules! delegate_virtual_pointer {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
         smithay::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             smithay::reexports::wayland_protocols_wlr::virtual_pointer::v1::server::zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1: $crate::protocols::virtual_pointer::VirtualPointerManagerGlobalData
-        ] => $crate::protocols::virtual_pointer::VirtualPointerManagerState);
+            ] => $crate::protocols::virtual_pointer::VirtualPointerManagerState);
 
         smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             smithay::reexports::wayland_protocols_wlr::virtual_pointer::v1::server::zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1: ()
         ] => $crate::protocols::virtual_pointer::VirtualPointerManagerState);
 
         smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            smithay::reexports::wayland_protocols_wlr::virtual_pointer::v1::server::zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1:  $crate::protocols::virtual_pointer::VirtualPointerState
+            smithay::reexports::wayland_protocols_wlr::virtual_pointer::v1::server::zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1:  $crate::protocols::virtual_pointer::VirtualPointerUserData
         ] => $crate::protocols::virtual_pointer::VirtualPointerManagerState);
     };
 }


### PR DESCRIPTION
My motivation for this is the use of KVM switching software, in particular i noticed that [`lan-mouse`](https://github.com/feschber/lan-mouse) requires them (hence my branch name).

Two things need to be done:

- Please someone check that what i am doing with pointer axis frames is sane. This was painful. It works. Smithay docs refer to a nonexistent function so i had to check 2-year-old git blames to find out what replaced it. We just ignore the axis source if it's done before an arbitrary other thing?? Help.
- Need to implement a keyboard-shortcuts-inhibit release bind. The current implementation already doesn't inhibit the `ChangeVt` binds ever.

You can try the functionality of both of these protocols using `lan-mouse --test-emulation` (will cause the pointer to move in a lemniscate) or `lan-mouse --test-capture` (WARNING: YOUR FOCUS WILL BE UNRECOVERABLE FROM WITHIN NIRI. use `Ctrl+Alt+F2` and then `pkill -f test-capture` to recover. the `Ctrl+Alt+{F1..F12}` binds are the `ChangeVt` binds i've mentioned already)

Another thing i've noticed is that virtual-keyboard inputs aren't ever handled by the compositor (i.e. `Super+Left` is passed to whatever client, instead of focusing the column to the left)? This is irrelevant to this PR, but something i noticed while using lan-mouse. This is probably a Smithay issue? Since it's uhh mostly implemented in Smithay.