### PR TITLE
implement locked cursor position hints

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -154,31 +154,35 @@ impl PointerConstraintsHandler for State {
             constraint.map_or(false, |c| c.is_active())
         });
 
-        if is_constraint_active {
-            if let Some((ref focused_surface, origin)) = self.niri.pointer_focus.surface {
-                if focused_surface == surface {
-                    let mut root = surface.clone();
-                    while let Some(parent) = get_parent(&root) {
-                        root = parent;
-                    }
-
-                    let target = self
-                        .niri
-                        .output_for_root(&root)
-                        .and_then(|output| self.niri.global_space.output_geometry(output))
-                        .map_or(origin + location, |mut output_geometry| {
-                            // i32 sizes are exclusive, but f64 sizes are inclusive.
-                            output_geometry.size -= (1, 1).into();
-                            (origin + location).constrain(output_geometry.to_f64())
-                        });
-                    pointer.set_location(target);
-                } else {
-                    error!("cursor_position_hint called on a surface that is not the focused surface, but the constraint is active. this should be impossible.");
-                }
-            } else {
-                error!("cursor_position_hint called with no focused surface, but the constraint is active. this should be impossible.");
-            }
+        if !is_constraint_active {
+            return;
         }
+
+        let Some((ref focused_surface, origin)) = self.niri.pointer_focus.surface else {
+            error!("cursor_position_hint called with no focused surface, but the constraint is active. this should be impossible.");
+            return;
+        };
+
+        if focused_surface != surface {
+            error!("cursor_position_hint called on a surface that is not the focused surface, but the constraint is active. this should be impossible.");
+            return;
+        }
+
+        let mut root = surface.clone();
+        while let Some(parent) = get_parent(&root) {
+            root = parent;
+        }
+
+        let target = self
+            .niri
+            .output_for_root(&root)
+            .and_then(|output| self.niri.global_space.output_geometry(output))
+            .map_or(origin + location, |mut output_geometry| {
+                // i32 sizes are exclusive, but f64 sizes are inclusive.
+                output_geometry.size -= (1, 1).into();
+                (origin + location).constrain(output_geometry.to_f64())
+            });
+        pointer.set_location(target);
     }
 }
 delegate_pointer_constraints!(State);

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -158,19 +158,19 @@ impl PointerConstraintsHandler for State {
             return;
         }
 
+        // Logically the following two checks should always succeed (so, they should print
+        // error!()s if they fail). However, currently both can fail because niri's pointer focus
+        // doesn't take pointer grabs into account. So if you start, say, a middle-drag in Blender,
+        // then touchpad-swipe the window away, the niri pointer focus will change, even though the
+        // real pointer focus remains on the Blender surface due to the click grab.
+        //
+        // FIXME: add error!()s when niri pointer focus takes grabs into account. Alternatively,
+        // recompute the surface origin here (but that is a bit clunky).
         let Some((ref focused_surface, origin)) = self.niri.pointer_focus.surface else {
-            error!(
-                "cursor_position_hint called with no focused surface, \
-                 but the constraint is active; this should be impossible"
-            );
             return;
         };
 
         if focused_surface != surface {
-            error!(
-                "cursor_position_hint called on a surface that is not the focused surface, \
-                 but the constraint is active; this should be impossible"
-            );
             return;
         }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -148,7 +148,7 @@ impl PointerConstraintsHandler for State {
         &mut self,
         surface: &WlSurface,
         pointer: &PointerHandle<Self>,
-        location: smithay::utils::Point<f64, Logical>,
+        location: Point<f64, Logical>,
     ) {
         let is_constraint_active = with_pointer_constraint(surface, pointer, |constraint| {
             constraint.map_or(false, |c| c.is_active())

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -159,12 +159,18 @@ impl PointerConstraintsHandler for State {
         }
 
         let Some((ref focused_surface, origin)) = self.niri.pointer_focus.surface else {
-            error!("cursor_position_hint called with no focused surface, but the constraint is active. this should be impossible.");
+            error!(
+                "cursor_position_hint called with no focused surface, \
+                 but the constraint is active; this should be impossible"
+            );
             return;
         };
 
         if focused_surface != surface {
-            error!("cursor_position_hint called on a surface that is not the focused surface, but the constraint is active. this should be impossible.");
+            error!(
+                "cursor_position_hint called on a surface that is not the focused surface, \
+                 but the constraint is active; this should be impossible"
+            );
             return;
         }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -189,6 +189,12 @@ impl PointerConstraintsHandler for State {
                 (origin + location).constrain(output_geometry.to_f64())
             });
         pointer.set_location(target);
+
+        // Redraw to update the cursor position if it's visible.
+        if !self.niri.pointer_hidden {
+            // FIXME: redraw only outputs overlapping the cursor.
+            self.niri.queue_redraw_all();
+        }
     }
 }
 delegate_pointer_constraints!(State);


