### PR TITLE
WIP: per-output default column width

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -372,6 +372,8 @@ pub struct Output {
     pub variable_refresh_rate: Option<Vrr>,
     #[knuffel(child, default = DEFAULT_BACKGROUND_COLOR)]
     pub background_color: Color,
+    #[knuffel(child)]
+    pub default_column_width: Option<DefaultPresetSize>,
 }
 
 impl Output {
@@ -399,6 +401,7 @@ impl Default for Output {
             mode: None,
             variable_refresh_rate: None,
             background_color: DEFAULT_BACKGROUND_COLOR,
+            default_column_width: None,
         }
     }
 }
@@ -3420,6 +3423,7 @@ mod tests {
                     }),
                     variable_refresh_rate: Some(Vrr { on_demand: true }),
                     background_color: Color::from_rgba8_unpremul(25, 25, 102, 255),
+                    default_column_width: None,
                 }]),
                 layout: Layout {
                     focus_ring: FocusRing {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -2,7 +2,9 @@ use std::cmp::max;
 use std::rc::Rc;
 use std::time::Duration;
 
-use niri_config::{CenterFocusedColumn, OutputName, PresetSize, Workspace as WorkspaceConfig};
+use niri_config::{
+    CenterFocusedColumn, DefaultPresetSize, OutputName, PresetSize, Workspace as WorkspaceConfig,
+};
 use niri_ipc::{PositionChange, SizeChange};
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::desktop::{layer_map_for_output, Window};
@@ -708,11 +710,17 @@ impl<W: LayoutElement> Workspace<W> {
         default_width: Option<Option<ColumnWidth>>,
         is_floating: bool,
     ) -> Option<ColumnWidth> {
-        match default_width {
-            Some(Some(width)) => Some(width),
-            Some(None) => None,
-            None if is_floating => None,
-            None => self.options.default_column_width,
+        let output_default_width = self
+            .output
+            .as_ref()
+            .map(|o| o.user_data().get::<Option<DefaultPresetSize>>())
+            .unwrap_or(None);
+        match (default_width, output_default_width) {
+            (Some(Some(width)), _) => Some(width),
+            (Some(None), _) => None,
+            (None, _) if is_floating => None,
+            (None, Some(Some(DefaultPresetSize(Some(width))))) => Some(ColumnWidth::from(*width)),
+            (None, _) => self.options.default_column_width,
         }
     }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2274,6 +2274,12 @@ impl Niri {
             .to_array_unpremul();
         background_color[3] = 1.;
 
+        let default_column_width = c.map(|c| c.default_column_width).unwrap_or(None);
+
+        output
+            .user_data()
+            .insert_if_missing(|| default_column_width);
+
         // FIXME: fix winit damage on other transforms.
         if name.connector == "winit" {
             transform = Transform::Flipped180;


### PR DESCRIPTION
Add a way to set the default column width per-output.

This is useful when there are multiple outputs with wildly different
aspect ratios, such as one vertical and one horizontal; with this change,
one can set the default width to 1.0 on a vertical one and 0.5 on the
horizontal one, making niri much more usable.

I'm making this draft just to see if a change like this would be accepted;

If there's a chance, I'll add some tests, documentation, and maybe think about
the priorities of various defaults a bit more.
