### PR TITLE
support binding actions to switches

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -54,6 +54,8 @@ pub struct Config {
     #[knuffel(child, default)]
     pub binds: Binds,
     #[knuffel(child, default)]
+    pub switch_events: SwitchBinds,
+    #[knuffel(child, default)]
     pub debug: DebugConfig,
     #[knuffel(children(name = "workspace"))]
     pub workspaces: Vec<Workspace>,
@@ -1086,6 +1088,24 @@ bitflags! {
         const ISO_LEVEL5_SHIFT = 1 << 5;
         const COMPOSITOR = 1 << 6;
     }
+}
+
+#[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
+pub struct SwitchBinds {
+    #[knuffel(child)]
+    pub lid_open: Option<SwitchAction>,
+    #[knuffel(child)]
+    pub lid_close: Option<SwitchAction>,
+    #[knuffel(child)]
+    pub tablet_mode_on: Option<SwitchAction>,
+    #[knuffel(child)]
+    pub tablet_mode_off: Option<SwitchAction>,
+}
+
+#[derive(knuffel::Decode, Debug, Clone, PartialEq)]
+pub struct SwitchAction {
+    #[knuffel(child, unwrap(arguments))]
+    pub spawn: Vec<String>,
 }
 
 // Remember to add new actions to the CLI enum too.
@@ -3079,6 +3099,11 @@ mod tests {
                 Mod+WheelScrollDown cooldown-ms=150 { focus-workspace-down; }
             }
 
+            switch-events {
+                tablet-mode-on { spawn "bash" "-c" "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true"; }
+                tablet-mode-off { spawn "bash" "-c" "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false"; }
+            }
+
             debug {
                 render-drm-device "/dev/dri/renderD129"
             }
@@ -3426,6 +3451,24 @@ mod tests {
                         allow_when_locked: false,
                     },
                 ]),
+                switch_events: SwitchBinds {
+                    lid_open: None,
+                    lid_close: None,
+                    tablet_mode_on: Some(SwitchAction {
+                        spawn: vec![
+                            "bash".to_owned(),
+                            "-c".to_owned(),
+                            "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true".to_owned(),
+                        ],
+                    }),
+                    tablet_mode_off: Some(SwitchAction {
+                        spawn: vec![
+                            "bash".to_owned(),
+                            "-c".to_owned(),
+                            "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false".to_owned(),
+                        ],
+                    }),
+                },
                 debug: DebugConfig {
                     render_drm_device: Some(PathBuf::from("/dev/dri/renderD129")),
                     ..Default::default()

--- a/wiki/Configuration:-Overview.md
+++ b/wiki/Configuration:-Overview.md
@@ -5,6 +5,7 @@ You can find documentation for various sections of the config on these wiki page
 * [`input {}`](./Configuration:-Input.md)
 * [`output "eDP-1" {}`](./Configuration:-Outputs.md)
 * [`binds {}`](./Configuration:-Key-Bindings.md)
+* [`switch-events {}`](./Configuration:-Switch-Events.md)
 * [`layout {}`](./Configuration:-Layout.md)
 * [top-level options](./Configuration:-Miscellaneous.md)
 * [`window-rule {}`](./Configuration:-Window-Rules.md)

--- a/wiki/Configuration:-Switch-Events.md
+++ b/wiki/Configuration:-Switch-Events.md
@@ -2,6 +2,8 @@
 
 Switch event bindings are declared in the `switch-events {}` section of the config.
 
+Here are all the events that you can bind at a glance:
+
 ```kdl
 switch-events {
     lid-close { spawn "bash" "-c" "niri msg output \"eDP-1\" off"; }
@@ -11,7 +13,33 @@ switch-events {
 }
 ```
 
-Currently only `spawn` actions are supported.
+The syntax is similar to key bindings.
+Currently only the `spawn` action are supported.
 
 > [!NOTE]
-> In contrast to key bindings, switch event bindings are *always* executed, independent of the current lock state.
+> In contrast to key bindings, switch event bindings are *always* executed, even when the session is locked.
+
+### `lid-close`, `lid-open`
+
+These events correspond to closing and opening of the laptop lid.
+
+You could use them to turn the laptop internal monitor off and on (until niri gets this functionality built-in).
+
+```kdl
+switch-events {
+    lid-close { spawn "bash" "-c" "niri msg output \"eDP-1\" off"; }
+    lid-open { spawn "bash" "-c" "niri msg output \"eDP-1\" on"; }
+}
+```
+
+### `tablet-mode-on`, `tablet-mode-off`
+
+These events trigger when a convertible laptop goes into or out of tablet mode.
+In tablet mode, the keyboard and mouse are usually inaccessible, so you can use these events to activate the on-screen keyboard.
+
+```kdl
+switch-events {
+    tablet-mode-on { spawn "bash" "-c" "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true"; }
+    tablet-mode-off { spawn "bash" "-c" "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false"; }
+}
+```

--- a/wiki/Configuration:-Switch-Events.md
+++ b/wiki/Configuration:-Switch-Events.md
@@ -1,0 +1,17 @@
+### Overview
+
+Switch event bindings are declared in the `switch-events {}` section of the config.
+
+```kdl
+switch-events {
+    lid-close { spawn "bash" "-c" "niri msg output \"eDP-1\" off"; }
+    lid-open { spawn "bash" "-c" "niri msg output \"eDP-1\" on"; }
+    tablet-mode-on { spawn "bash" "-c" "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true"; }
+    tablet-mode-off { spawn "bash" "-c" "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false"; }
+}
+```
+
+Currently only `spawn` actions are supported.
+
+> [!NOTE]
+> In contrast to key bindings, switch event bindings are *always* executed, independent of the current lock state.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -14,6 +14,7 @@
 * [Input](./Configuration:-Input.md)
 * [Outputs](./Configuration:-Outputs.md)
 * [Key Bindings](./Configuration:-Key-Bindings.md)
+* [Switch Events](./Configuration:-Switch-Events.md)
 * [Layout](./Configuration:-Layout.md)
 * [Named Workspaces](./Configuration:-Named-Workspaces.md)
 * [Miscellaneous](./Configuration:-Miscellaneous.md)


### PR DESCRIPTION
Not sure this is the right approach, but it seems to work fine so far. Though the switch bindings should probably be also run during startup.