### PR TITLE
Fix several clippy lints; most notably by using cstr literals

### DIFF
--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -3102,14 +3102,11 @@ impl<W: LayoutElement> Column<W> {
     }
 
     pub fn advance_animations(&mut self, current_time: Duration) {
-        match &mut self.move_animation {
-            Some(anim) => {
-                anim.set_current_time(current_time);
-                if anim.is_done() {
-                    self.move_animation = None;
-                }
+        if let Some(anim) = &mut self.move_animation {
+            anim.set_current_time(current_time);
+            if anim.is_done() {
+                self.move_animation = None;
             }
-            None => (),
         }
 
         for tile in &mut self.tiles {

--- a/src/render_helpers/shader_element.rs
+++ b/src/render_helpers/shader_element.rs
@@ -88,26 +88,19 @@ unsafe fn compile_program(
     Ok(ShaderProgram(Rc::new(ShaderProgramInner {
         normal: ShaderProgramInternal {
             program,
-            uniform_matrix: gl
-                .GetUniformLocation(program, matrix.as_ptr() as *const ffi::types::GLchar),
-            uniform_tex_matrix: gl
-                .GetUniformLocation(program, tex_matrix.as_ptr() as *const ffi::types::GLchar),
-            uniform_size: gl
-                .GetUniformLocation(program, size.as_ptr() as *const ffi::types::GLchar),
-            uniform_scale: gl
-                .GetUniformLocation(program, scale.as_ptr() as *const ffi::types::GLchar),
-            uniform_alpha: gl
-                .GetUniformLocation(program, alpha.as_ptr() as *const ffi::types::GLchar),
-            attrib_vert: gl.GetAttribLocation(program, vert.as_ptr() as *const ffi::types::GLchar),
-            attrib_vert_position: gl
-                .GetAttribLocation(program, vert_position.as_ptr() as *const ffi::types::GLchar),
+            uniform_matrix: gl.GetUniformLocation(program, matrix.as_ptr()),
+            uniform_tex_matrix: gl.GetUniformLocation(program, tex_matrix.as_ptr()),
+            uniform_size: gl.GetUniformLocation(program, size.as_ptr()),
+            uniform_scale: gl.GetUniformLocation(program, scale.as_ptr()),
+            uniform_alpha: gl.GetUniformLocation(program, alpha.as_ptr()),
+            attrib_vert: gl.GetAttribLocation(program, vert.as_ptr()),
+            attrib_vert_position: gl.GetAttribLocation(program, vert_position.as_ptr()),
             additional_uniforms: additional_uniforms
                 .iter()
                 .map(|uniform| {
                     let name =
                         CString::new(uniform.name.as_bytes()).expect("Interior null in name");
-                    let location =
-                        gl.GetUniformLocation(program, name.as_ptr() as *const ffi::types::GLchar);
+                    let location = gl.GetUniformLocation(program, name.as_ptr());
                     (
                         uniform.name.clone().into_owned(),
                         UniformDesc {
@@ -121,41 +114,26 @@ unsafe fn compile_program(
                 .iter()
                 .map(|name_| {
                     let name = CString::new(name_.as_bytes()).expect("Interior null in name");
-                    let location =
-                        gl.GetUniformLocation(program, name.as_ptr() as *const ffi::types::GLchar);
+                    let location = gl.GetUniformLocation(program, name.as_ptr());
                     (name_.to_string(), location)
                 })
                 .collect(),
         },
         debug: ShaderProgramInternal {
             program: debug_program,
-            uniform_matrix: gl
-                .GetUniformLocation(debug_program, matrix.as_ptr() as *const ffi::types::GLchar),
-            uniform_tex_matrix: gl.GetUniformLocation(
-                debug_program,
-                tex_matrix.as_ptr() as *const ffi::types::GLchar,
-            ),
-            uniform_size: gl
-                .GetUniformLocation(debug_program, size.as_ptr() as *const ffi::types::GLchar),
-            uniform_scale: gl
-                .GetUniformLocation(debug_program, scale.as_ptr() as *const ffi::types::GLchar),
-            uniform_alpha: gl
-                .GetUniformLocation(debug_program, alpha.as_ptr() as *const ffi::types::GLchar),
-            attrib_vert: gl
-                .GetAttribLocation(debug_program, vert.as_ptr() as *const ffi::types::GLchar),
-            attrib_vert_position: gl.GetAttribLocation(
-                debug_program,
-                vert_position.as_ptr() as *const ffi::types::GLchar,
-            ),
+            uniform_matrix: gl.GetUniformLocation(debug_program, matrix.as_ptr()),
+            uniform_tex_matrix: gl.GetUniformLocation(debug_program, tex_matrix.as_ptr()),
+            uniform_size: gl.GetUniformLocation(debug_program, size.as_ptr()),
+            uniform_scale: gl.GetUniformLocation(debug_program, scale.as_ptr()),
+            uniform_alpha: gl.GetUniformLocation(debug_program, alpha.as_ptr()),
+            attrib_vert: gl.GetAttribLocation(debug_program, vert.as_ptr()),
+            attrib_vert_position: gl.GetAttribLocation(debug_program, vert_position.as_ptr()),
             additional_uniforms: additional_uniforms
                 .iter()
                 .map(|uniform| {
                     let name =
                         CString::new(uniform.name.as_bytes()).expect("Interior null in name");
-                    let location = gl.GetUniformLocation(
-                        debug_program,
-                        name.as_ptr() as *const ffi::types::GLchar,
-                    );
+                    let location = gl.GetUniformLocation(debug_program, name.as_ptr());
                     (
                         uniform.name.clone().into_owned(),
                         UniformDesc {
@@ -169,16 +147,12 @@ unsafe fn compile_program(
                 .iter()
                 .map(|name_| {
                     let name = CString::new(name_.as_bytes()).expect("Interior null in name");
-                    let location = gl.GetUniformLocation(
-                        debug_program,
-                        name.as_ptr() as *const ffi::types::GLchar,
-                    );
+                    let location = gl.GetUniformLocation(debug_program, name.as_ptr());
                     (name_.to_string(), location)
                 })
                 .collect(),
         },
-        uniform_tint: gl
-            .GetUniformLocation(debug_program, tint.as_ptr() as *const ffi::types::GLchar),
+        uniform_tint: gl.GetUniformLocation(debug_program, tint.as_ptr()),
     })))
 }
 

--- a/src/render_helpers/shader_element.rs
+++ b/src/render_helpers/shader_element.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::rc::Rc;
 
 use glam::{Mat3, Vec2};
@@ -76,14 +76,14 @@ unsafe fn compile_program(
     let debug_program =
         unsafe { link_program(gl, include_str!("shaders/texture.vert"), &debug_shader)? };
 
-    let vert = CStr::from_bytes_with_nul(b"vert\0").expect("NULL terminated");
-    let vert_position = CStr::from_bytes_with_nul(b"vert_position\0").expect("NULL terminated");
-    let matrix = CStr::from_bytes_with_nul(b"matrix\0").expect("NULL terminated");
-    let tex_matrix = CStr::from_bytes_with_nul(b"tex_matrix\0").expect("NULL terminated");
-    let size = CStr::from_bytes_with_nul(b"niri_size\0").expect("NULL terminated");
-    let scale = CStr::from_bytes_with_nul(b"niri_scale\0").expect("NULL terminated");
-    let alpha = CStr::from_bytes_with_nul(b"niri_alpha\0").expect("NULL terminated");
-    let tint = CStr::from_bytes_with_nul(b"niri_tint\0").expect("NULL terminated");
+    let vert = c"vert";
+    let vert_position = c"vert_position";
+    let matrix = c"matrix";
+    let tex_matrix = c"tex_matrix";
+    let size = c"niri_size";
+    let scale = c"niri_scale";
+    let alpha = c"niri_alpha";
+    let tint = c"niri_tint";
 
     Ok(ShaderProgram(Rc::new(ShaderProgramInner {
         normal: ShaderProgramInternal {


### PR DESCRIPTION
I noticed the [`clippy::manual_c_str_literals`](https://rust-lang.github.io/rust-clippy/master/index.html#/manual_c_str_literals) lint started firing now for some reason, even though [it was added in Rust 1.78.0](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-178) (from May 2024), so it should've been firing on that code earlier. This PR primarily fixes those literals into their equivalent `c""` literals. This makes the code subtly safer to editing by moving the checks performed by that `expect()` to the compiler itself; although it doesn't actually change anything tangible for this code. It now looks kinda dumb to assign string literals to variables; but they are used several times throughout, so i haven't decided to inline them.

I have. however, removed a bunch of redundant pointer casts. [`CStr::as_ptr()` returns a `*const ::core::ffi::c_char`](https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.as_ptr), which is [exactly the same type as `*const ffi::types::GLchar`](https://smithay.github.io/smithay/smithay/backend/renderer/gles/ffi/types/type.GLchar.html) (defined as an alias of `::std::os::raw::c_char`, which is an alias of `::core:.ffi::c_char`, which is the full path of the type `CStr` gives us) on all architectures, so the cast that was there was already redundant.

I also fixed another lint that's been bugging me for a while where the layout code is matching on an option with `None => ()`