### PR TITLE
Extend switch-layout action to accept layout index

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -668,6 +668,8 @@ pub enum LayoutSwitchTarget {
     Next,
     /// The previous configured layout.
     Prev,
+    /// The specific layout by index.
+    Index(u8),
 }
 
 /// Output actions that niri can perform.
@@ -1174,7 +1176,10 @@ impl FromStr for LayoutSwitchTarget {
         match s {
             "next" => Ok(Self::Next),
             "prev" => Ok(Self::Prev),
-            _ => Err(r#"invalid layout action, can be "next" or "prev""#),
+            other => match other.parse() {
+                Ok(layout) => Ok(Self::Index(layout)),
+                _ => Err(r#"invalid layout action, can be "next", "prev" or a layout index"#),
+            },
         }
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -17,7 +17,7 @@ use smithay::backend::input::{
     TabletToolTipState, TouchEvent,
 };
 use smithay::backend::libinput::LibinputInputBackend;
-use smithay::input::keyboard::{keysyms, FilterResult, Keysym, ModifiersState};
+use smithay::input::keyboard::{keysyms, FilterResult, Keysym, Layout, ModifiersState};
 use smithay::input::pointer::{
     AxisFrame, ButtonEvent, CursorIcon, CursorImageStatus, Focus, GestureHoldBeginEvent,
     GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent,
@@ -691,6 +691,14 @@ impl State {
                 keyboard.with_xkb_state(self, |mut state| match action {
                     LayoutSwitchTarget::Next => state.cycle_next_layout(),
                     LayoutSwitchTarget::Prev => state.cycle_prev_layout(),
+                    LayoutSwitchTarget::Index(layout) => {
+                        let num_layouts = state.xkb().lock().unwrap().layouts().count();
+                        if usize::from(layout) > (num_layouts - 1) {
+                            warn!("requested layout doesn't exist")
+                        } else {
+                            state.set_layout(Layout(layout.into()))
+                        }
+                    }
                 });
             }
             Action::MoveColumnLeft => {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -693,7 +693,7 @@ impl State {
                     LayoutSwitchTarget::Prev => state.cycle_prev_layout(),
                     LayoutSwitchTarget::Index(layout) => {
                         let num_layouts = state.xkb().lock().unwrap().layouts().count();
-                        if usize::from(layout) > (num_layouts - 1) {
+                        if usize::from(layout) >= num_layouts {
                             warn!("requested layout doesn't exist")
                         } else {
                             state.set_layout(Layout(layout.into()))


### PR DESCRIPTION
_**Problem:**_
Cycling over keyboard layouts becomes uncomfortable with **three or more xkb layouts**.

_**Proposal:**_
Deterministic switching to a specific layout enables "muscle memory" and makes the experience of working with multiple languages much better overall.

_**Solution:**_
Extending `niri msg action switch-layout` to accept numbers for O(1) switch.
Later a user can assign this command to create a dedicated keyboard shortcut per layout.

P.S. @YaLTeR Thanks a lot for your effort, niri is great!

