### PR TITLE
adjust horizontal view movement gestures snap points for center-focused-column "on-overflow"

### DIFF
--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2569,7 +2569,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                                 && adj_col_w
                                     .filter(|adj_col_w| {
                                         center_on_overflow
-                                            && adj_col_w + gaps + col_w > working_area_width
+                                            && adj_col_w + 3.0 * gaps + col_w > working_area_width
                                     })
                                     .is_some()
                         };


### PR DESCRIPTION
adjust snap points for view offset gestures to account for any centering induced by center-focused-column "on-overflow", making them consistent with other navigation methods.

in the implementation of `ScrollingSpace::view_offset_gesture_end`, unless center-focused-column is "always", every column has 2 snap points: one that snaps its left edge to the left side of the screen and one that snaps its right edge to the right side of the screen. note however that when center-focused-column is "on-overflow", snapping the left edge of the column to the left edge of the screen is invalid if together with the column to the right it overflows the screen, and similarly for snapping its right edge. for snap points where such overflow would happen, we instead adjust them to position the column in the center of the screen. so a column with overflow on both sides will always be centered and a column with overflow on only one side can be either centered or snapped to the opposite side.