### PR TITLE
portal: prefer gtk for access portal

### DIFF
--- a/resources/niri-portals.conf
+++ b/resources/niri-portals.conf
@@ -1,3 +1,4 @@
 [preferred]
 default=gnome;gtk;
+org.freedesktop.impl.portal.Access=gtk;
 org.freedesktop.impl.portal.Secret=gnome-keyring;


### PR DESCRIPTION
using gnome for the access portal does not work,
so just override by directly using the gtk one