### PR TITLE
document interaction between hide-when-typing and wine wayland

### DIFF
--- a/wiki/Configuration:-Miscellaneous.md
+++ b/wiki/Configuration:-Miscellaneous.md
@@ -119,6 +119,9 @@ cursor {
 
 If set, hides the cursor when pressing a key on the keyboard.
 
+This setting might interfere with games running in Wine in native Wayland mode that use mouselook, such as first-person games.
+If your character's point of view jumps down when you press a key and move the mouse simultaneously try disabling this setting.
+
 ```kdl
 cursor {
     hide-when-typing

--- a/wiki/Configuration:-Miscellaneous.md
+++ b/wiki/Configuration:-Miscellaneous.md
@@ -119,8 +119,9 @@ cursor {
 
 If set, hides the cursor when pressing a key on the keyboard.
 
-This setting might interfere with games running in Wine in native Wayland mode that use mouselook, such as first-person games.
-If your character's point of view jumps down when you press a key and move the mouse simultaneously try disabling this setting.
+> [!NOTE]
+> This setting might interfere with games running in Wine in native Wayland mode that use mouselook, such as first-person games.
+> If your character's point of view jumps down when you press a key and move the mouse simultaneously, try disabling this setting.
 
 ```kdl
 cursor {


### PR DESCRIPTION
There is a specific interaction between `hide-when-typing` and Wine running in native Wayland mode. In first person games pressing a key while simultaneously moving the mouse causes the character's crosshair to jump down a few dozen pixels or so until pretty quickly you are looking straight down at your character's feet. There is also slight cursor flickering in game menus.

I filed an issue, #1075. I thought it might be helpful to follow up with a documentation PR.