### PR TITLE
Add support for running as a dinit service

### DIFF
--- a/resources/dinit/niri
+++ b/resources/dinit/niri
@@ -1,7 +1,7 @@
 type              = process
 command           = niri --session
 restart           = false
-working-dig       = $HOME
+working-dir       = $HOME
 depends-on        = dbus
 after             = niri-shutdown
 chain-to          = niri-shutdown

--- a/resources/dinit/niri
+++ b/resources/dinit/niri
@@ -1,0 +1,8 @@
+type              = process
+command           = niri --session
+restart           = false
+working-dig       = $HOME
+depends-on        = dbus
+after             = niri-shutdown
+chain-to          = niri-shutdown
+options:          always-chain

--- a/resources/dinit/niri-shutdown
+++ b/resources/dinit/niri-shutdown
@@ -1,0 +1,3 @@
+type               = scripted
+command            = /usr/lib/dinit/user/niri-shutdown.sh
+restart            = false

--- a/resources/dinit/niri-shutdown
+++ b/resources/dinit/niri-shutdown
@@ -1,3 +1,3 @@
 type               = scripted
-command            = /usr/lib/dinit/user/niri-shutdown.sh
+command            = dinitctl -u setenv WAYLAND_DISPLAY= XDG_SESSION_TYPE= XDG_CURRENT_DESKTOP= NIRI_SOCKET=
 restart            = false

--- a/resources/dinit/niri-shutdown.sh
+++ b/resources/dinit/niri-shutdown.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-dinitctl -u setenv WAYLAND_DISPLAY= XDG_SESSION_TYPE= XDG_CURRENT_DESKTOP= NIRI_SOCKET=

--- a/resources/dinit/niri-shutdown.sh
+++ b/resources/dinit/niri-shutdown.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+dinitctl -u setenv WAYLAND_DISPLAY= XDG_SESSION_TYPE= XDG_CURRENT_DESKTOP= NIRI_SOCKET=

--- a/resources/niri-session
+++ b/resources/niri-session
@@ -11,31 +11,57 @@ if [ -n "$SHELL" ] &&
   fi
 fi
 
-# Make sure there's no already running session.
-if systemctl --user -q is-active niri.service; then
-  echo 'A niri session is already running.'
-  exit 1
+# Try to detect the service manager that is being used
+if hash systemctl &> /dev/null; then
+    # Make sure there's no already running session.
+    if systemctl --user -q is-active niri.service; then
+      echo 'A niri session is already running.'
+      exit 1
+    fi
+
+    # Reset failed state of all user units.
+    systemctl --user reset-failed
+
+    # Import the login manager environment.
+    systemctl --user import-environment
+
+    # DBus activation environment is independent from systemd. While most of
+    # dbus-activated services are already using `SystemdService` directive, some
+    # still don't and thus we should set the dbus environment with a separate
+    # command.
+    if hash dbus-update-activation-environment 2>/dev/null; then
+        dbus-update-activation-environment --all
+    fi
+
+    # Start niri and wait for it to terminate.
+    systemctl --user --wait start niri.service
+
+    # Force stop of graphical-session.target.
+    systemctl --user start --job-mode=replace-irreversibly niri-shutdown.target
+
+    # Unset environment that we've set.
+    systemctl --user unset-environment WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP NIRI_SOCKET
+elif hash dinitctl &> /dev/null; then
+    # Check that the user dinit daemon is running
+	if ! pgrep -u $(id -u) dinit &> /dev/null; then
+      echo "dinit user daemon is not running, starting..."
+      dinit &
+
+      # Check that the user dinit daemon has started successfully
+      if ! pgrep -u $(id -u) dinit &> /dev/null; then
+        echo "unable to start user dinit daemon"
+        exit 1
+      fi
+    fi
+
+    # Make sure there's no already running session.
+    if dinitctl --user is-started niri &> /dev/null; then
+      echo 'A niri session is already running.'
+      exit 1
+    fi
+
+    # Start niri
+    dinitctl --user start niri
+else
+    echo "No systemd or dinit detected, please use niri --session instead."
 fi
-
-# Reset failed state of all user units.
-systemctl --user reset-failed
-
-# Import the login manager environment.
-systemctl --user import-environment
-
-# DBus activation environment is independent from systemd. While most of
-# dbus-activated services are already using `SystemdService` directive, some
-# still don't and thus we should set the dbus environment with a separate
-# command.
-if hash dbus-update-activation-environment 2>/dev/null; then
-    dbus-update-activation-environment --all
-fi
-
-# Start niri and wait for it to terminate.
-systemctl --user --wait start niri.service
-
-# Force stop of graphical-session.target.
-systemctl --user start --job-mode=replace-irreversibly niri-shutdown.target
-
-# Unset environment that we've set.
-systemctl --user unset-environment WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP NIRI_SOCKET

