### PR TITLE
xdg: startup activation

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1537,6 +1537,8 @@ pub struct DebugConfig {
     pub keep_laptop_panel_on_when_lid_is_closed: bool,
     #[knuffel(child)]
     pub disable_monitor_names: bool,
+    #[knuffel(child)]
+    pub strict_new_window_focus_policy: bool,
 }
 
 #[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq)]

--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use niri::animation::Clock;
 use niri::layout::workspace::ColumnWidth;
-use niri::layout::{LayoutElement as _, Options};
+use niri::layout::{ActivateWindow, LayoutElement as _, Options};
 use niri::render_helpers::RenderTarget;
 use niri_config::{Color, FloatOrInt, OutputName};
 use smithay::backend::renderer::element::RenderElement;
@@ -162,7 +162,8 @@ impl Layout {
         window.request_size(ws.new_window_size(width, window.rules()), false, None);
         window.communicate();
 
-        self.layout.add_window(window.clone(), width, false);
+        self.layout
+            .add_window(window.clone(), width, false, ActivateWindow::default());
         self.windows.push(window);
     }
 

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -145,7 +145,14 @@ impl CompositorHandler for State {
                         .filter(|token| token.timestamp.elapsed() < XDG_ACTIVATION_TOKEN_TIMEOUT)
                     {
                         Some(_) => ActivateWindow::Yes,
-                        None => ActivateWindow::Smart,
+                        None => {
+                            let config = self.niri.config.borrow();
+                            if config.debug.strict_new_window_focus_policy {
+                                ActivateWindow::No
+                            } else {
+                                ActivateWindow::Smart
+                            }
+                        }
                     };
 
                     let output = if let Some(p) = parent {

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -18,6 +18,8 @@ use smithay::wayland::shm::{ShmHandler, ShmState};
 use smithay::{delegate_compositor, delegate_shm};
 
 use super::xdg_shell::add_mapped_toplevel_pre_commit_hook;
+use crate::handlers::XDG_ACTIVATION_TOKEN_TIMEOUT;
+use crate::layout::ActivateWindow;
 use crate::niri::{ClientState, State};
 use crate::utils::send_scale_transform;
 use crate::utils::transaction::Transaction;
@@ -84,7 +86,11 @@ impl CompositorHandler for State {
 
                 if is_mapped {
                     // The toplevel got mapped.
-                    let Unmapped { window, state } = entry.remove();
+                    let Unmapped {
+                        window,
+                        state,
+                        activation_token_data,
+                    } = entry.remove();
 
                     window.on_commit();
 
@@ -133,8 +139,20 @@ impl CompositorHandler for State {
                     let mapped = Mapped::new(window, rules, hook);
                     let window = mapped.window.clone();
 
+                    // Check the token timestamp again in case the window took a while between
+                    // requesting activation and mapping.
+                    let activate = match activation_token_data
+                        .filter(|token| token.timestamp.elapsed() < XDG_ACTIVATION_TOKEN_TIMEOUT)
+                    {
+                        Some(_) => ActivateWindow::Yes,
+                        None => ActivateWindow::Smart,
+                    };
+
                     let output = if let Some(p) = parent {
                         // Open dialogs immediately to the right of their parent window.
+                        //
+                        // FIXME: do we want to use activate here? How do we want things to behave
+                        // exactly?
                         self.niri
                             .layout
                             .add_window_right_of(&p, mapped, width, is_full_width)
@@ -144,14 +162,21 @@ impl CompositorHandler for State {
                             mapped,
                             width,
                             is_full_width,
+                            activate,
                         )
                     } else if let Some(output) = &output {
-                        self.niri
-                            .layout
-                            .add_window_on_output(output, mapped, width, is_full_width);
+                        self.niri.layout.add_window_on_output(
+                            output,
+                            mapped,
+                            width,
+                            is_full_width,
+                            activate,
+                        );
                         Some(output)
                     } else {
-                        self.niri.layout.add_window(mapped, width, is_full_width)
+                        self.niri
+                            .layout
+                            .add_window(mapped, width, is_full_width, activate)
                     };
 
                     if let Some(output) = output.cloned() {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -670,10 +670,12 @@ impl XdgActivationHandler for State {
                 self.niri.layout.activate_window(&window);
                 self.niri.layer_shell_on_demand_focus = None;
                 self.niri.queue_redraw_all();
-
-                self.niri.activation_state.remove_token(&token);
+            } else if let Some(unmapped) = self.niri.unmapped_windows.get_mut(&surface) {
+                unmapped.activation_token_data = Some(token_data);
             }
         }
+
+        self.niri.activation_state.remove_token(&token);
     }
 }
 delegate_xdg_activation!(State);

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -752,7 +752,7 @@ impl State {
             self.niri.is_at_startup,
         );
 
-        let Unmapped { window, state } = unmapped;
+        let Unmapped { window, state, .. } = unmapped;
 
         let InitialConfigureState::NotConfigured { wants_fullscreen } = state else {
             error!("window must not be already configured in send_initial_configure()");

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -520,7 +520,8 @@ impl State {
                 self.niri.debug_toggle_damage();
             }
             Action::Spawn(command) => {
-                spawn(command);
+                let (token, _) = self.niri.activation_state.create_external_token(None);
+                spawn(command, Some(token.clone()));
             }
             Action::DoScreenTransition(delay_ms) => {
                 self.backend.with_primary_renderer(|renderer| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,10 +236,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Spawn commands from cli and auto-start.
-    spawn(cli.command);
+    spawn(cli.command, None);
 
     for elem in spawn_at_startup {
-        spawn(elem.command);
+        spawn(elem.command, None);
     }
 
     // Show the config error notification right away if needed.

--- a/src/window/unmapped.rs
+++ b/src/window/unmapped.rs
@@ -1,6 +1,7 @@
 use smithay::desktop::Window;
 use smithay::output::Output;
 use smithay::wayland::shell::xdg::ToplevelSurface;
+use smithay::wayland::xdg_activation::XdgActivationTokenData;
 
 use super::ResolvedWindowRules;
 use crate::layout::workspace::ColumnWidth;
@@ -9,6 +10,8 @@ use crate::layout::workspace::ColumnWidth;
 pub struct Unmapped {
     pub window: Window,
     pub state: InitialConfigureState,
+    /// Activation token, if one was used on this unmapped window.
+    pub activation_token_data: Option<XdgActivationTokenData>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -57,6 +60,7 @@ impl Unmapped {
             state: InitialConfigureState::NotConfigured {
                 wants_fullscreen: None,
             },
+            activation_token_data: None,
         }
     }
 

--- a/wiki/Configuration:-Debug-Options.md
+++ b/wiki/Configuration:-Debug-Options.md
@@ -24,6 +24,7 @@ debug {
     disable-transactions
     keep-laptop-panel-on-when-lid-is-closed
     disable-monitor-names
+    strict-new-window-focus-policy
 }
 
 binds {
@@ -191,6 +192,19 @@ Use this flag to work around a crash present in 0.1.9 and 0.1.10 when connecting
 ```kdl
 debug {
     disable-monitor-names
+}
+```
+
+### `strict-new-window-focus-policy`
+
+<sup>Since: 0.1.11</sup>
+
+Disables heuristic automatic focusing for new windows.
+Only windows that activate themselves with a valid xdg-activation token will be focused.
+
+```kdl
+debug {
+    strict-new-window-focus-policy
 }
 ```
 


### PR DESCRIPTION
Okay, at first it looked like an easy task to just extend the logic to pass an activation token to process spawned through actions.

But it looks like the whole activation implementation misses some parts to actually make this work.
Actually it also looks like activation is not handled for launchers like fuzzel.

The reason is that `XdgActivationState::request_activation` might be called before the window is actually mapped
as part of the startup.

A quick look at sway reveals that it also handles unmapped windows, but in this case make sure that an token is only used once.

Draft because testing this will need the above to be fixed before.