### PR TITLE
Fix focus-window-up-or-column-right focusing the left column

### DIFF
--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -403,7 +403,7 @@ impl<W: LayoutElement> Monitor<W> {
             let curr_idx = workspace.columns[workspace.active_column_idx].active_tile_idx;
             let new_idx = curr_idx.saturating_sub(1);
             if curr_idx == new_idx {
-                self.focus_left();
+                self.focus_right();
             } else {
                 workspace.focus_up();
             }


### PR DESCRIPTION
I'm currently trying out niri and noticed that focus-window-up-or-column-right actually focuses the left column. Seems like it's just a mix up with left and right.