### PR DESCRIPTION
~~Firstly, this PR updates Smithay to latest master fixing stuff along the way~~ (superseded by https://github.com/YaLTeR/niri/commit/eb190e3f9447e4d49cfdcb5a0093443ca8b684fe) and also fixes a clippy lint in the ~~second~~ first commit.

The ~~third~~ second commit implements cursor position hints for locked pointers.

Clients which hold a locked pointer may send a [zwp_locked_pointer_v1::set_cursor_position_hint](https://wayland.app/protocols/pointer-constraints-unstable-v1#zwp_locked_pointer_v1:request:set_cursor_position_hint) which we currently ignore. This leads to annoying behaviour, detailed below.

This is based off a Smithay PR, and is going to be a draft until that PR is merged into Smithay:
- https://github.com/Smithay/smithay/pull/1551

---

I ran into this while working on [an improved Wayland backend](https://github.com/sodiboo/niri/tree/wayland-backend) to fix some annoyances with the winit backend. One such thing is more seamless pointer handling; to properly support features such as `warp-mouse-to-focus` and internal pointer constraints, i must use the pointer constraints protocol in that backend. Since niri already has cursor compositing functionality baked in, it only makes sense to use this while niri has cursor focus. However, when the niri wayland backend loses cursor focus, the parent compositor (which is also niri, in my case) should know where the cursor actually is, because otherwise it can be really disorienting for a user.

Let's introduce some names to these branches of niri, and how to tell them apart in the videos i'm about to show you:

- the latest commit from niri's main branch as i write and record this is https://github.com/YaLTeR/niri/commit/6ee5b5afa784c76b1c31c371b59177136e558fa6. It is just after niri 0.1.9, and i have it installed as my main session. For the main graphical session, i have an orange Firewatch wallpaper.
- the "location hint" / "position hint" branch of niri is the one in this PR. It is built off the latest commit from niri's main branch, and in particular https://github.com/sodiboo/niri/commit/b5bb92f6dd7334cde9111ab4d6cfcf0b299ac24e is the one shown in these videos (which is based on https://github.com/sodiboo/smithay/commit/0739c87a1780ccffefc2d7034b29df8e117bc59e). This is not my main session; i ran it as a standalone instance of niri on a separate TTY. As such, it has a modulated wallpaper to tell it apart.
- the Wayland backend is what i've been mostly working on. It is based on a version of niri just before 0.1.9, and in particular https://github.com/sodiboo/niri/commit/20e976749755d1ce615f178264761a70b18a8f92 is the one i've been using to test the pointer hint functionality. For the purposes of this PR, this is just a Wayland client. It also has the same modulated wallpaper, because it's not the graphical login session.

The Wayland backend, aka the client shown in these videos, is correctly reporting its cursor position hint. It is the same client in both videos, and sending the same requests in both. The only difference is what the compositor (Yeah! I know the client is a compositor too, but to be clear i mean *the outermost one*) does with the position hint. It's worth noting that this cursor lock is held to allow the client to deal with its own internal pointer constraints smoothly. To ensure a seamless windowing experience, however, the lock is automatically released when the cursor touches the window edge. The intended result is that it's not obvious there is a cursor lock to begin with, but features like `warp-mouse-to-focus` should still "just work". Currently, in the winit backend, that *doesn't* work at all.

---

The latest commit of niri's main branch (shown in orange) simply ignores it. This leads to a disorienting mess where the cursor seems to jump around erratically. When the pointer lock is deactivated, the pointer is returned to its initial position. Because of how this client in particular behaves, you need to go several roundtrips over a window before you can pass through it, but in other clients there may not even be a guarantee that the cursor can make progress. Because the compositor ignores cursor position hints, this leads to worst-case possibility that a surface can (unintentionally!) become an impenetrable barrier for the cursor. That's not very cool.


https://github.com/user-attachments/assets/75cce59d-24a6-4703-807d-5ca154c2f4ac

However, the position hint variant from this PR (shown in blue) properly updates the pointer location hint whenever it receives a cursor position hint. Below is shown the same client; which hides the cursor and renders its own, and sends cursor position hints. The client is running the exact same commit of my Wayland backend for niri, but with the compositor supporting cursor position hints, it is now much more seamless. If you weren't paying attention really, you might think that the nested niri actually doesn't at all render a cursor, and this is *just* the outer cursor moving unimpeded across the surface. You'd be wrong.

https://github.com/user-attachments/assets/c4826cbe-5dd8-4e0b-a8af-54dc9243c300

