### PR TITLE
xdg-desktop-portal: add basic support for access dialogs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,7 @@
             ''
               install -Dm644 resources/niri.desktop -t $out/share/wayland-sessions
               install -Dm644 resources/niri-portals.conf -t $out/share/xdg-desktop-portal
+              install -Dm644 resources/niri.portal -t $out/share/xdg-desktop-portal/portals
             ''
             + lib.optionalString withSystemd ''
               install -Dm755 resources/niri-session $out/bin/niri-session

--- a/niri.spec.rpkg
+++ b/niri.spec.rpkg
@@ -122,6 +122,7 @@ sed -i 's/.*please-remove-me$//' .cargo/config.toml
 install -Dm755 -t %{buildroot}%{_bindir} ./resources/niri-session
 install -Dm644 -t %{buildroot}%{_datadir}/wayland-sessions ./resources/niri.desktop
 install -Dm644 -t %{buildroot}%{_datadir}/xdg-desktop-portal ./resources/niri-portals.conf
+install -Dm644 -t %{buildroot}%{_datadir}/xdg-desktop-portal/portals ./resources/niri.portal
 install -Dm644 -t %{buildroot}%{_userunitdir} ./resources/niri.service
 install -Dm644 -t %{buildroot}%{_userunitdir} ./resources/niri-shutdown.target
 
@@ -140,6 +141,7 @@ install -Dm644 -t %{buildroot}%{_userunitdir} ./resources/niri-shutdown.target
 %{_datadir}/wayland-sessions/niri.desktop
 %dir %{_datadir}/xdg-desktop-portal
 %{_datadir}/xdg-desktop-portal/niri-portals.conf
+%{_datadir}/xdg-desktop-portal/portals/niri.portal
 %{_userunitdir}/niri.service
 %{_userunitdir}/niri-shutdown.target
 

--- a/resources/niri-portals.conf
+++ b/resources/niri-portals.conf
@@ -1,3 +1,4 @@
 [preferred]
 default=gnome;gtk;
+org.freedesktop.impl.portal.Access=niri;
 org.freedesktop.impl.portal.Secret=gnome-keyring;

--- a/resources/niri.portal
+++ b/resources/niri.portal
@@ -1,0 +1,4 @@
+[portal]
+DBusName=org.freedesktop.impl.portal.desktop.niri
+Interfaces=org.freedesktop.impl.portal.Access;
+UseIn=niri

