### PR TITLE
nix: use bindgen hook over directly depending on `clang`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nix-filter": {
       "locked": {
-        "lastModified": 1710156097,
-        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
+        "lastModified": 1731533336,
+        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
+        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726365531,
-        "narHash": "sha256-luAKNxWZ+ZN0kaHchx1OdLQ71n81Y31ryNPWP1YRDZc=",
+        "lastModified": 1733064805,
+        "narHash": "sha256-7NbtSLfZO0q7MXPl5hzA0sbVJt6pWxxtGWbaVUDDmjs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9299cdf978e15f448cf82667b0ffdd480b44ee48",
+        "rev": "31d66ae40417bb13765b0ad75dd200400e98de84",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727663505,
-        "narHash": "sha256-83j/GrHsx8GFUcQofKh+PRPz6pz8sxAsZyT/HCNdey8=",
+        "lastModified": 1733106880,
+        "narHash": "sha256-aJmAIjZfWfPSWSExwrYBLRgXVvgF5LP1vaeUGOOIQ98=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c2099c6c7599ea1980151b8b6247a8f93e1806ee",
+        "rev": "e66c0d43abf5bdefb664c3583ca8994983c332ae",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,10 +26,8 @@
         {
           lib,
           cairo,
-          clang,
           dbus,
           libGL,
-          libclang,
           libdisplay-info,
           libinput,
           seatd,
@@ -79,7 +77,7 @@
           strictDeps = true;
 
           nativeBuildInputs = [
-            clang
+            rustPlatform.bindgenHook
             pkg-config
           ];
 
@@ -119,8 +117,6 @@
             '';
 
           env = {
-            LIBCLANG_PATH = lib.getLib libclang + "/lib";
-
             # Force linking with libEGL and libwayland-client
             # so they can be discovered by `dlopen()`
             RUSTFLAGS = toString (
@@ -191,7 +187,7 @@
             ];
 
             nativeBuildInputs = [
-              pkgs.clang
+              pkgs.rustPlatform.bindgenHook
               pkgs.pkg-config
               pkgs.wrapGAppsHook4 # For `niri-visual-tests`
             ];
@@ -201,8 +197,6 @@
             ];
 
             env = {
-              inherit (niri) LIBCLANG_PATH;
-
               # WARN: Do not overwrite this variable in your shell!
               # It is required for `dlopen()` to work on some libraries; see the comment
               # in the package expression


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/360711 helped me realize what `bindgenHook` actually does.

in fact, it is a simple thing that just sets `LIBCLANG_PATH` for us. this is meant to be used in conjunction with `bindgen`, hence `bindgenHook`.

![image](https://github.com/user-attachments/assets/4dd7e2c6-e578-41be-866b-ffa09328262e)

so we don't need to set `LIBCLANG_PATH`.

no idea about `RUSTFLAGS` though. i tried to make it build properly without nix needing to pass it but i didn't get anywhere

bonus: updated flake lock, which was like 3 months out of date. there's not really a pressing need to do so but it's in general nice to have it be somewhat recentish. also means nix-based developers (hi that's me i work on niri at times from nix) get new nightly Rust yay :3