### PR TITLE
Add a window swap operation

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1240,6 +1240,8 @@ pub enum Action {
     ConsumeOrExpelWindowRightById(u64),
     ConsumeWindowIntoColumn,
     ExpelWindowFromColumn,
+    SwapWindowLeft,
+    SwapWindowRight,
     CenterColumn,
     CenterWindow,
     #[knuffel(skip)]
@@ -1397,6 +1399,8 @@ impl From<niri_ipc::Action> for Action {
             }
             niri_ipc::Action::ConsumeWindowIntoColumn {} => Self::ConsumeWindowIntoColumn,
             niri_ipc::Action::ExpelWindowFromColumn {} => Self::ExpelWindowFromColumn,
+            niri_ipc::Action::SwapWindowRight {} => Self::SwapWindowRight,
+            niri_ipc::Action::SwapWindowLeft {} => Self::SwapWindowLeft,
             niri_ipc::Action::CenterColumn {} => Self::CenterColumn,
             niri_ipc::Action::CenterWindow { id: None } => Self::CenterWindow,
             niri_ipc::Action::CenterWindow { id: Some(id) } => Self::CenterWindowById(id),

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -290,6 +290,10 @@ pub enum Action {
     ConsumeWindowIntoColumn {},
     /// Expel the focused window from the column.
     ExpelWindowFromColumn {},
+    /// Swap focused window with one to the right
+    SwapWindowRight {},
+    /// Swap focused window with one to the left
+    SwapWindowLeft {},
     /// Center the focused column on the screen.
     CenterColumn {},
     /// Center a window on the screen.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -36,6 +36,7 @@ use touch_move_grab::TouchMoveGrab;
 use self::move_grab::MoveGrab;
 use self::resize_grab::ResizeGrab;
 use self::spatial_movement_grab::SpatialMovementGrab;
+use crate::layout::scrolling::ScrollDirection;
 use crate::niri::State;
 use crate::ui::screenshot_ui::ScreenshotUi;
 use crate::utils::spawning::spawn;
@@ -1128,6 +1129,22 @@ impl State {
             }
             Action::ExpelWindowFromColumn => {
                 self.niri.layout.expel_from_column();
+                self.maybe_warp_cursor_to_focus();
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
+            Action::SwapWindowRight => {
+                self.niri
+                    .layout
+                    .swap_window_in_direction(ScrollDirection::Right);
+                self.maybe_warp_cursor_to_focus();
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
+            Action::SwapWindowLeft => {
+                self.niri
+                    .layout
+                    .swap_window_in_direction(ScrollDirection::Left);
                 self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -9,7 +9,7 @@ use smithay::backend::renderer::element::utils::{
 use smithay::output::Output;
 use smithay::utils::{Logical, Point, Rectangle, Size};
 
-use super::scrolling::{Column, ColumnWidth};
+use super::scrolling::{Column, ColumnWidth, ScrollDirection};
 use super::tile::Tile;
 use super::workspace::{
     OutputId, Workspace, WorkspaceAddWindowTarget, WorkspaceId, WorkspaceRenderElement,
@@ -705,6 +705,10 @@ impl<W: LayoutElement> Monitor<W> {
 
     pub fn expel_from_column(&mut self) {
         self.active_workspace().expel_from_column();
+    }
+
+    pub fn swap_window_in_direction(&mut self, direction: ScrollDirection) {
+        self.active_workspace().swap_window_in_direction(direction);
     }
 
     pub fn center_column(&mut self) {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -15,7 +15,8 @@ use smithay::wayland::shell::xdg::SurfaceCachedState;
 
 use super::floating::{FloatingSpace, FloatingSpaceRenderElement};
 use super::scrolling::{
-    Column, ColumnWidth, InsertHint, InsertPosition, ScrollingSpace, ScrollingSpaceRenderElement,
+    Column, ColumnWidth, InsertHint, InsertPosition, ScrollDirection, ScrollingSpace,
+    ScrollingSpaceRenderElement,
 };
 use super::tile::{Tile, TileRenderSnapshot};
 use super::{ActivateWindow, InteractiveResizeData, LayoutElement, Options, RemovedTile, SizeFrac};
@@ -967,6 +968,13 @@ impl<W: LayoutElement> Workspace<W> {
             return;
         }
         self.scrolling.expel_from_column();
+    }
+
+    pub fn swap_window_in_direction(&mut self, direction: ScrollDirection) {
+        if self.floating_is_active.get() {
+            return;
+        }
+        self.scrolling.swap_window_in_direction(direction);
     }
 
     pub fn center_column(&mut self) {


### PR DESCRIPTION
Swap the active window in the active column with a neighboring column's active window.

This PR adds a `swap-window-left` and `swap-window-right` action. They are used to swap the active window
in the active column with the active window in a neighboring column. When there is no neighboring column it
behaves just like the respective `expel-window-....` actions.

This is something quite simple but that I often found missing when using Niri. It was standard in Awesome and easy enough to script in Sway, but I was unable to create a decent niri-ipc based version.