### PR TITLE
Inverse touchpad scroll

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1999,7 +1999,7 @@ impl State {
 
         if let Some((cx, cy)) = &mut self.niri.gesture_swipe_3f_cumulative {
             *cx += delta_x;
-            *cy += delta_y;
+            *cy -= delta_y;
 
             // Check if the gesture moved far enough to decide. Threshold copied from GNOME Shell.
             let (cx, cy) = (*cx, *cy);


### PR DESCRIPTION
Currently when scrolling down with two fingers on touchpad I can move cursor down or scroll page down. But scrolling workspaces with three-finger swipe doing opposite - it scrolls up

This patch aims to achieve more consistency in interaction with the WM