### PR TITLE
Add scroll-button property to Touchpad, Mouse, and Trackpoint

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2890,6 +2890,7 @@ mod tests {
                     accel-speed 0.2
                     accel-profile "flat"
                     scroll-method "two-finger"
+                    scroll-button 271
                     tap-button-map "left-middle-right"
                     disabled-on-external-mouse
                 }
@@ -2899,6 +2900,7 @@ mod tests {
                     accel-speed 0.4
                     accel-profile "flat"
                     scroll-method "no-scroll"
+                    scroll-button 272
                     middle-emulation
                 }
 
@@ -3076,6 +3078,7 @@ mod tests {
                         accel_speed: 0.2,
                         accel_profile: Some(AccelProfile::Flat),
                         scroll_method: Some(ScrollMethod::TwoFinger),
+                        scroll_button: 271,
                         tap_button_map: Some(TapButtonMap::LeftMiddleRight),
                         left_handed: false,
                         disabled_on_external_mouse: true,
@@ -3087,6 +3090,7 @@ mod tests {
                         accel_speed: 0.4,
                         accel_profile: Some(AccelProfile::Flat),
                         scroll_method: Some(ScrollMethod::NoScroll),
+                        scroll_button: 272,
                         left_handed: false,
                         middle_emulation: true,
                     },

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -174,6 +174,8 @@ pub struct Touchpad {
     pub accel_profile: Option<AccelProfile>,
     #[knuffel(child, unwrap(argument, str))]
     pub scroll_method: Option<ScrollMethod>,
+    #[knuffel(child, unwrap(argument), default)]
+    pub scroll_button: u32,
     #[knuffel(child, unwrap(argument, str))]
     pub tap_button_map: Option<TapButtonMap>,
     #[knuffel(child)]
@@ -196,6 +198,8 @@ pub struct Mouse {
     pub accel_profile: Option<AccelProfile>,
     #[knuffel(child, unwrap(argument, str))]
     pub scroll_method: Option<ScrollMethod>,
+    #[knuffel(child, unwrap(argument), default)]
+    pub scroll_button: u32,
     #[knuffel(child)]
     pub left_handed: bool,
     #[knuffel(child)]
@@ -214,6 +218,8 @@ pub struct Trackpoint {
     pub accel_profile: Option<AccelProfile>,
     #[knuffel(child, unwrap(argument, str))]
     pub scroll_method: Option<ScrollMethod>,
+    #[knuffel(child, unwrap(argument), default)]
+    pub scroll_button: u32,
     #[knuffel(child)]
     pub middle_emulation: bool,
 }
@@ -2902,6 +2908,7 @@ mod tests {
                     accel-speed 0.0
                     accel-profile "flat"
                     scroll-method "on-button-down"
+                    scroll-button 273
                 }
 
                 tablet {
@@ -3089,6 +3096,7 @@ mod tests {
                         accel_speed: 0.0,
                         accel_profile: Some(AccelProfile::Flat),
                         scroll_method: Some(ScrollMethod::OnButtonDown),
+                        scroll_button: 273,
                         middle_emulation: false,
                     },
                     tablet: Tablet {

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -40,6 +40,16 @@ input {
         // scroll-method "no-scroll"
     }
 
+    trackpoint {
+        // off
+        // natural-scroll
+        // accel-speed 0.2
+        // accel-profile "flat"
+        // scroll-method "on-button-down"
+        // scroll-button 273
+        // middle-emulation
+    }
+
     // Uncomment this to make the mouse warp to the center of newly focused windows.
     // warp-mouse-to-focus
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2651,6 +2651,10 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
 
         if let Some(method) = c.scroll_method {
             let _ = device.config_scroll_set_method(method.into());
+
+            if method == niri_config::ScrollMethod::OnButtonDown {
+                let _ = device.config_scroll_set_button(c.scroll_button);
+            }
         } else if let Some(default) = device.config_scroll_default_method() {
             let _ = device.config_scroll_set_method(default);
         }
@@ -2707,6 +2711,10 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
 
         if let Some(method) = c.scroll_method {
             let _ = device.config_scroll_set_method(method.into());
+
+            if method == niri_config::ScrollMethod::OnButtonDown {
+                let _ = device.config_scroll_set_button(c.scroll_button);
+            }
         } else if let Some(default) = device.config_scroll_default_method() {
             let _ = device.config_scroll_set_method(default);
         }
@@ -2731,6 +2739,10 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
 
         if let Some(method) = c.scroll_method {
             let _ = device.config_scroll_set_method(method.into());
+
+            if method == niri_config::ScrollMethod::OnButtonDown {
+                let _ = device.config_scroll_set_button(c.scroll_button);
+            }
         } else if let Some(default) = device.config_scroll_default_method() {
             let _ = device.config_scroll_set_method(default);
         }

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -56,6 +56,7 @@ input {
         // accel-speed 0.2
         // accel-profile "flat"
         // scroll-method "on-button-down"
+        // scroll-button 273
         // middle-emulation
     }
 
@@ -140,6 +141,7 @@ A few settings are common between `touchpad`, `mouse` and `trackpoint`:
 - `accel-speed`: pointer acceleration speed, valid values are from `-1.0` to `1.0` where the default is `0.0`.
 - `accel-profile`: can be `adaptive` (the default) or `flat` (disables pointer acceleration).
 - `scroll-method`: when to generate scroll events instead of pointer motion events, can be `no-scroll`, `two-finger`, `edge`, or `on-button-down`.
+- `scroll-button`: the button key (numerical form) used for the `on-button-down` scroll method
   The default and supported methods vary depending on the device type.
 - `middle-emulation`: emulate a middle mouse click by pressing left and right mouse buttons at once.
 


### PR DESCRIPTION
* Added scroll-button option to touchpad, mouse, and trackpoint
* Added to default config an example touchpad config that uses the `on-button-down` scroll method with an assigned scroll button
* Added tests
* Updated wiki to describe `scroll-button` config option 