### PR TITLE
Add `Mouse{Left,Right,Middle,Back,Forward}` binds

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1124,6 +1124,11 @@ pub struct Key {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum Trigger {
     Keysym(Keysym),
+    MouseLeft,
+    MouseRight,
+    MouseMiddle,
+    MouseBack,
+    MouseForward,
     WheelScrollDown,
     WheelScrollUp,
     WheelScrollLeft,
@@ -2924,7 +2929,17 @@ impl FromStr for Key {
             }
         }
 
-        let trigger = if key.eq_ignore_ascii_case("WheelScrollDown") {
+        let trigger = if key.eq_ignore_ascii_case("MouseLeft") {
+            Trigger::MouseLeft
+        } else if key.eq_ignore_ascii_case("MouseRight") {
+            Trigger::MouseRight
+        } else if key.eq_ignore_ascii_case("MouseMiddle") {
+            Trigger::MouseMiddle
+        } else if key.eq_ignore_ascii_case("MouseBack") {
+            Trigger::MouseBack
+        } else if key.eq_ignore_ascii_case("MouseForward") {
+            Trigger::MouseForward
+        } else if key.eq_ignore_ascii_case("WheelScrollDown") {
             Trigger::WheelScrollDown
         } else if key.eq_ignore_ascii_case("WheelScrollUp") {
             Trigger::WheelScrollUp

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -415,6 +415,11 @@ fn key_name(comp_mod: CompositorMod, key: &Key) -> String {
 
     let pretty = match key.trigger {
         Trigger::Keysym(keysym) => prettify_keysym_name(&keysym_get_name(keysym)),
+        Trigger::MouseLeft => String::from("Mouse Left"),
+        Trigger::MouseRight => String::from("Mouse Right"),
+        Trigger::MouseMiddle => String::from("Mouse Middle"),
+        Trigger::MouseBack => String::from("Mouse Back"),
+        Trigger::MouseForward => String::from("Mouse Forward"),
         Trigger::WheelScrollDown => String::from("Wheel Scroll Down"),
         Trigger::WheelScrollUp => String::from("Wheel Scroll Up"),
         Trigger::WheelScrollLeft => String::from("Wheel Scroll Left"),

--- a/wiki/Configuration:-Key-Bindings.md
+++ b/wiki/Configuration:-Key-Bindings.md
@@ -99,6 +99,26 @@ binds {
 Both mouse wheel and touchpad scroll binds will prevent applications from receiving any scroll events when their modifiers are held down.
 For example, if you have a `Mod+WheelScrollDown` bind, then while holding `Mod`, all mouse wheel scrolling will be consumed by niri.
 
+### Mouse Click Bindings
+
+<sup>Since: next release</sup>
+
+You can bind mouse clicks using the following syntax.
+
+```kdl
+binds {
+    Mod+MouseLeft    { close-window; }
+    Mod+MouseRight   { close-window; }
+    Mod+MouseMiddle  { close-window; }
+    Mod+MouseForward { close-window; }
+    Mod+MouseBack    { close-window; }
+}
+```
+
+Mouse clicks operate on the window that was focused at the time of the click, not the window you're clicking.
+
+Note that binding `Mod+MouseLeft` or `Mod+MouseRight` will override the corresponding gesture (moving or resizing the window).
+
 ### Actions
 
 Every action that you can bind is also available for programmatic invocation via `niri msg action`.


### PR DESCRIPTION
I'm not entirely sure about the name, I originally named everything with `Pointer` because it's technically more correct, but I think it made it less clear.

I don't know the history behind `BTN_BACK == BTN_SIDE` and `BTN_FORWARD == BTN_EXTRA`, but everyone seems to be doing it so if it's "wrong" it's better for compatability. It's my fault it's like that on winit too :P

Fixes #761.