### PR TITLE
IPC: Accept multiple actions from stdin

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -43,6 +43,8 @@ use serde::{Deserialize, Serialize};
 pub mod socket;
 pub mod state;
 
+mod utils;
+
 /// Request from client to niri.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
@@ -63,8 +65,8 @@ pub enum Request {
     FocusedOutput,
     /// Request information about the focused window.
     FocusedWindow,
-    /// Perform an action.
-    Action(Action),
+    /// Perform actions.
+    Action(#[serde(with = "utils::one_or_many")] Vec<Action>),
     /// Change output configuration temporarily.
     ///
     /// The configuration is changed temporarily and not saved into the config file. If the output

--- a/niri-ipc/src/utils.rs
+++ b/niri-ipc/src/utils.rs
@@ -30,55 +30,57 @@ pub(crate) mod one_or_many {
 
     #[cfg(test)]
     mod tests {
+        use std::fmt::Debug;
+
         use serde_json::de::SliceRead;
         use serde_json::{Deserializer, Serializer, Value};
 
         use super::*;
 
+        fn test_serialize<T: Serialize>(value: &Vec<T>, expected: &str) {
+            let mut bytes = Vec::new();
+            let mut serializer = Serializer::new(&mut bytes);
+            serialize(value, &mut serializer).expect("failed to serialize");
+            assert_eq!(String::from_utf8_lossy(&bytes), expected);
+        }
+
+        fn test_deserialize<'de, T>(value: &'de str, expected: &Vec<T>)
+        where
+            T: Deserialize<'de> + Debug + PartialEq,
+        {
+            let mut deserailier = Deserializer::new(SliceRead::new(value.as_bytes()));
+            let result: Vec<T> = deserialize(&mut deserailier).expect("failed to deserialize");
+            assert_eq!(&result, expected);
+        }
+
         #[test]
         fn serialize_one() {
-            let mut result = Vec::new();
-            let mut serializer = Serializer::new(&mut result);
-            serialize(&vec![Value::Null], &mut serializer).expect("failed to serialize");
-            assert_eq!(String::from_utf8_lossy(&result), "null");
+            test_serialize(&vec![Value::Null], "null");
         }
 
         #[test]
         fn deserialize_one() {
-            let mut deserailier = Deserializer::new(SliceRead::new("null".as_bytes()));
-            let result: Vec<Value> = deserialize(&mut deserailier).expect("failed to deserialize");
-            assert_eq!(result, vec![Value::Null]);
+            test_deserialize("null", &vec![Value::Null]);
         }
 
         #[test]
         fn serialize_many() {
-            let mut result = Vec::new();
-            let mut serializer = Serializer::new(&mut result);
-            serialize(&vec![Value::Null, Value::Null], &mut serializer)
-                .expect("failed to serialize");
-            assert_eq!(String::from_utf8_lossy(&result), "[null,null]");
+            test_serialize(&vec![Value::Null, Value::Null], "[null,null]");
         }
 
         #[test]
         fn deserialize_many() {
-            let mut deserailier = Deserializer::new(SliceRead::new("[null,null]".as_bytes()));
-            let result: Vec<Value> = deserialize(&mut deserailier).expect("failed to deserialize");
-            assert_eq!(result, vec![Value::Null, Value::Null]);
+            test_deserialize("[null,null]", &vec![Value::Null, Value::Null]);
         }
 
         #[test]
         fn serialize_none() {
-            let mut result = Vec::new();
-            let mut serializer = Serializer::new(&mut result);
-            serialize(&Vec::<Value>::new(), &mut serializer).expect("failed to serialize");
-            assert_eq!(String::from_utf8_lossy(&result), "[]");
+            test_serialize(&Vec::<Value>::new(), "[]");
         }
 
         #[test]
         fn deserialize_none() {
-            let mut deserailier = Deserializer::new(SliceRead::new("[]".as_bytes()));
-            let result: Vec<Value> = deserialize(&mut deserailier).expect("failed to deserialize");
-            assert_eq!(result, Vec::<Value>::new());
+            test_deserialize("[]", &Vec::<Value>::new());
         }
 
         #[test]

--- a/niri-ipc/src/utils.rs
+++ b/niri-ipc/src/utils.rs
@@ -1,0 +1,116 @@
+pub(crate) mod one_or_many {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub(crate) fn serialize<T: Serialize, S: Serializer>(
+        value: &Vec<T>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        if value.len() == 1 {
+            value[0].serialize(serializer)
+        } else {
+            value.serialize(serializer)
+        }
+    }
+
+    pub(crate) fn deserialize<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Vec<T>, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum OneOrMany<T> {
+            Many(Vec<T>),
+            One(T),
+        }
+
+        match OneOrMany::deserialize(deserializer)? {
+            OneOrMany::Many(v) => Ok(v),
+            OneOrMany::One(v) => Ok(vec![v]),
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use serde_json::de::SliceRead;
+        use serde_json::{Deserializer, Serializer, Value};
+
+        use super::*;
+
+        #[test]
+        fn serialize_one() {
+            let mut result = Vec::new();
+            let mut serializer = Serializer::new(&mut result);
+            serialize(&vec![Value::Null], &mut serializer).expect("failed to serialize");
+            assert_eq!(String::from_utf8_lossy(&result), "null");
+        }
+
+        #[test]
+        fn deserialize_one() {
+            let mut deserailier = Deserializer::new(SliceRead::new("null".as_bytes()));
+            let result: Vec<Value> = deserialize(&mut deserailier).expect("failed to deserialize");
+            assert_eq!(result, vec![Value::Null]);
+        }
+
+        #[test]
+        fn serialize_many() {
+            let mut result = Vec::new();
+            let mut serializer = Serializer::new(&mut result);
+            serialize(&vec![Value::Null, Value::Null], &mut serializer)
+                .expect("failed to serialize");
+            assert_eq!(String::from_utf8_lossy(&result), "[null,null]");
+        }
+
+        #[test]
+        fn deserialize_many() {
+            let mut deserailier = Deserializer::new(SliceRead::new("[null,null]".as_bytes()));
+            let result: Vec<Value> = deserialize(&mut deserailier).expect("failed to deserialize");
+            assert_eq!(result, vec![Value::Null, Value::Null]);
+        }
+
+        #[test]
+        fn serialize_none() {
+            let mut result = Vec::new();
+            let mut serializer = Serializer::new(&mut result);
+            serialize(&Vec::<Value>::new(), &mut serializer).expect("failed to serialize");
+            assert_eq!(String::from_utf8_lossy(&result), "[]");
+        }
+
+        #[test]
+        fn deserialize_none() {
+            let mut deserailier = Deserializer::new(SliceRead::new("[]".as_bytes()));
+            let result: Vec<Value> = deserialize(&mut deserailier).expect("failed to deserialize");
+            assert_eq!(result, Vec::<Value>::new());
+        }
+
+        #[test]
+        fn serialize_derive() {
+            #[derive(Debug, Serialize, PartialEq)]
+            enum Request {
+                Action(#[serde(with = "self")] Vec<String>),
+            }
+            let request = serde_json::to_string(&Request::Action(vec!["foo".to_string()]))
+                .expect("failed to serialize");
+            assert_eq!(request, r#"{"Action":"foo"}"#);
+            let request =
+                serde_json::to_string(&Request::Action(vec!["foo".to_string(), "bar".to_string()]))
+                    .expect("failed to serialize");
+            assert_eq!(request, r#"{"Action":["foo","bar"]}"#);
+        }
+
+        #[test]
+        fn deserialize_derive() {
+            #[derive(Debug, Deserialize, PartialEq)]
+            enum Request {
+                Action(#[serde(with = "self")] Vec<String>),
+            }
+            let request: Request =
+                serde_json::from_str(r#"{"Action":"foo"}"#).expect("failed to deserialize");
+            assert_eq!(request, Request::Action(vec!["foo".to_string()]));
+            let request: Request =
+                serde_json::from_str(r#"{"Action":["foo","bar"]}"#).expect("failed to deserialize");
+            assert_eq!(
+                request,
+                Request::Action(vec!["foo".to_string(), "bar".to_string()])
+            );
+        }
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,9 +74,13 @@ pub enum Msg {
     FocusedWindow,
     /// Perform an action.
     Action {
+        // NOTE: This is only optional because of clap_derive limitations and will never be `None`.
+        // If an action is not provided it reads actions from stdin and turns to [`Msg::Actions`].
         #[command(subcommand)]
-        action: Action,
+        action: Option<Action>,
     },
+    #[clap(skip)]
+    Actions { actions: Vec<Action> },
     /// Change output configuration temporarily.
     ///
     /// The configuration is changed temporarily and not saved into the config file. If the output

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -19,7 +19,11 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
         Msg::Outputs => Request::Outputs,
         Msg::FocusedWindow => Request::FocusedWindow,
         Msg::FocusedOutput => Request::FocusedOutput,
-        Msg::Action { action } => Request::Action(action.clone()),
+        Msg::Action {
+            action: Some(action),
+        } => Request::Action(vec![action.clone()]),
+        Msg::Action { action: None } => unreachable!(),
+        Msg::Actions { actions } => Request::Action(actions.clone()),
         Msg::Output { output, action } => Request::Output {
             output: output.clone(),
             action: action.clone(),
@@ -252,7 +256,7 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                 println!("No output is focused.");
             }
         }
-        Msg::Action { .. } => {
+        Msg::Action { .. } | Msg::Actions { .. } => {
             let Response::Handled = response else {
                 bail!("unexpected response: expected Handled, got {response:?}");
             };

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -309,15 +309,16 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let window = windows.values().find(|win| win.is_focused).cloned();
             Response::FocusedWindow(window)
         }
-        Request::Action(action) => {
+        Request::Action(actions) => {
             let (tx, rx) = async_channel::bounded(1);
 
-            let action = niri_config::Action::from(action);
             ctx.event_loop.insert_idle(move |state| {
                 // Make sure some logic like workspace clean-up has a chance to run before doing
                 // actions.
                 state.niri.advance_animations();
-                state.do_action(action, false);
+                for action in actions.into_iter().map(niri_config::Action::from) {
+                    state.do_action(action, false);
+                }
                 let _ = tx.send_blocking(());
             });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,11 @@ use std::io::{self, Write};
 use std::os::fd::FromRawFd;
 use std::path::PathBuf;
 use std::process::Command;
-use std::{env, mem};
+use std::{env, iter, mem};
 
 use clap::Parser;
 use directories::ProjectDirs;
-use niri::cli::{Cli, Sub};
+use niri::cli::{Cli, Msg, Sub};
 #[cfg(feature = "dbus")]
 use niri::dbus;
 use niri::ipc::client::handle_msg;
@@ -24,6 +24,7 @@ use niri::utils::watcher::Watcher;
 use niri::utils::{cause_panic, version, IS_SYSTEMD_SERVICE};
 use niri_config::Config;
 use niri_ipc::socket::SOCKET_PATH_ENV;
+use niri_ipc::Action;
 use portable_atomic::Ordering;
 use sd_notify::NotifyState;
 use smithay::reexports::calloop::EventLoop;
@@ -104,7 +105,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 info!("config is valid");
                 return Ok(());
             }
-            Sub::Msg { msg, json } => {
+            Sub::Msg { mut msg, json } => {
+                if let Msg::Action { action: None } = msg {
+                    let actions = io::stdin()
+                        .lines()
+                        .map(|line| {
+                            line.map(|line| {
+                                Action::parse_from(iter::once("action").chain(line.split(' ')))
+                            })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    if actions.is_empty() {
+                        warn!("read actions from stdin but no actions were provided");
+                        return Ok(());
+                    }
+                    msg = Msg::Actions { actions }
+                }
                 handle_msg(msg, json)?;
                 return Ok(());
             }


### PR DESCRIPTION
This needs some testing, `io::stdin().lines()` behaves a little weird with EOF, notably pressing <kbd>Ctrl</kbd> + <kbd>D</kbd> twice (apparently that's a unix thing, you need to hit it twice when not at the start of a line), you still need to hit it an additional time for some reason.. with `echo -e "one\ntwo" | niri msg action` it works as expected (by the way, it seems like `NIRI_SOCKET` isn't replaced correctly in the winit backend).

I made the serialization prefer keeping 1-length vectors as single values to maximize compatibility. The amount of tests for `one_or_many` is a bit excessive (I thought a visitor was needed at first, and then got the order of the enum variants wrong, so they were helpful), should I only keep the derive ones?

Also I'm not sure what should happen if you pass no actions, currently the cli prints a warning and does nothing but it's allowed in the ipc, should niri respond with an error instead?

Also, this currently splits on spaces, meaning it handles quoting and multiple spaces incorrectly, should this use e.g. `shlex` instead?