### PR TITLE
Add setting to disable primary selection

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -53,6 +53,8 @@ pub struct Config {
     ]
     pub screenshot_path: Option<String>,
     #[knuffel(child, default)]
+    pub clipboard: Clipboard,
+    #[knuffel(child, default)]
     pub hotkey_overlay: HotkeyOverlay,
     #[knuffel(child, default)]
     pub animations: Animations,
@@ -783,6 +785,12 @@ pub struct Struts {
 pub struct HotkeyOverlay {
     #[knuffel(child)]
     pub skip_at_startup: bool,
+}
+
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Clipboard {
+    #[knuffel(child)]
+    pub disable_primary: bool,
 }
 
 #[derive(knuffel::Decode, Debug, Clone, PartialEq)]
@@ -3432,6 +3440,10 @@ mod tests {
 
             screenshot-path "~/Screenshots/screenshot.png"
 
+            clipboard {
+                disable-primary
+            }
+
             hotkey-overlay {
                 skip-at-startup
             }
@@ -3686,6 +3698,9 @@ mod tests {
                     hide_after_inactive_ms: Some(3000),
                 },
                 screenshot_path: Some(String::from("~/Screenshots/screenshot.png")),
+                clipboard: Clipboard {
+                    disable_primary: true,
+                },
                 hotkey_overlay: HotkeyOverlay {
                     skip_at_startup: true,
                 },

--- a/src/dbus/mutter_service_channel.rs
+++ b/src/dbus/mutter_service_channel.rs
@@ -28,6 +28,7 @@ impl ServiceChannel {
             compositor_state: Default::default(),
             // Would be nice to thread config here but for now it's fine.
             can_view_decoration_globals: false,
+            primary_selection_disabled: false,
             restricted: false,
             // FIXME: maybe you can get the PID from D-Bus somehow?
             credentials_unknown: true,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -475,6 +475,7 @@ impl SecurityContextHandler for State {
                 let data = Arc::new(ClientState {
                     compositor_state: Default::default(),
                     can_view_decoration_globals: config.prefer_no_csd,
+                    primary_selection_disabled: config.clipboard.disable_primary,
                     restricted: true,
                     credentials_unknown: false,
                 });


### PR DESCRIPTION
I've been using a custom build for a while where I commented out the primary selection code.
There's probably other users that don't want the primary selection, so I made it into a configurable feature.

I wasn't sure how to implement this (especially with live-reload involved, which I've intentionally ignored).
Feedback welcome.