### PR TITLE
implement `always_center_single_column` layout option

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -397,6 +397,8 @@ pub struct Layout {
     pub default_column_width: Option<DefaultColumnWidth>,
     #[knuffel(child, unwrap(argument), default)]
     pub center_focused_column: CenterFocusedColumn,
+    #[knuffel(child)]
+    pub always_center_single_column: bool,
     #[knuffel(child, unwrap(argument), default = Self::default().gaps)]
     pub gaps: FloatOrInt<0, 65535>,
     #[knuffel(child, default)]
@@ -411,6 +413,7 @@ impl Default for Layout {
             preset_column_widths: Default::default(),
             default_column_width: Default::default(),
             center_focused_column: Default::default(),
+            always_center_single_column: false,
             gaps: FloatOrInt(16.),
             struts: Default::default(),
         }
@@ -3057,6 +3060,7 @@ mod tests {
                         bottom: FloatOrInt(0.),
                     },
                     center_focused_column: CenterFocusedColumn::OnOverflow,
+                    always_center_single_column: false,
                 },
                 spawn_at_startup: vec![SpawnAtStartup {
                     command: vec!["alacritty".to_owned(), "-e".to_owned(), "fish".to_owned()],

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -236,6 +236,7 @@ pub struct Options {
     pub focus_ring: niri_config::FocusRing,
     pub border: niri_config::Border,
     pub center_focused_column: CenterFocusedColumn,
+    pub always_center_single_column: bool,
     /// Column widths that `toggle_width()` switches between.
     pub preset_widths: Vec<ColumnWidth>,
     /// Initial width for new columns.
@@ -255,6 +256,7 @@ impl Default for Options {
             focus_ring: Default::default(),
             border: Default::default(),
             center_focused_column: Default::default(),
+            always_center_single_column: false,
             preset_widths: vec![
                 ColumnWidth::Proportion(1. / 3.),
                 ColumnWidth::Proportion(0.5),
@@ -297,6 +299,7 @@ impl Options {
             focus_ring: layout.focus_ring,
             border: layout.border,
             center_focused_column: layout.center_focused_column,
+            always_center_single_column: layout.always_center_single_column,
             preset_widths,
             default_width,
             animations: config.animations.clone(),
@@ -4455,11 +4458,13 @@ mod tests {
             focus_ring in arbitrary_focus_ring(),
             border in arbitrary_border(),
             center_focused_column in arbitrary_center_focused_column(),
+            always_center_single_column in any::<bool>(),
         ) -> Options {
             Options {
                 gaps,
                 struts,
                 center_focused_column,
+                always_center_single_column,
                 focus_ring,
                 border,
                 ..Default::default()


### PR DESCRIPTION
This option basically configures niri such that, regardless of the center focused column option, windows are centered if there's only one column in the workspace.