### PR TITLE
skip keyboard focus for layer shell surfaces not...

### DIFF
--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -374,7 +374,6 @@ impl XdgShellHandler for State {
         }
 
         trace!("new grab for root {:?}", root);
-        keyboard.set_focus(self, grab.current_grab(), serial);
         keyboard.set_grab(self, PopupKeyboardGrab::new(&grab), serial);
         pointer.set_grab(self, PopupPointerGrab::new(&grab), serial, Focus::Keep);
         self.niri.popup_grab = Some(PopupGrabState { root, grab });


### PR DESCRIPTION
...requesting keyboard interactivity

I have seen clients reacting weird when receiving keyboard focus unexpectedly.
The last time it was about implicit focus for popups in firefox, which immediately dismissed the popup.
Looks like the same applies to layer surfaces not requesting keyboard interactivity.

fixes #311 