### PR TITLE
flake: `libseat` renamed to `seatd`; add missing runtime dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
           libclang,
           libdisplay-info,
           libinput,
-          libseat,
+          seatd,
           libxkbcommon,
           mesa,
           pango,
@@ -90,7 +90,7 @@
               libGL
               libdisplay-info
               libinput
-              libseat
+              seatd
               libxkbcommon
               mesa # libgbm
               pango

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
 
             # Force linking with libEGL and libwayland-client
             # so they can be discovered by `dlopen()`
-            CARGO_BUILD_RUSTFLAGS = toString (
+            RUSTFLAGS = toString (
               map (arg: "-C link-arg=" + arg) [
                 "-Wl,--push-state,--no-as-needed"
                 "-lEGL"
@@ -208,7 +208,7 @@
               # in the package expression
               #
               # This should only be set with `CARGO_BUILD_RUSTFLAGS="$CARGO_BUILD_RUSTFLAGS -C your-flags"`
-              inherit (niri) CARGO_BUILD_RUSTFLAGS;
+              CARGO_BUILD_RUSTFLAGS = niri.RUSTFLAGS;
             };
           };
         }


### PR DESCRIPTION
1. In newer nixpkgs, `libseat` alias for `seatd` got removed. This doesn't affect the current `flake.lock` version, but it will in the future.
2. Added `runtimeDependencies` and `autoPatchelfHook`. Without that, built `niri` binary wouldn't work (it would panic at startup). I think they were part of the flake some time ago, but got removed (I think in #687 ), I don't know why.

@getchoo @sodiboo you were involved with this flake, so maybe you have any comments. I just made it work for me ;]