### PR TITLE
Implement Cursor Hiding While Typing & Cursor Inactive Timeout (#284)

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -615,6 +615,10 @@ pub struct Cursor {
     pub xcursor_theme: String,
     #[knuffel(child, unwrap(argument), default = 24)]
     pub xcursor_size: u8,
+    #[knuffel(child)]
+    pub hide_on_key_press: bool,
+    #[knuffel(child, unwrap(argument))]
+    pub hide_after_inactive_ms: Option<u32>,
 }
 
 impl Default for Cursor {
@@ -622,6 +626,8 @@ impl Default for Cursor {
         Self {
             xcursor_theme: String::from("default"),
             xcursor_size: 24,
+            hide_on_key_press: false,
+            hide_after_inactive_ms: None,
         }
     }
 }
@@ -2953,6 +2959,8 @@ mod tests {
             cursor {
                 xcursor-theme "breeze_cursors"
                 xcursor-size 16
+                hide-on-key-press
+                hide-after-inactive-ms 3000
             }
 
             screenshot-path "~/Screenshots/screenshot.png"
@@ -3154,6 +3162,8 @@ mod tests {
                 cursor: Cursor {
                     xcursor_theme: String::from("breeze_cursors"),
                     xcursor_size: 16,
+                    hide_on_key_press: true,
+                    hide_after_inactive_ms: Some(3000),
                 },
                 screenshot_path: Some(String::from("~/Screenshots/screenshot.png")),
                 hotkey_overlay: HotkeyOverlay {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::cmp::min;
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use calloop::timer::{TimeoutAction, Timer};
 use input::event::gesture::GestureEventCoordinates as _;
@@ -87,8 +87,8 @@ impl State {
             }
         }
 
-        if should_update_cursor_timeout(&event) {
-            self.niri.last_cursor_movement = Instant::now();
+        if should_reset_pointer_inactivity_timer(&event) {
+            self.niri.reset_pointer_inactivity_timer();
         }
 
         let hide_hotkey_overlay =
@@ -2561,7 +2561,7 @@ fn should_notify_activity<I: InputBackend>(event: &InputEvent<I>) -> bool {
     )
 }
 
-fn should_update_cursor_timeout<I: InputBackend>(event: &InputEvent<I>) -> bool {
+fn should_reset_pointer_inactivity_timer<I: InputBackend>(event: &InputEvent<I>) -> bool {
     matches!(
         event,
         InputEvent::PointerAxis { .. }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1469,6 +1469,10 @@ impl State {
         let button_state = event.state();
 
         if ButtonState::Pressed == button_state {
+            // We received an event for the regular pointer, so show it now.
+            self.niri.pointer_hidden = false;
+            self.niri.tablet_cursor_location = None;
+
             if let Some(mapped) = self.niri.window_under_cursor() {
                 let window = mapped.window.clone();
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::cmp::min;
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use calloop::timer::{TimeoutAction, Timer};
 use input::event::gesture::GestureEventCoordinates as _;
@@ -85,6 +85,10 @@ impl State {
                     .idle_notifier_state
                     .notify_activity(&self.niri.seat);
             }
+        }
+
+        if should_update_cursor_timeout(&event) {
+            self.niri.last_cursor_movement = Instant::now();
         }
 
         let hide_hotkey_overlay =
@@ -307,6 +311,10 @@ impl State {
             }
         }
 
+        if pressed {
+            self.hide_cursor_if_needed();
+        }
+
         let Some(Some(bind)) = self.niri.seat.get_keyboard().unwrap().input(
             self,
             event.key_code(),
@@ -349,7 +357,10 @@ impl State {
 
         self.handle_bind(bind.clone());
 
-        // Start the key repeat timer if necessary.
+        self.start_key_repeat(bind);
+    }
+
+    fn start_key_repeat(&mut self, bind: Bind) {
         if !bind.repeat {
             return;
         }
@@ -381,6 +392,22 @@ impl State {
             .unwrap();
 
         self.niri.bind_repeat_timer = Some(token);
+    }
+
+    fn hide_cursor_if_needed(&mut self) {
+        if !self.niri.config.borrow().cursor.hide_on_key_press {
+            return;
+        }
+
+        // niri keeps this set only while actively using a tablet, which means the cursor position
+        // is likely to change almost immediately, causing pointer_hidden to just flicker back and
+        // forth.
+        if self.niri.tablet_cursor_location.is_some() {
+            return;
+        }
+
+        self.niri.pointer_hidden = true;
+        self.niri.queue_redraw_all();
     }
 
     pub fn handle_bind(&mut self, bind: Bind) {
@@ -2531,6 +2558,20 @@ fn should_notify_activity<I: InputBackend>(event: &InputEvent<I>) -> bool {
     !matches!(
         event,
         InputEvent::DeviceAdded { .. } | InputEvent::DeviceRemoved { .. }
+    )
+}
+
+fn should_update_cursor_timeout<I: InputBackend>(event: &InputEvent<I>) -> bool {
+    matches!(
+        event,
+        InputEvent::PointerAxis { .. }
+            | InputEvent::PointerButton { .. }
+            | InputEvent::PointerMotion { .. }
+            | InputEvent::PointerMotionAbsolute { .. }
+            | InputEvent::TabletToolAxis { .. }
+            | InputEvent::TabletToolButton { .. }
+            | InputEvent::TabletToolProximity { .. }
+            | InputEvent::TabletToolTip { .. }
     )
 }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -267,7 +267,7 @@ pub struct Niri {
     /// When this happens, the pointer also loses any focus. This is so that touch can prevent
     /// various tooltips from sticking around.
     pub pointer_hidden: bool,
-    pub last_cursor_movement: Instant,
+    pub pointer_inactivity_timer: Option<RegistrationToken>,
     // FIXME: this should be able to be removed once PointerFocus takes grabs into account.
     pub pointer_grab_ongoing: bool,
     pub tablet_cursor_location: Option<Point<f64, Logical>>,
@@ -589,6 +589,7 @@ impl State {
 
         // We moved the pointer, show it.
         self.niri.pointer_hidden = false;
+        self.niri.reset_pointer_inactivity_timer();
 
         // FIXME: granular
         self.niri.queue_redraw_all();
@@ -991,6 +992,7 @@ impl State {
         let mut window_rules_changed = false;
         let mut debug_config_changed = false;
         let mut shaders_changed = false;
+        let mut cursor_inactivity_timeout_changed = false;
         let mut old_config = self.niri.config.borrow_mut();
 
         // Reload the cursor.
@@ -1077,6 +1079,10 @@ impl State {
             shaders_changed = true;
         }
 
+        if config.cursor.hide_after_inactive_ms != old_config.cursor.hide_after_inactive_ms {
+            cursor_inactivity_timeout_changed = true;
+        }
+
         if config.debug != old_config.debug {
             debug_config_changed = true;
         }
@@ -1121,6 +1127,10 @@ impl State {
 
         if shaders_changed {
             self.niri.layout.update_shaders();
+        }
+
+        if cursor_inactivity_timeout_changed {
+            self.niri.reset_pointer_inactivity_timer();
         }
 
         // Can't really update xdg-decoration settings since we have to hide the globals for CSD
@@ -1784,7 +1794,7 @@ impl Niri {
             .unwrap();
 
         drop(config_);
-        Self {
+        let mut niri = Self {
             config,
             config_file_output_config,
 
@@ -1861,7 +1871,7 @@ impl Niri {
             dnd_icon: None,
             pointer_focus: PointerFocus::default(),
             pointer_hidden: false,
-            last_cursor_movement: Instant::now(),
+            pointer_inactivity_timer: None,
             pointer_grab_ongoing: false,
             tablet_cursor_location: None,
             gesture_swipe_3f_cumulative: None,
@@ -1897,7 +1907,11 @@ impl Niri {
 
             #[cfg(feature = "xdp-gnome-screencast")]
             mapped_cast_output: HashMap::new(),
-        }
+        };
+
+        niri.reset_pointer_inactivity_timer();
+
+        niri
     }
 
     #[cfg(feature = "dbus")]
@@ -2665,26 +2679,7 @@ impl Niri {
         pointer_elements
     }
 
-    fn hide_cursor_after_timeout_if_needed(&mut self) {
-        if self.pointer_hidden {
-            return;
-        }
-
-        let config = self.config.borrow();
-        let timeout = &config.cursor.hide_after_inactive_ms;
-
-        if let Some(duration_ms) = timeout {
-            let timeout = Duration::from_millis(*duration_ms as u64);
-
-            if self.last_cursor_movement.elapsed() >= timeout {
-                self.pointer_hidden = true;
-            }
-        }
-    }
-
     pub fn refresh_pointer_outputs(&mut self) {
-        self.hide_cursor_after_timeout_if_needed();
-
         if self.pointer_hidden {
             return;
         }
@@ -4727,6 +4722,32 @@ impl Niri {
             // FIXME: granular.
             self.queue_redraw_all();
         }
+    }
+
+    pub fn reset_pointer_inactivity_timer(&mut self) {
+        let _span = tracy_client::span!("Niri::reset_pointer_inactivity_timer");
+
+        if let Some(token) = self.pointer_inactivity_timer.take() {
+            self.event_loop.remove(token);
+        }
+
+        let Some(timeout_ms) = self.config.borrow().cursor.hide_after_inactive_ms else {
+            return;
+        };
+
+        let duration = Duration::from_millis(timeout_ms as u64);
+        let timer = Timer::from_duration(duration);
+        let token = self
+            .event_loop
+            .insert_source(timer, move |_, _, state| {
+                state.niri.pointer_inactivity_timer = None;
+                state.niri.pointer_hidden = true;
+                state.niri.queue_redraw_all();
+
+                TimeoutAction::Drop
+            })
+            .unwrap();
+        self.pointer_inactivity_timer = Some(token);
     }
 }
 

--- a/wiki/Configuration:-Miscellaneous.md
+++ b/wiki/Configuration:-Miscellaneous.md
@@ -20,6 +20,9 @@ environment {
 cursor {
     xcursor-theme "breeze_cursors"
     xcursor-size 48
+
+    hide-on-key-press
+    hide-after-inactive-ms 1000
 }
 
 hotkey-overlay {
@@ -103,6 +106,31 @@ Change the theme and size of the cursor as well as set the `XCURSOR_THEME` and `
 cursor {
     xcursor-theme "breeze_cursors"
     xcursor-size 48
+}
+```
+
+#### `hide-on-key-press`
+
+<sup>Since: 0.1.10</sup>
+
+If set, hides the cursor when pressing a key on the keyboard.
+
+```kdl
+cursor {
+    hide-on-key-press
+}
+```
+
+#### `hide-after-inactive-ms`
+
+<sup>Since: 0.1.10</sup>
+
+If set, the cursor will automatically hide once this number of milliseconds passes since the last cursor movement.
+
+```kdl
+cursor {
+    // Hide the cursor after one second of inactivity.
+    hide-after-inactive-ms 1000
 }
 ```
 


### PR DESCRIPTION
This pull request addresses the discussion on #284 regarding cursor management in niri. Specifically, I have implemented the second solution: hiding the cursor while typing.

The implementation of cursor timeout (solution 1) would require active polling to check the remaining time, which is not straightforward given our current design where all cursor-related updates are triggered by events. Implementing this approach would involve finding a suitable place in the codebase to handle the periodic checks, which I found challenging due to the existing event-driven architecture.

In contrast, hiding the cursor while typing (solution 2) can be seamlessly integrated as it aligns with the existing event-driven model. This implementation is more straightforward and reduces potential complexity.

Please review the changes and let me know if any further adjustments are needed.