--- a/src/dbus/xdg_deskop_portal_impl_access.rs
+++ b/src/dbus/xdg_deskop_portal_impl_access.rs
@@ -1,0 +1,107 @@
+use std::collections::HashMap;
+use std::ops::Not;
+
+use zbus::dbus_interface;
+use zbus::zvariant::{ObjectPath, OwnedValue, Value};
+
+use super::Start;
+use crate::ui::access_dialog::{AccessDialogOptions, AccessDialogRequest, AccessDialogResponse};
+
+pub struct AccessPortalImpl {
+    to_niri: calloop::channel::Sender<AccessDialogRequest>,
+}
+
+#[dbus_interface(name = "org.freedesktop.impl.portal.Access")]
+impl AccessPortalImpl {
+    /// AccessDialog method
+    #[allow(clippy::too_many_arguments)]
+    async fn access_dialog(
+        &self,
+        _handle: ObjectPath<'_>,
+        app_id: &str,
+        parent_window: &str,
+        title: &str,
+        subtitle: &str,
+        body: &str,
+        options: HashMap<&str, Value<'_>>,
+    ) -> zbus::fdo::Result<(u32, HashMap<String, OwnedValue>)> {
+        let options = AccessDialogOptions::from_dbus_options(options);
+        let (request, response_channel_receiver) = AccessDialogRequest::new(
+            app_id.to_string(),
+            parent_window
+                .is_empty()
+                .not()
+                .then(|| parent_window.to_string()),
+            title.to_string(),
+            subtitle.to_string(),
+            body.is_empty().not().then(|| body.to_string()),
+            options,
+        );
+
+        if let Err(err) = self.to_niri.send(request) {
+            tracing::warn!(?err, "failed to send access dialog request");
+            return Err(zbus::fdo::Error::Failed(format!(
+                "error creating access dialog: {err:?}"
+            )));
+        };
+
+        let result = HashMap::<String, OwnedValue>::new();
+        let response = match response_channel_receiver.recv().await {
+            Ok(AccessDialogResponse::Grant) => {
+                // FIXME: Add selected choices to the result
+                0
+            }
+            Ok(AccessDialogResponse::Deny) => 1,
+            Err(err) => {
+                tracing::warn!(?err, "failed to receive response for access dialog request");
+                return Ok((2, Default::default()));
+            }
+        };
+
+        return Ok((response, result));
+    }
+}
+
+impl AccessPortalImpl {
+    pub fn new(to_niri: calloop::channel::Sender<AccessDialogRequest>) -> Self {
+        Self { to_niri }
+    }
+}
+
+impl Start for AccessPortalImpl {
+    fn start(self) -> anyhow::Result<zbus::blocking::Connection> {
+        let conn = zbus::blocking::ConnectionBuilder::session()?
+            .name("org.freedesktop.impl.portal.desktop.niri")?
+            .serve_at("/org/freedesktop/portal/desktop", self)?
+            .build()?;
+        Ok(conn)
+    }
+}
+
+impl AccessDialogOptions {
+    fn from_dbus_options(options: HashMap<&str, Value<'_>>) -> Self {
+        let modal: bool = options
+            .get("modal")
+            .and_then(|option| option.downcast_ref())
+            .copied()
+            .unwrap_or(true);
+        let deny_label: Option<String> = options
+            .get("deny_label")
+            .and_then(|option| option.clone().downcast());
+        let grant_label: Option<String> = options
+            .get("grant_label")
+            .and_then(|option| option.clone().downcast());
+        let icon: Option<String> = options
+            .get("icon")
+            .and_then(|option| option.clone().downcast());
+
+        // FIXME: Add support for choices
+
+        Self {
+            modal,
+            deny_label,
+            grant_label,
+            icon,
+        }
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -36,6 +36,7 @@ use self::move_grab::MoveGrab;
 use self::resize_grab::ResizeGrab;
 use self::spatial_movement_grab::SpatialMovementGrab;
 use crate::niri::State;
+use crate::ui::access_dialog::AccessDialog;
 use crate::ui::screenshot_ui::ScreenshotUi;
 use crate::utils::spawning::spawn;
 use crate::utils::{center, get_monotonic_time, ResizeEdge};
@@ -372,6 +373,7 @@ impl State {
                     pressed,
                     *mods,
                     &this.niri.screenshot_ui,
+                    &this.niri.access_dialog_ui,
                     this.niri.config.borrow().input.disable_power_key_handling,
                 )
             },
@@ -2447,6 +2449,7 @@ fn should_intercept_key(
     pressed: bool,
     mods: ModifiersState,
     screenshot_ui: &ScreenshotUi,
+    access_dialog_ui: &AccessDialog,
     disable_power_key_handling: bool,
 ) -> FilterResult<Option<Bind>> {
     // Actions are only triggered on presses, release of the key
@@ -2491,6 +2494,12 @@ fn should_intercept_key(
                 });
             }
         }
+    }
+
+    if access_dialog_ui.is_visible() {
+        access_dialog_ui.handle_key(raw, mods);
+        suppressed_keys.insert(key_code);
+        return FilterResult::Intercept(None);
     }
 
     match (final_bind, pressed) {
@@ -2991,6 +3000,7 @@ mod tests {
         let mut suppressed_keys = HashSet::new();
 
         let screenshot_ui = ScreenshotUi::new(Default::default());
+        let access_dialog_ui = AccessDialog::new();
         let disable_power_key_handling = false;
 
         // The key_code we pick is arbitrary, the only thing
@@ -3008,6 +3018,7 @@ mod tests {
                 pressed,
                 mods,
                 &screenshot_ui,
+                &access_dialog_ui,
                 disable_power_key_handling,
             )
         };
@@ -3024,6 +3035,7 @@ mod tests {
                 pressed,
                 mods,
                 &screenshot_ui,
+                &access_dialog_ui,
                 disable_power_key_handling,
             )
         };

