### PR TITLE
Add `scroll-factor` Window Rule

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1079,6 +1079,8 @@ pub struct WindowRule {
     pub variable_refresh_rate: Option<bool>,
     #[knuffel(child)]
     pub default_floating_position: Option<FloatingPosition>,
+    #[knuffel(child, unwrap(argument))]
+    pub scroll_factor: Option<FloatOrInt<0, 100>>,
 }
 
 #[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -343,13 +343,12 @@ impl ClientDndGrabHandler for State {
         // example. On successful drop, additionally activate the target window.
         let mut activate_output = true;
         if let Some(target) = validated.then_some(target).flatten() {
-            if let Some(root) = self.niri.root_surface.get(&target) {
-                if let Some((mapped, _)) = self.niri.layout.find_window_and_output(root) {
-                    let window = mapped.window.clone();
-                    self.niri.layout.activate_window(&window);
-                    self.niri.layer_shell_on_demand_focus = None;
-                    activate_output = false;
-                }
+            let root = self.niri.find_root_shell_surface(&target);
+            if let Some((mapped, _)) = self.niri.layout.find_window_and_output(&root) {
+                let window = mapped.window.clone();
+                self.niri.layout.activate_window(&window);
+                self.niri.layer_shell_on_demand_focus = None;
+                activate_output = false;
             }
         }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -100,6 +100,9 @@ pub struct ResolvedWindowRules {
 
     /// Whether to enable VRR on this window's primary output if it is on-demand.
     pub variable_refresh_rate: Option<bool>,
+
+    /// Multiplier for all scroll events sent to this window.
+    pub scroll_factor: Option<f64>,
 }
 
 impl<'a> WindowRef<'a> {
@@ -190,6 +193,7 @@ impl ResolvedWindowRules {
             clip_to_geometry: None,
             block_out_from: None,
             variable_refresh_rate: None,
+            scroll_factor: None,
         }
     }
 
@@ -300,6 +304,9 @@ impl ResolvedWindowRules {
                 }
                 if let Some(x) = rule.variable_refresh_rate {
                     resolved.variable_refresh_rate = Some(x);
+                }
+                if let Some(x) = rule.scroll_factor {
+                    resolved.scroll_factor = Some(x.0);
                 }
             }
 

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -53,6 +53,7 @@ window-rule {
     // block-out-from "screen-capture"
     variable-refresh-rate true
     default-floating-position x=100 y=200 relative-to="bottom-left"
+    scroll-factor 0.75
 
     focus-ring {
         // off
@@ -554,6 +555,23 @@ window-rule {
     match app-id="firefox$" title="^Picture-in-Picture$"
 
     default-floating-position x=32 y=32 relative-to="bottom-left"
+}
+```
+
+#### `scroll-factor`
+
+<sup>Since: next release</sup>
+
+Set a scroll factor for all scroll events sent to a window.
+
+This will be multiplied with the scroll factor set for your input device in the [input](/wiki/Configuration:-Input.md) section.
+
+```kdl
+// Make scrolling in Firefox a bit slower.
+window-rule {
+    match app-id="firefox$"
+
+    scroll-factor 0.75
 }
 ```
 


### PR DESCRIPTION
Example window rule:
```kdl
window-rule {
	match app-id=r#"^wev$"#
	scroll-factor 4
}
```
Note this multiples the scroll factor rather than override it like the issue suggested. This way you can normalize all the window scroll factors once, and it'll scale like you'd expect when changing your input scroll factor and when using multiple input devices with different scroll factors. You can "reset" a scroll factor by setting it to the input device's scroll factor inverse.

Fixes #909.