### PR TITLE
Add scroll-button property for Touchpad, Mouse, Trackpoint, Trackball

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -176,6 +176,8 @@ pub struct Touchpad {
     pub accel_profile: Option<AccelProfile>,
     #[knuffel(child, unwrap(argument, str))]
     pub scroll_method: Option<ScrollMethod>,
+    #[knuffel(child, unwrap(argument))]
+    pub scroll_button: Option<u32>,
     #[knuffel(child, unwrap(argument, str))]
     pub tap_button_map: Option<TapButtonMap>,
     #[knuffel(child)]
@@ -198,6 +200,8 @@ pub struct Mouse {
     pub accel_profile: Option<AccelProfile>,
     #[knuffel(child, unwrap(argument, str))]
     pub scroll_method: Option<ScrollMethod>,
+    #[knuffel(child, unwrap(argument))]
+    pub scroll_button: Option<u32>,
     #[knuffel(child)]
     pub left_handed: bool,
     #[knuffel(child)]
@@ -216,6 +220,8 @@ pub struct Trackpoint {
     pub accel_profile: Option<AccelProfile>,
     #[knuffel(child, unwrap(argument, str))]
     pub scroll_method: Option<ScrollMethod>,
+    #[knuffel(child, unwrap(argument))]
+    pub scroll_button: Option<u32>,
     #[knuffel(child)]
     pub middle_emulation: bool,
 }
@@ -230,6 +236,10 @@ pub struct Trackball {
     pub accel_speed: f64,
     #[knuffel(child, unwrap(argument, str))]
     pub accel_profile: Option<AccelProfile>,
+    #[knuffel(child, unwrap(argument, str))]
+    pub scroll_method: Option<ScrollMethod>,
+    #[knuffel(child, unwrap(argument))]
+    pub scroll_button: Option<u32>,
     #[knuffel(child)]
     pub left_handed: bool,
     #[knuffel(child)]
@@ -2902,6 +2912,7 @@ mod tests {
                     accel-speed 0.2
                     accel-profile "flat"
                     scroll-method "two-finger"
+                    scroll-button 272
                     tap-button-map "left-middle-right"
                     disabled-on-external-mouse
                 }
@@ -2911,6 +2922,7 @@ mod tests {
                     accel-speed 0.4
                     accel-profile "flat"
                     scroll-method "no-scroll"
+                    scroll-button 273
                     middle-emulation
                 }
 
@@ -2920,6 +2932,7 @@ mod tests {
                     accel-speed 0.0
                     accel-profile "flat"
                     scroll-method "on-button-down"
+                    scroll-button 274
                 }
 
                 trackball {
@@ -2927,6 +2940,8 @@ mod tests {
                     natural-scroll
                     accel-speed 0.0
                     accel-profile "flat"
+                    scroll-method "edge"
+                    scroll-button 275
                     left-handed
                     middle-emulation
                 }
@@ -3096,6 +3111,7 @@ mod tests {
                         accel_speed: 0.2,
                         accel_profile: Some(AccelProfile::Flat),
                         scroll_method: Some(ScrollMethod::TwoFinger),
+                        scroll_button: Some(272),
                         tap_button_map: Some(TapButtonMap::LeftMiddleRight),
                         left_handed: false,
                         disabled_on_external_mouse: true,
@@ -3107,6 +3123,7 @@ mod tests {
                         accel_speed: 0.4,
                         accel_profile: Some(AccelProfile::Flat),
                         scroll_method: Some(ScrollMethod::NoScroll),
+                        scroll_button: Some(273),
                         left_handed: false,
                         middle_emulation: true,
                     },
@@ -3116,6 +3133,7 @@ mod tests {
                         accel_speed: 0.0,
                         accel_profile: Some(AccelProfile::Flat),
                         scroll_method: Some(ScrollMethod::OnButtonDown),
+                        scroll_button: Some(274),
                         middle_emulation: false,
                     },
                     trackball: Trackball {
@@ -3123,6 +3141,8 @@ mod tests {
                         natural_scroll: true,
                         accel_speed: 0.0,
                         accel_profile: Some(AccelProfile::Flat),
+                        scroll_method: Some(ScrollMethod::Edge),
+                        scroll_button: Some(275),
                         left_handed: true,
                         middle_emulation: true,
                     },

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -40,6 +40,16 @@ input {
         // scroll-method "no-scroll"
     }
 
+    trackpoint {
+        // off
+        // natural-scroll
+        // accel-speed 0.2
+        // accel-profile "flat"
+        // scroll-method "on-button-down"
+        // scroll-button 273
+        // middle-emulation
+    }
+
     // Uncomment this to make the mouse warp to the center of newly focused windows.
     // warp-mouse-to-focus
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2657,8 +2657,20 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
 
         if let Some(method) = c.scroll_method {
             let _ = device.config_scroll_set_method(method.into());
+
+            if method == niri_config::ScrollMethod::OnButtonDown {
+                if let Some(button) = c.scroll_button {
+                    let _ = device.config_scroll_set_button(button);
+                }
+            }
         } else if let Some(default) = device.config_scroll_default_method() {
             let _ = device.config_scroll_set_method(default);
+
+            if default == input::ScrollMethod::OnButtonDown {
+                if let Some(button) = c.scroll_button {
+                    let _ = device.config_scroll_set_button(button);
+                }
+            }
         }
 
         if let Some(tap_button_map) = c.tap_button_map {
@@ -2713,8 +2725,20 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
 
         if let Some(method) = c.scroll_method {
             let _ = device.config_scroll_set_method(method.into());
+
+            if method == niri_config::ScrollMethod::OnButtonDown {
+                if let Some(button) = c.scroll_button {
+                    let _ = device.config_scroll_set_button(button);
+                }
+            }
         } else if let Some(default) = device.config_scroll_default_method() {
             let _ = device.config_scroll_set_method(default);
+
+            if default == input::ScrollMethod::OnButtonDown {
+                if let Some(button) = c.scroll_button {
+                    let _ = device.config_scroll_set_button(button);
+                }
+            }
         }
     }
 
@@ -2734,6 +2758,24 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
             let _ = device.config_accel_set_profile(accel_profile.into());
         } else if let Some(default) = device.config_accel_default_profile() {
             let _ = device.config_accel_set_profile(default);
+        }
+
+        if let Some(method) = c.scroll_method {
+            let _ = device.config_scroll_set_method(method.into());
+
+            if method == niri_config::ScrollMethod::OnButtonDown {
+                if let Some(button) = c.scroll_button {
+                    let _ = device.config_scroll_set_button(button);
+                }
+            }
+        } else if let Some(default) = device.config_scroll_default_method() {
+            let _ = device.config_scroll_set_method(default);
+
+            if default == input::ScrollMethod::OnButtonDown {
+                if let Some(button) = c.scroll_button {
+                    let _ = device.config_scroll_set_button(button);
+                }
+            }
         }
     }
 
@@ -2756,8 +2798,20 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
 
         if let Some(method) = c.scroll_method {
             let _ = device.config_scroll_set_method(method.into());
+
+            if method == niri_config::ScrollMethod::OnButtonDown {
+                if let Some(button) = c.scroll_button {
+                    let _ = device.config_scroll_set_button(button);
+                }
+            }
         } else if let Some(default) = device.config_scroll_default_method() {
             let _ = device.config_scroll_set_method(default);
+
+            if default == input::ScrollMethod::OnButtonDown {
+                if let Some(button) = c.scroll_button {
+                    let _ = device.config_scroll_set_button(button);
+                }
+            }
         }
     }
 

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -56,6 +56,7 @@ input {
         // accel-speed 0.2
         // accel-profile "flat"
         // scroll-method "on-button-down"
+        // scroll-button 273
         // middle-emulation
     }
 
@@ -134,13 +135,14 @@ A few settings are common between input devices:
 
 - `off`: if set, no events will be sent from this device.
 
-A few settings are common between `touchpad`, `mouse` and `trackpoint`:
+A few settings are common between `touchpad`, `mouse`, `trackpoint`, and `trackball`:
 
 - `natural-scroll`: if set, inverts the scrolling direction.
 - `accel-speed`: pointer acceleration speed, valid values are from `-1.0` to `1.0` where the default is `0.0`.
 - `accel-profile`: can be `adaptive` (the default) or `flat` (disables pointer acceleration).
 - `scroll-method`: when to generate scroll events instead of pointer motion events, can be `no-scroll`, `two-finger`, `edge`, or `on-button-down`.
   The default and supported methods vary depending on the device type.
+- `scroll-button`: the button code used for the `on-button-down` scroll method. You can find it in `libinput debug-events`.
 - `middle-emulation`: emulate a middle mouse click by pressing left and right mouse buttons at once.
 
 Settings specific to `touchpad`s:


### PR DESCRIPTION
* Added scroll-button option to touchpad, mouse, trackpoint, and trackball
* Added to default config an example touchpad config that uses the on-button-down scroll method with an assigned scroll button
* Added tests
* Updated wiki to describe scroll-button config option

Applied suggestions from prior pull requests.