### PR TITLE
Miscellaneous Aesthetic Fixes 

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -4,12 +4,11 @@ use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::rc::Rc;
-use std::sync::Mutex;
 
 use anyhow::{anyhow, Context};
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::renderer::element::memory::MemoryRenderBuffer;
-use smithay::input::pointer::{CursorIcon, CursorImageAttributes, CursorImageStatus};
+use smithay::input::pointer::{CursorIcon, CursorImageStatus, CursorImageSurfaceData};
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::{IsAlive, Logical, Physical, Point, Transform};
 use smithay::wayland::compositor::with_states;
@@ -67,7 +66,7 @@ impl CursorManager {
                 let hotspot = with_states(&surface, |states| {
                     states
                         .data_map
-                        .get::<Mutex<CursorImageAttributes>>()
+                        .get::<CursorImageSurfaceData>()
                         .unwrap()
                         .lock()
                         .unwrap()

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2973,7 +2973,7 @@ fn should_intercept_key(
             }
         }
         (_, false) => {
-            // By this point, we know that the key was supressed on press. Even if we're inhibiting
+            // By this point, we know that the key was suppressed on press. Even if we're inhibiting
             // shortcuts, we should still suppress the release.
             // But we don't need to check for shortcuts inhibition here, because
             // if it was inhibited on press (forwarded to the client), it wouldn't be suppressed,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -3074,7 +3074,7 @@ impl<W: LayoutElement> Layout<W> {
         target.previous_workspace_id = Some(target.workspaces[target.active_workspace_idx].id());
 
         if target.options.empty_workspace_above_first && target.workspaces.len() == 1 {
-            // Insert a new empty workspace on top to prepare for insertion of new workspce.
+            // Insert a new empty workspace on top to prepare for insertion of new workspace.
             target.add_workspace_top();
         }
         // Insert the workspace after the currently active one. Unless the currently active one is
@@ -3151,7 +3151,7 @@ impl<W: LayoutElement> Layout<W> {
         target.previous_workspace_id = Some(target.workspaces[target.active_workspace_idx].id());
 
         if target.options.empty_workspace_above_first && target.workspaces.len() == 1 {
-            // Insert a new empty workspace on top to prepare for insertion of new workspce.
+            // Insert a new empty workspace on top to prepare for insertion of new workspace.
             target.add_workspace_top();
         }
         // Insert the workspace after the currently active one. Unless the currently active one is

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1776,6 +1776,10 @@ impl Niri {
 
         let (blocker_cleared_tx, blocker_cleared_rx) = mpsc::channel();
 
+        fn client_is_unrestricted(client: &Client) -> bool {
+            !client.get_data::<ClientState>().unwrap().restricted
+        }
+
         let compositor_state = CompositorState::new_v6::<State>(&display_handle);
         let xdg_shell_state = XdgShellState::new_with_capabilities::<State>(
             &display_handle,
@@ -1799,14 +1803,12 @@ impl Niri {
                     .can_view_decoration_globals
             },
         );
-        let layer_shell_state =
-            WlrLayerShellState::new_with_filter::<State, _>(&display_handle, |client| {
-                !client.get_data::<ClientState>().unwrap().restricted
-            });
+        let layer_shell_state = WlrLayerShellState::new_with_filter::<State, _>(
+            &display_handle,
+            client_is_unrestricted,
+        );
         let session_lock_state =
-            SessionLockManagerState::new::<State, _>(&display_handle, |client| {
-                !client.get_data::<ClientState>().unwrap().restricted
-            });
+            SessionLockManagerState::new::<State, _>(&display_handle, client_is_unrestricted);
         let shm_state = ShmState::new::<State>(
             &display_handle,
             vec![wl_shm::Format::Xbgr8888, wl_shm::Format::Abgr8888],
@@ -1834,42 +1836,29 @@ impl Niri {
         let data_control_state = DataControlState::new::<State, _>(
             &display_handle,
             Some(&primary_selection_state),
-            |client| !client.get_data::<ClientState>().unwrap().restricted,
+            client_is_unrestricted,
         );
         let presentation_state =
             PresentationState::new::<State>(&display_handle, Monotonic::ID as u32);
         let security_context_state =
-            SecurityContextState::new::<State, _>(&display_handle, |client| {
-                !client.get_data::<ClientState>().unwrap().restricted
-            });
+            SecurityContextState::new::<State, _>(&display_handle, client_is_unrestricted);
 
         let text_input_state = TextInputManagerState::new::<State>(&display_handle);
         let input_method_state =
-            InputMethodManagerState::new::<State, _>(&display_handle, |client| {
-                !client.get_data::<ClientState>().unwrap().restricted
-            });
+            InputMethodManagerState::new::<State, _>(&display_handle, client_is_unrestricted);
         let keyboard_shortcuts_inhibit_state =
             KeyboardShortcutsInhibitState::new::<State>(&display_handle);
         let virtual_keyboard_state =
-            VirtualKeyboardManagerState::new::<State, _>(&display_handle, |client| {
-                !client.get_data::<ClientState>().unwrap().restricted
-            });
+            VirtualKeyboardManagerState::new::<State, _>(&display_handle, client_is_unrestricted);
         let virtual_pointer_state =
-            VirtualPointerManagerState::new::<State, _>(&display_handle, |client| {
-                !client.get_data::<ClientState>().unwrap().restricted
-            });
+            VirtualPointerManagerState::new::<State, _>(&display_handle, client_is_unrestricted);
         let foreign_toplevel_state =
-            ForeignToplevelManagerState::new::<State, _>(&display_handle, |client| {
-                !client.get_data::<ClientState>().unwrap().restricted
-            });
+            ForeignToplevelManagerState::new::<State, _>(&display_handle, client_is_unrestricted);
         let mut output_management_state =
-            OutputManagementManagerState::new::<State, _>(&display_handle, |client| {
-                !client.get_data::<ClientState>().unwrap().restricted
-            });
+            OutputManagementManagerState::new::<State, _>(&display_handle, client_is_unrestricted);
         output_management_state.on_config_changed(config_.outputs.clone());
-        let screencopy_state = ScreencopyManagerState::new::<State, _>(&display_handle, |client| {
-            !client.get_data::<ClientState>().unwrap().restricted
-        });
+        let screencopy_state =
+            ScreencopyManagerState::new::<State, _>(&display_handle, client_is_unrestricted);
         let viewporter_state = ViewporterState::new::<State>(&display_handle);
         let xdg_foreign_state = XdgForeignState::new::<State>(&display_handle);
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -46,7 +46,7 @@ use smithay::desktop::{
     PopupUngrabStrategy, Space, Window, WindowSurfaceType,
 };
 use smithay::input::keyboard::Layout as KeyboardLayout;
-use smithay::input::pointer::{CursorIcon, CursorImageAttributes, CursorImageStatus, MotionEvent};
+use smithay::input::pointer::{CursorIcon, CursorImageStatus, CursorImageSurfaceData, MotionEvent};
 use smithay::input::{Seat, SeatState};
 use smithay::output::{self, Output, OutputModeSource, PhysicalProperties, Subpixel};
 use smithay::reexports::calloop::generic::Generic;
@@ -3026,7 +3026,7 @@ impl Niri {
                 let hotspot = with_states(surface, |states| {
                     states
                         .data_map
-                        .get::<Mutex<CursorImageAttributes>>()
+                        .get::<CursorImageSurfaceData>()
                         .unwrap()
                         .lock()
                         .unwrap()

--- a/src/tests/client.rs
+++ b/src/tests/client.rs
@@ -62,7 +62,7 @@ pub struct Window {
     pub viewport: WpViewport,
     pub pending_configure: Configure,
     pub configures_received: Vec<(u32, Configure)>,
-    pub close_requsted: bool,
+    pub close_requested: bool,
 
     pub configures_looked_at: usize,
 }
@@ -194,7 +194,7 @@ impl State {
             viewport,
             pending_configure: Configure::default(),
             configures_received: Vec::new(),
-            close_requsted: false,
+            close_requested: false,
 
             configures_looked_at: 0,
         };
@@ -459,7 +459,7 @@ impl Dispatch<XdgToplevel, ()> for State {
                     .collect();
             }
             xdg_toplevel::Event::Close => {
-                window.close_requsted = true;
+                window.close_requested = true;
             }
             xdg_toplevel::Event::ConfigureBounds { width, height } => {
                 window.pending_configure.bounds = Some((width, height));

--- a/src/tests/fixture.rs
+++ b/src/tests/fixture.rs
@@ -125,7 +125,7 @@ impl Fixture {
         }
     }
 
-    /// Rountrip twice in a row.
+    /// Roundtrip twice in a row.
     ///
     /// For some reason, when running tests on many threads at once, a single roundtrip is
     /// sometimes not sufficient to get the configure events to the client.

--- a/src/tests/window_opening.rs
+++ b/src/tests/window_opening.rs
@@ -339,7 +339,7 @@ window-rule {{
     window.ack_last_and_commit();
     f.double_roundtrip(id);
 
-    // Commit to the post-intial configures.
+    // Commit to the post-initial configures.
     let window = f.client(id).window(&surface);
     let new_serial = window.configures_received.last().unwrap().0;
     if new_serial != serial {
@@ -582,7 +582,7 @@ window-rule {
     window.ack_last_and_commit();
     f.double_roundtrip(id);
 
-    // Commit to the post-intial configures.
+    // Commit to the post-initial configures.
     let window = f.client(id).window(&surface);
     let new_serial = window.configures_received.last().unwrap().0;
     if new_serial != serial {

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -778,7 +778,7 @@ impl LayoutElement for Mapped {
         let _span =
             trace_span!("send_pending_configure", surface = ?toplevel.wl_surface().id()).entered();
 
-        // Check for pending changes manually to account fo RequestSizeOnce::UseWindowSize.
+        // Check for pending changes manually to account for RequestSizeOnce::UseWindowSize.
         let has_pending_changes = with_toplevel_role(self.toplevel(), |role| {
             if role.server_pending.is_none() {
                 return false;


### PR DESCRIPTION
Fixes some small unimportant style neats I noticed:
- Fixes typos with [`typos`](https://github.com/crate-ci/typos)
- Replaces `Mutux<CursorImageAttributes>` with the `CursorImageSurfaceData` type alias
- Replaces repeated `restricted` protocol filters closures with a helper