### PR TITLE
Check for layer surface under cursor when clicking

### DIFF
--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2408,7 +2408,19 @@ impl Niri {
 
         // Check if some layer-shell surface is on top.
         let layers = layer_map_for_output(output);
-        let layer_under = |layer| layers.layer_under(layer, pos_within_output).is_some();
+        let layer_under = |layer| {
+            layers
+                .layer_under(layer, pos_within_output)
+                .and_then(|layer| {
+                    let layer_pos_within_output =
+                        layers.layer_geometry(layer).unwrap().loc.to_f64();
+                    layer.surface_under(
+                        pos_within_output - layer_pos_within_output,
+                        WindowSurfaceType::ALL,
+                    )
+                })
+                .is_some()
+        };
         if layer_under(Layer::Overlay) {
             return None;
         }


### PR DESCRIPTION
Currently, windows don't get focus when clicking on them through a clickthrough layer. This PR fixes that by only considering layers under the cursor if we fall in an input area.