### PR TITLE
Allow workspace names to be changed dynamically

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1221,6 +1221,8 @@ pub enum Action {
     MoveColumnToWorkspace(#[knuffel(argument)] WorkspaceReference),
     MoveWorkspaceDown,
     MoveWorkspaceUp,
+    SetWorkspaceName(#[knuffel(argument)] String),
+    UnsetWorkspaceName,
     FocusMonitorLeft,
     FocusMonitorRight,
     FocusMonitorDown,
@@ -1349,6 +1351,10 @@ impl From<niri_ipc::Action> for Action {
             }
             niri_ipc::Action::MoveWorkspaceDown {} => Self::MoveWorkspaceDown,
             niri_ipc::Action::MoveWorkspaceUp {} => Self::MoveWorkspaceUp,
+            niri_ipc::Action::SetWorkspaceName {
+                name,
+            } => Self::SetWorkspaceName(name),
+            niri_ipc::Action::UnsetWorkspaceName {} => Self::UnsetWorkspaceName,
             niri_ipc::Action::FocusMonitorLeft {} => Self::FocusMonitorLeft,
             niri_ipc::Action::FocusMonitorRight {} => Self::FocusMonitorRight,
             niri_ipc::Action::FocusMonitorDown {} => Self::FocusMonitorDown,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -338,6 +338,14 @@ pub enum Action {
     MoveWorkspaceDown {},
     /// Move the focused workspace up.
     MoveWorkspaceUp {},
+    /// Set the name of the focused workspace.
+    SetWorkspaceName {
+        /// New name for the workspace.
+        #[cfg_attr(feature = "clap", arg())]
+        name: String,
+    },
+    /// Unset the name of te focused workspace.
+    UnsetWorkspaceName {},
     /// Focus the monitor to the left.
     FocusMonitorLeft {},
     /// Focus the monitor to the right.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1096,6 +1096,12 @@ impl State {
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
+            Action::SetWorkspaceName(name) => {
+                self.niri.layout.set_workspace_name(name);
+            }
+            Action::UnsetWorkspaceName => {
+                self.niri.layout.unset_workspace_name();
+            }
             Action::ConsumeWindowIntoColumn => {
                 self.niri.layout.consume_into_column();
                 // This does not cause immediate focus or window size change, so warping mouse to

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -3394,6 +3394,26 @@ impl<W: LayoutElement> Layout<W> {
         monitor.move_workspace_up();
     }
 
+    pub fn set_workspace_name(&mut self, name: String) {
+        // ignore request if the name is an integer
+        if name.parse::<usize>().is_ok() { return }
+
+        // also ignore the request if the name is already used by another workspace
+        if self.find_workspace_by_name(&name).is_some() { return }
+
+        let Some(monitor) = self.active_monitor() else {
+            return;
+        };
+        monitor.set_workspace_name(name);
+    }
+
+    pub fn unset_workspace_name(&mut self) {
+        let Some(monitor) = self.active_monitor() else {
+            return;
+        };
+        monitor.unset_workspace_name();
+    }
+
     pub fn start_open_animation_for_window(&mut self, window: &W::Id) {
         if let Some(InteractiveMoveState::Moving(move_)) = &self.interactive_move {
             if move_.tile.window().id() == window {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -658,6 +658,16 @@ impl<W: LayoutElement> Monitor<W> {
         }
     }
 
+    pub fn set_workspace_name(&mut self, name: String) {
+        let ws = &mut self.workspaces[self.active_workspace_idx];
+        ws.name.replace(name);
+    }
+
+    pub fn unset_workspace_name(&mut self) {
+        let ws = &mut self.workspaces[self.active_workspace_idx];
+        ws.name.take();
+    }
+
     pub fn consume_into_column(&mut self) {
         self.active_workspace().consume_into_column();
     }


### PR DESCRIPTION
A trivial PR that adds `set-workspace-name` and `unset-workspace-name` actions.

This is really nifty when combined with the [Waybar Niri workspace module](https://github.com/Alexays/Waybar/wiki/Module:-Niri#workspaces).