### PR TITLE
flake: drop most external inputs & improve packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v3
         continue-on-error: true
 
-      - run: nix build
+      - run: nix flake check
         continue-on-error: true
 
   publish-wiki:

--- a/flake.lock
+++ b/flake.lock
@@ -34,7 +34,28 @@
     "root": {
       "inputs": {
         "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1727663505,
+        "narHash": "sha256-83j/GrHsx8GFUcQofKh+PRPz6pz8sxAsZyT/HCNdey8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c2099c6c7599ea1980151b8b6247a8f93e1806ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,60 +1,5 @@
 {
   "nodes": {
-    "crane": {
-      "locked": {
-        "lastModified": 1725409566,
-        "narHash": "sha256-PrtLmqhM6UtJP7v7IGyzjBFhbG4eOAHT6LPYOFmYfbk=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "7e4586bad4e3f8f97a9271def747cf58c4b68f3c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1725172314,
-        "narHash": "sha256-BtLY9lWu/pe6/ImFwuRRRqMwLacY5AZOKA2hUHUQ64k=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "28b42d01f549c38bd165296fbcb4fe66d98fc24f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "monthly",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nix-filter": {
       "locked": {
         "lastModified": 1710156097,
@@ -88,43 +33,8 @@
     },
     "root": {
       "inputs": {
-        "crane": "crane",
-        "fenix": "fenix",
-        "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1725094379,
-        "narHash": "sha256-TBujPMMIv8RG6BKlsBEpCln1ePmWz79xTcJOQpU2L18=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "914a1caab54e48a028b2407d0fe6fade89532f67",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -85,7 +85,7 @@
         cargoArtifacts = craneLib.buildDepsOnly craneArgs;
         niri = craneLib.buildPackage (craneArgs // {inherit cargoArtifacts;});
       in {
-        formatter = pkgs.alejandra;
+        formatter = pkgs.nixfmt-rfc-style;
 
         checks.niri = niri;
         packages.default = niri;

--- a/flake.nix
+++ b/flake.nix
@@ -13,19 +13,25 @@
     };
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    crane,
-    nix-filter,
-    flake-utils,
-    fenix,
-    ...
-  }: let
-    systems = ["aarch64-linux" "x86_64-linux"];
-  in
+  outputs =
+    {
+      self,
+      nixpkgs,
+      crane,
+      nix-filter,
+      flake-utils,
+      fenix,
+      ...
+    }:
+    let
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+    in
     flake-utils.lib.eachSystem systems (
-      system: let
+      system:
+      let
         pkgs = nixpkgs.legacyPackages.${system};
         toolchain = fenix.packages.${system}.complete.toolchain;
         craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
@@ -36,10 +42,10 @@
 
           src = nixpkgs.lib.cleanSourceWith {
             src = craneLib.path ./.;
-            filter = path: type:
+            filter =
+              path: type:
               (builtins.match "resources" path == null)
-              || ((craneLib.filterCargoSources path type)
-                && (builtins.match "niri-visual-tests" path == null));
+              || ((craneLib.filterCargoSources path type) && (builtins.match "niri-visual-tests" path == null));
           };
 
           nativeBuildInputs = with pkgs; [
@@ -83,17 +89,20 @@
         };
 
         cargoArtifacts = craneLib.buildDepsOnly craneArgs;
-        niri = craneLib.buildPackage (craneArgs // {inherit cargoArtifacts;});
-      in {
+        niri = craneLib.buildPackage (craneArgs // { inherit cargoArtifacts; });
+      in
+      {
         formatter = pkgs.nixfmt-rfc-style;
 
         checks.niri = niri;
         packages.default = niri;
 
         devShells.default = craneLib.devShell {
-          inputsFrom = [niri];
+          inputsFrom = [ niri ];
 
-          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (craneArgs.runtimeDependencies ++ craneArgs.nativeBuildInputs ++ craneArgs.buildInputs);
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (
+            craneArgs.runtimeDependencies ++ craneArgs.nativeBuildInputs ++ craneArgs.buildInputs
+          );
           inherit (niri) LIBCLANG_PATH;
         };
       }


### PR DESCRIPTION
The primary goals of this are to make this flake

- Easier to consume
  - All inputs aside from nixpkgs and (the very small) nix-filter have been removed. This is basically free as the advantages of Crane and Fenix were never really leveraged here
  - Stable Nix is now supported via [flake-compat](https://github.com/edolstra/flake-compat)
  - `niri` is now overridable
  - Important Cargo build features can be set by the user like so (the defaults are unchanged)
  
  ```nix
  niri.override { withScreencastingSupport = false; }
  ```
- Follow community best practices
  - `callPackage` is used for the package expression, making it much easier to share code between here, nixpkgs, and anywhere else
  - `alejandra` has been replaced with `nixfmt-rfc-style`, the now [standard](https://github.com/NixOS/rfcs/blob/62d1245ec1eae275edb996229585637035c02538/rfcs/0166-nix-formatting.md) formatter of Nix code
  - `autoPatchelfHook` is dropped in favor of forcing linkage through `ld` arguments where needed
  - Meta-attributes are now provided
  - `passthru.providedSessions` is now provided
  
See commit messages for more context