--- a/resources/niri-session
+++ b/resources/niri-session
@@ -43,15 +43,9 @@ if hash systemctl &> /dev/null; then
     systemctl --user unset-environment WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP NIRI_SOCKET
 elif hash dinitctl &> /dev/null; then
     # Check that the user dinit daemon is running
-	if ! pgrep -u $(id -u) dinit &> /dev/null; then
-      echo "dinit user daemon is not running, starting..."
-      dinit &
-
-      # Check that the user dinit daemon has started successfully
-      if ! pgrep -u $(id -u) dinit &> /dev/null; then
-        echo "unable to start user dinit daemon"
-        exit 1
-      fi
+    if ! pgrep -u $(id -u) dinit &> /dev/null; then
+      echo "dinit user daemon is not running."
+      exit 1
     fi
 
     # Make sure there's no already running session.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -8,8 +8,8 @@ After installing, start niri from your display manager like GDM.
 Press <kbd>Super</kbd><kbd>T</kbd> to run a terminal ([Alacritty]) and <kbd>Super</kbd><kbd>D</kbd> to run an application launcher ([fuzzel]).
 To exit niri, press <kbd>Super</kbd><kbd>Shift</kbd><kbd>E</kbd>.
 
-If you're not using a display manager, you should run `niri-session` (systemd) or `niri --session` (not systemd) from a TTY.
-The `--session` flag will make niri import its environment variables globally into systemd and D-Bus, and start its D-Bus services.
+If you're not using a display manager, you should run `niri-session` (systemd/dinit) or `niri --session` (others) from a TTY.
+The `--session` flag will make niri import its environment variables globally into system manager and D-Bus, and start its D-Bus services.
 
 You can also run `niri` inside an existing desktop session.
 Then it will open as a window, where you can give it a try.
@@ -178,8 +178,10 @@ To do that, put files into the correct directories according to this table.
 | `resources/niri-session` | `/usr/bin/` |
 | `resources/niri.desktop` | `/usr/share/wayland-sessions/` |
 | `resources/niri-portals.conf` | `/usr/share/xdg-desktop-portal/` |
-| `resources/niri.service` | `/usr/lib/systemd/user/` |
-| `resources/niri-shutdown.target` | `/usr/lib/systemd/user/` |
+| `resources/niri.service` (systemd) | `/usr/lib/systemd/user/` |
+| `resources/niri-shutdown.target` (systemd) | `/usr/lib/systemd/user/` |
+| `resources/dinit/niri` (dinit) | `/usr/lib/dinit.d/user/` |
+| `resources/dinit/niri-shutdown` (dinit) | `/usr/lib/dinit.d/user/` |
 
 Doing this will make niri appear in GDM and other display managers.
 
@@ -195,8 +197,10 @@ These may vary depending on your distribution.
 | `resources/niri-session` | `/usr/local/bin/` |
 | `resources/niri.desktop`  | `/usr/local/share/wayland-sessions/` |
 | `resources/niri-portals.conf` | `/usr/local/share/xdg-desktop-portal/` |
-| `resources/niri.service` | `/etc/systemd/user/` |
-| `resources/niri-shutdown.target` | `/etc/systemd/user/` |
+| `resources/niri.service` (systemd) | `/etc/systemd/user/` |
+| `resources/niri-shutdown.target` (systemd) | `/etc/systemd/user/` |
+| `resources/dinit/niri` (dinit) | `/etc/dinit.d/user/` |
+| `resources/dinit/niri-shutdown` (dinit) | `/etc/dinit.d/user/` |
 
 [Alacritty]: https://github.com/alacritty/alacritty
 [fuzzel]: https://codeberg.org/dnkl/fuzzel

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -9,7 +9,7 @@ Press <kbd>Super</kbd><kbd>T</kbd> to run a terminal ([Alacritty]) and <kbd>Supe
 To exit niri, press <kbd>Super</kbd><kbd>Shift</kbd><kbd>E</kbd>.
 
 If you're not using a display manager, you should run `niri-session` (systemd/dinit) or `niri --session` (others) from a TTY.
-The `--session` flag will make niri import its environment variables globally into system manager and D-Bus, and start its D-Bus services.
+The `--session` flag will make niri import its environment variables globally into the system manager and D-Bus, and start its D-Bus services.
 
 You can also run `niri` inside an existing desktop session.
 Then it will open as a window, where you can give it a try.


### PR DESCRIPTION
Added dinit service files, also made `niri-session` support starting a dinit service if it doesn't detect systemd.
(Requires dbus user service to exist)

- **Added dinit services**
- **Added dinit support to niri-session**
- **Replaced shutdown script for dinit with a single command execution**
- **Added dinit service files to Getting Started install tables**
