### PR TITLE
Implement `scroll_factor` for `Touchpad`

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -188,8 +188,8 @@ pub struct Touchpad {
     pub disabled_on_external_mouse: bool,
     #[knuffel(child)]
     pub middle_emulation: bool,
-    #[knuffel(child, unwrap(argument), default = 1.0)]
-    pub scroll_factor: f64,
+    #[knuffel(child, unwrap(argument), default = FloatOrInt(1.0))]
+    pub scroll_factor: FloatOrInt<0, 100>,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
@@ -210,8 +210,8 @@ pub struct Mouse {
     pub left_handed: bool,
     #[knuffel(child)]
     pub middle_emulation: bool,
-    #[knuffel(child, unwrap(argument), default = 1.0)]
-    pub scroll_factor: f64,
+    #[knuffel(child, unwrap(argument), default = FloatOrInt(1.0))]
+    pub scroll_factor: FloatOrInt<0, 100>,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
@@ -3175,7 +3175,7 @@ mod tests {
                         left_handed: false,
                         disabled_on_external_mouse: true,
                         middle_emulation: false,
-                        scroll_factor: 0.9,
+                        scroll_factor: FloatOrInt(0.9),
                     },
                     mouse: Mouse {
                         off: false,
@@ -3186,7 +3186,7 @@ mod tests {
                         scroll_button: Some(273),
                         left_handed: false,
                         middle_emulation: true,
-                        scroll_factor: 0.2,
+                        scroll_factor: FloatOrInt(0.2),
                     },
                     trackpoint: Trackpoint {
                         off: true,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -188,6 +188,8 @@ pub struct Touchpad {
     pub disabled_on_external_mouse: bool,
     #[knuffel(child)]
     pub middle_emulation: bool,
+    #[knuffel(child, unwrap(argument), default = 1.0)]
+    pub scroll_factor: f64,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
@@ -208,6 +210,8 @@ pub struct Mouse {
     pub left_handed: bool,
     #[knuffel(child)]
     pub middle_emulation: bool,
+    #[knuffel(child, unwrap(argument), default = 1.0)]
+    pub scroll_factor: f64,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
@@ -2958,6 +2962,7 @@ mod tests {
                     scroll-button 272
                     tap-button-map "left-middle-right"
                     disabled-on-external-mouse
+                    scroll-factor 0.9
                 }
 
                 mouse {
@@ -2967,6 +2972,7 @@ mod tests {
                     scroll-method "no-scroll"
                     scroll-button 273
                     middle-emulation
+                    scroll-factor 0.2
                 }
 
                 trackpoint {
@@ -3169,6 +3175,7 @@ mod tests {
                         left_handed: false,
                         disabled_on_external_mouse: true,
                         middle_emulation: false,
+                        scroll_factor: 0.9,
                     },
                     mouse: Mouse {
                         off: false,
@@ -3179,6 +3186,7 @@ mod tests {
                         scroll_button: Some(273),
                         left_handed: false,
                         middle_emulation: true,
+                        scroll_factor: 0.2,
                     },
                     trackpoint: Trackpoint {
                         off: true,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1881,14 +1881,20 @@ impl State {
             }
         }
 
+        let scroll_factor = match source {
+            AxisSource::Wheel => self.niri.config.borrow().input.mouse.scroll_factor,
+            AxisSource::Finger => self.niri.config.borrow().input.touchpad.scroll_factor,
+            _ => 1.0,
+        };
+
         let horizontal_amount = horizontal_amount.unwrap_or_else(|| {
             // Winit backend, discrete scrolling.
             horizontal_amount_v120.unwrap_or(0.0) / 120. * 15.
-        });
+        }) * scroll_factor;
         let vertical_amount = vertical_amount.unwrap_or_else(|| {
             // Winit backend, discrete scrolling.
             vertical_amount_v120.unwrap_or(0.0) / 120. * 15.
-        });
+        }) * scroll_factor;
 
         let mut frame = AxisFrame::new(event.time_msec()).source(source);
         if horizontal_amount != 0.0 {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1896,6 +1896,9 @@ impl State {
             vertical_amount_v120.unwrap_or(0.0) / 120. * 15.
         }) * scroll_factor;
 
+        let horizontal_amount_v120 = horizontal_amount_v120.map(|x| x * scroll_factor);
+        let vertical_amount_v120 = vertical_amount_v120.map(|x| x * scroll_factor);
+
         let mut frame = AxisFrame::new(event.time_msec()).source(source);
         if horizontal_amount != 0.0 {
             frame = frame

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1882,8 +1882,8 @@ impl State {
         }
 
         let scroll_factor = match source {
-            AxisSource::Wheel => self.niri.config.borrow().input.mouse.scroll_factor,
-            AxisSource::Finger => self.niri.config.borrow().input.touchpad.scroll_factor,
+            AxisSource::Wheel => self.niri.config.borrow().input.mouse.scroll_factor.0,
+            AxisSource::Finger => self.niri.config.borrow().input.touchpad.scroll_factor.0,
             _ => 1.0,
         };
 

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -32,6 +32,7 @@ input {
         natural-scroll
         // accel-speed 0.2
         // accel-profile "flat"
+        // scroll-factor 1.0
         // scroll-method "two-finger"
         // tap-button-map "left-middle-right"
         // click-method "clickfinger"
@@ -45,6 +46,7 @@ input {
         // natural-scroll
         // accel-speed 0.2
         // accel-profile "flat"
+        // scroll-factor 1.0
         // scroll-method "no-scroll"
         // left-handed
         // middle-emulation
@@ -153,6 +155,10 @@ Settings specific to `touchpad`s:
 - `tap-button-map`: can be `left-right-middle` or `left-middle-right`, controls which button corresponds to a two-finger tap and a three-finger tap.
 - `click-method`: can be `button-areas` or `clickfinger`, changes the [click method](https://wayland.freedesktop.org/libinput/doc/latest/clickpad-softbuttons.html).
 - `disabled-on-external-mouse`: do not send events while external pointer device is plugged in.
+
+Settings specific to `touchpad` and `mouse`:
+
+- `scroll-factor`: scales the scrolling by this value.
 
 Settings specific to `touchpad`, `mouse` and `tablet`:
 


### PR DESCRIPTION
Quick, dirty and poorly researched, but implementing it like this seems to behave quite the same as in `sway`.

I gathered that `libinput` doesn't directly support this, so seems like there's no relevant function to call in the  `apply_libinput_settings` function found in `src/input/mod.rs`.