### PR TITLE
flake: add libdisplay-info to buildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
             systemd # For libudev
             seatd # For libseat
             libxkbcommon
+            libdisplay-info
             libinput
             mesa # For libgbm
             fontconfig


### PR DESCRIPTION
see also https://github.com/sodiboo/niri-flake/commit/e2f5c2e01e05241c438652fc7c0c8a6c9c35ed68

i tested this on my own system with both `nix build .` and `cargo build --release`. both fail as-is. both succeed with this change.