--- a/src/ui/access_dialog.rs
+++ b/src/ui/access_dialog.rs
@@ -1,0 +1,257 @@
+use std::cell::RefCell;
+use std::collections::{HashMap, VecDeque};
+
+use pango::{Alignment, FontDescription};
+use pangocairo::cairo::{self, ImageSurface};
+use smithay::backend::renderer::element::Kind;
+use smithay::input::keyboard::{Keysym, ModifiersState};
+use smithay::output::{Output, WeakOutput};
+use smithay::reexports::gbm::Format as Fourcc;
+use smithay::utils::{Scale, Transform};
+
+use crate::render_helpers::memory::MemoryBuffer;
+use crate::render_helpers::primary_gpu_texture::PrimaryGpuTextureRenderElement;
+use crate::render_helpers::renderer::NiriRenderer;
+use crate::render_helpers::texture::{TextureBuffer, TextureRenderElement};
+use crate::utils::{output_size, to_physical_precise_round};
+
+const PADDING: i32 = 16;
+const FONT: &str = "sans 14px";
+const BORDER: i32 = 8;
+
+pub struct AccessDialog {
+    requests: RefCell<VecDeque<AccessDialogRequest>>,
+    buffers: RefCell<HashMap<WeakOutput, Option<MemoryBuffer>>>,
+}
+
+impl AccessDialog {
+    pub fn new() -> Self {
+        Self {
+            requests: Default::default(),
+            buffers: Default::default(),
+        }
+    }
+
+    pub fn enque_request(&self, request: AccessDialogRequest) {
+        self.requests.borrow_mut().push_back(request);
+    }
+
+    pub fn is_visible(&self) -> bool {
+        !self.requests.borrow().is_empty()
+    }
+
+    pub fn render<R: NiriRenderer>(
+        &self,
+        renderer: &mut R,
+        output: &Output,
+    ) -> Option<PrimaryGpuTextureRenderElement> {
+        let requests = self.requests.borrow();
+        let Some(current_request) = requests.front() else {
+            return None;
+        };
+
+        let scale = output.current_scale().fractional_scale();
+        let output_size = output_size(output);
+        let weak_output = output.downgrade();
+
+        let mut buffers = self.buffers.borrow_mut();
+        buffers.retain(|output, buffer| {
+            output.is_alive()
+                && (*output != weak_output
+                    || buffer
+                        .as_ref()
+                        .map(|buffer| Scale::from(scale) == buffer.scale())
+                        .unwrap_or(false))
+        });
+
+        let Some(buffer) = buffers
+            .entry(weak_output)
+            .or_insert_with(|| render(scale, current_request).ok())
+        else {
+            buffers.clear();
+            return None;
+        };
+
+        let size = buffer.logical_size();
+        let buffer = TextureBuffer::from_memory_buffer(renderer.as_gles_renderer(), buffer).ok()?;
+
+        let location = (output_size.to_f64().to_point() - size.to_point()).downscale(2.);
+        let mut location = location.to_physical_precise_round(scale).to_logical(scale);
+        location.x = f64::max(0., location.x);
+        location.y = f64::max(0., location.y);
+
+        let elem = TextureRenderElement::from_texture_buffer(
+            buffer,
+            location,
+            1.,
+            None,
+            None,
+            Kind::Unspecified,
+        );
+        Some(PrimaryGpuTextureRenderElement(elem))
+    }
+
+    pub fn handle_key(&self, raw: Option<Keysym>, _mods: ModifiersState) {
+        if let Some(Keysym::Escape) = raw {
+            if let Some(request) = self.requests.borrow_mut().pop_front() {
+                let _ = request.deny();
+            }
+            self.buffers.borrow_mut().clear();
+        }
+
+        if let Some(Keysym::Return) = raw {
+            if let Some(request) = self.requests.borrow_mut().pop_front() {
+                // FIXME: Allow to select choices
+                let _ = request.grant();
+            }
+            self.buffers.borrow_mut().clear();
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AccessDialogRequest {
+    pub app_id: String,
+    pub parent_window: Option<String>,
+    pub title: String,
+    pub subtitle: String,
+    pub body: Option<String>,
+    pub options: AccessDialogOptions,
+
+    response_channel_sender: async_channel::Sender<AccessDialogResponse>,
+}
+
+/// Options that might be used for a [`AccessDialogRequest`]
+#[derive(Debug, Clone)]
+pub struct AccessDialogOptions {
+    /// Whether to make the dialog modal. Defaults to true.
+    pub modal: bool,
+    /// Label for the Deny button.
+    pub deny_label: Option<String>,
+    /// Label for the Grant button.
+    pub grant_label: Option<String>,
+    /// Icon name for an icon to show in the dialog. This should be a symbolic icon name.
+    pub icon: Option<String>,
+}
+
+impl Default for AccessDialogOptions {
+    fn default() -> Self {
+        Self {
+            modal: true,
+            deny_label: None,
+            grant_label: None,
+            icon: None,
+        }
+    }
+}
+
+impl AccessDialogRequest {
+    pub fn new(
+        app_id: String,
+        parent_window: Option<String>,
+        title: String,
+        subtitle: String,
+        body: Option<String>,
+        options: AccessDialogOptions,
+    ) -> (Self, async_channel::Receiver<AccessDialogResponse>) {
+        let (response_channel_sender, response_channel_receiver) = async_channel::bounded(1);
+        let request = AccessDialogRequest {
+            app_id,
+            parent_window,
+            title,
+            subtitle,
+            body,
+            options,
+
+            response_channel_sender,
+        };
+        (request, response_channel_receiver)
+    }
+
+    pub fn grant(self) -> anyhow::Result<()> {
+        self.response_channel_sender
+            .send_blocking(AccessDialogResponse::Grant)?;
+        Ok(())
+    }
+
+    pub fn deny(self) -> anyhow::Result<()> {
+        self.response_channel_sender
+            .send_blocking(AccessDialogResponse::Deny)?;
+        Ok(())
+    }
+}
+
+pub enum AccessDialogResponse {
+    Grant,
+    Deny,
+}
+
+fn render(scale: f64, request: &AccessDialogRequest) -> anyhow::Result<MemoryBuffer> {
+    let _span = tracy_client::span!("access_dialog_ui::render");
+
+    let padding: i32 = to_physical_precise_round(scale, PADDING);
+
+    let mut font = FontDescription::from_string(FONT);
+    font.set_absolute_size(to_physical_precise_round(scale, font.size()));
+
+    let text = format!(
+        "<span weight='bold' underline='single'>{}</span>\n\
+        {}\n\n\
+        {}\
+        Press <span face='mono' bgcolor='#2C2C2C'> Enter </span> to {} or <span face='mono' bgcolor='#2C2C2C'> Escape </span> to {}.",
+        request.title,
+        request.subtitle,
+        request.body.as_deref().map(|body| format!("{}\n\n", body)).unwrap_or("".to_string()),
+        request.options.grant_label.as_deref().unwrap_or("grant"),
+        request.options.deny_label.as_deref().unwrap_or("deny"),
+    );
+
+    let surface = ImageSurface::create(cairo::Format::ARgb32, 0, 0)?;
+    let cr = cairo::Context::new(&surface)?;
+    let layout = pangocairo::functions::create_layout(&cr);
+    layout.context().set_round_glyph_positions(false);
+    layout.set_font_description(Some(&font));
+    layout.set_alignment(Alignment::Center);
+    layout.set_markup(&text);
+
+    let (mut width, mut height) = layout.pixel_size();
+    width += padding * 2;
+    height += padding * 2;
+
+    let surface = ImageSurface::create(cairo::Format::ARgb32, width, height)?;
+    let cr = cairo::Context::new(&surface)?;
+    cr.set_source_rgb(0.1, 0.1, 0.1);
+    cr.paint()?;
+
+    cr.move_to(padding.into(), padding.into());
+    let layout = pangocairo::functions::create_layout(&cr);
+    layout.context().set_round_glyph_positions(false);
+    layout.set_font_description(Some(&font));
+    layout.set_alignment(Alignment::Center);
+    layout.set_markup(&text);
+
+    cr.set_source_rgb(1., 1., 1.);
+    pangocairo::functions::show_layout(&cr, &layout);
+
+    cr.move_to(0., 0.);
+    cr.line_to(width.into(), 0.);
+    cr.line_to(width.into(), height.into());
+    cr.line_to(0., height.into());
+    cr.line_to(0., 0.);
+    cr.set_source_rgb(1., 0.3, 0.3);
+    // Keep the border width even to avoid blurry edges.
+    cr.set_line_width((f64::from(BORDER) / 2. * scale).round() * 2.);
+    cr.stroke()?;
+    drop(cr);
+
+    let data = surface.take_data().unwrap();
+    let buffer = MemoryBuffer::new(
+        data.to_vec(),
+        Fourcc::Argb8888,
+        (width, height),
+        scale,
+        Transform::Normal,
+    );
+
+    Ok(buffer)
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod access_dialog;
 pub mod config_error_notification;
 pub mod exit_confirm_dialog;
 pub mod hotkey_overlay;


### PR DESCRIPTION
Accessing certain devices like cameras might require permissions. This is handled in xdg-desktop-portal by issuing an access dialog. The backend is expected to expose the [org.freedesktop.impl.portal.Access](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.Access.html) dbus interface.

## TODO:

- [x] Handling `options`, especially `choices` -> partially done, `grant_label` and `deny_label` should at least work
- [x] ~~Proper~~ UI (atm just copy of exit dialog with changed message) -> Uses `title`,`subtitle` and the optional `body`