### PR TITLE
Highlight that the path in niri.service should be checked

### DIFF
--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -164,7 +164,7 @@ nix run --impure github:guibou/nixGL -- ./results/bin/niri
 
 If installing directly without a package, the recommended file destinations are slightly different.
 In this case, put the files in the directories indicated in the table below.
-These may vary depending on your distribution.
+These may vary depending on your distribution. Don't forget to make sure that the path to `niri` in niri.service is correct. This defaults to /usr/bin/niri.
 
 | File | Destination |
 | ---- | ----------- |

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -164,7 +164,10 @@ nix run --impure github:guibou/nixGL -- ./results/bin/niri
 
 If installing directly without a package, the recommended file destinations are slightly different.
 In this case, put the files in the directories indicated in the table below.
-These may vary depending on your distribution. Don't forget to make sure that the path to `niri` in niri.service is correct. This defaults to /usr/bin/niri.
+These may vary depending on your distribution.
+
+Don't forget to make sure that the path to `niri` in niri.service is correct.
+This defaults to `/usr/bin/niri`.
 
 | File | Destination |
 | ---- | ----------- |


### PR DESCRIPTION
Having just installed niri I ran into this issue.  When building from source on Ubuntu the install location using the instructions in this document is /usr/local//bin/niri.

However niri.service pointed to /usr/bin/niri so my session would not start at all. Hopefully this update helps