### PR TITLE
add option to not move cursor when focussing a window via ipc

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -4188,9 +4188,9 @@ mod tests {
                             trigger: Trigger::Keysym(Keysym::_1),
                             modifiers: Modifiers::COMPOSITOR | Modifiers::SHIFT,
                         },
-                        action: Action::FocusWorkspace(WorkspaceReference::Name(
+                        action: Action::FocusWorkspace(FocusWorkspaceWithReference{reference: WorkspaceReference::Name(
                             "workspace-1".to_string(),
-                        ), false),
+                        ), no_mouse_warp: false}),
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -214,6 +214,9 @@ pub enum Action {
         /// Id of the window to focus.
         #[cfg_attr(feature = "clap", arg(long))]
         id: u64,
+        /// Disable moving the cursor to the newly focused window or output.
+        #[cfg_attr(feature = "clap", arg(long))]
+        no_mouse_warp: bool,
     },
     /// Focus a window in the focused column by index.
     FocusWindowInColumn {
@@ -344,14 +347,25 @@ pub enum Action {
         id: Option<u64>,
     },
     /// Focus the workspace below.
-    FocusWorkspaceDown {},
+    FocusWorkspaceDown {
+        /// Disable moving the cursor to the newly focused window or output.
+        #[cfg_attr(feature = "clap", arg(long))]
+        no_mouse_warp: bool,
+    },
     /// Focus the workspace above.
-    FocusWorkspaceUp {},
+    FocusWorkspaceUp {
+        /// Disable moving the cursor to the newly focused window or output.
+        #[cfg_attr(feature = "clap", arg(long))]
+        no_mouse_warp: bool,
+    },
     /// Focus a workspace by reference (index or name).
     FocusWorkspace {
         /// Reference (index or name) of the workspace to focus.
         #[cfg_attr(feature = "clap", arg())]
         reference: WorkspaceReferenceArg,
+        /// Disable moving the cursor to the newly focused window or output.
+        #[cfg_attr(feature = "clap", arg(long))]
+        no_mouse_warp: bool,
     },
     /// Focus the previous workspace.
     FocusWorkspacePrevious {},

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -679,11 +679,15 @@ impl State {
                     self.niri.queue_redraw_all();
                 }
             }
-            Action::FocusWindow(id) => {
+            Action::FocusWindow { id, no_mouse_warp } => {
                 let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
                 let window = window.map(|(_, m)| m.window.clone());
                 if let Some(window) = window {
-                    self.focus_window(&window);
+                    if !no_mouse_warp {
+                        self.focus_window(&window);
+                        return;
+                    }
+                    self.focus_window_without_moving_cursor(&window);
                 }
             }
             Action::FocusWindowInColumn(index) => {
@@ -1149,21 +1153,28 @@ impl State {
                     self.niri.queue_redraw_all();
                 }
             }
-            Action::FocusWorkspaceDown => {
+            Action::FocusWorkspaceDown(niri_config::FocusWorkspaceArgument { no_mouse_warp }) => {
                 self.niri.layout.switch_workspace_down();
-                self.maybe_warp_cursor_to_focus();
+                if !no_mouse_warp {
+                    self.maybe_warp_cursor_to_focus();
+                }
                 self.niri.layer_shell_on_demand_focus = None;
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
-            Action::FocusWorkspaceUp => {
+            Action::FocusWorkspaceUp(niri_config::FocusWorkspaceArgument { no_mouse_warp }) => {
                 self.niri.layout.switch_workspace_up();
-                self.maybe_warp_cursor_to_focus();
+                if !no_mouse_warp {
+                    self.maybe_warp_cursor_to_focus();
+                }
                 self.niri.layer_shell_on_demand_focus = None;
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
-            Action::FocusWorkspace(reference) => {
+            Action::FocusWorkspace(niri_config::FocusWorkspaceWithReference {
+                reference,
+                no_mouse_warp,
+            }) => {
                 if let Some((mut output, index)) =
                     self.niri.find_output_and_workspace_index(reference)
                 {
@@ -1176,7 +1187,7 @@ impl State {
                     if let Some(output) = output {
                         self.niri.layout.focus_output(&output);
                         self.niri.layout.switch_workspace(index);
-                        if !self.maybe_warp_cursor_to_focus_centered() {
+                        if !no_mouse_warp && !self.maybe_warp_cursor_to_focus_centered() {
                             self.move_cursor_to_output(&output);
                         }
                     } else {
@@ -1186,7 +1197,9 @@ impl State {
                         } else {
                             self.niri.layout.switch_workspace(index);
                         }
-                        self.maybe_warp_cursor_to_focus();
+                        if !no_mouse_warp {
+                            self.maybe_warp_cursor_to_focus();
+                        }
                     }
                     self.niri.layer_shell_on_demand_focus = None;
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -775,6 +775,13 @@ impl State {
         self.niri.queue_redraw_all();
     }
 
+    /// Focus a specific window without moving the cursor.
+    pub fn focus_window_without_moving_cursor(&mut self, window: &Window) {
+        self.niri.layout.activate_window(window);
+        // FIXME: granular
+        self.niri.queue_redraw_all();
+    }
+
     pub fn maybe_warp_cursor_to_focus(&mut self) -> bool {
         if !self.niri.config.borrow().input.warp_mouse_to_focus {
             return false;

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -210,8 +210,12 @@ fn render(
         &Action::FocusColumnRight,
         &Action::MoveColumnLeft,
         &Action::MoveColumnRight,
-        &Action::FocusWorkspaceDown,
-        &Action::FocusWorkspaceUp,
+        &Action::FocusWorkspaceDown(niri_config::FocusWorkspaceArgument {
+            no_mouse_warp: false,
+        }),
+        &Action::FocusWorkspaceUp(niri_config::FocusWorkspaceArgument {
+            no_mouse_warp: false,
+        }),
     ]);
 
     // Prefer move-column-to-workspace-down, but fall back to move-window-to-workspace-down.
@@ -422,8 +426,8 @@ fn action_name(action: &Action) -> String {
         Action::FocusColumnRight => String::from("Focus Column to the Right"),
         Action::MoveColumnLeft => String::from("Move Column Left"),
         Action::MoveColumnRight => String::from("Move Column Right"),
-        Action::FocusWorkspaceDown => String::from("Switch Workspace Down"),
-        Action::FocusWorkspaceUp => String::from("Switch Workspace Up"),
+        Action::FocusWorkspaceDown { .. } => String::from("Switch Workspace Down"),
+        Action::FocusWorkspaceUp { .. } => String::from("Switch Workspace Up"),
         Action::MoveColumnToWorkspaceDown => String::from("Move Column to Workspace Down"),
         Action::MoveColumnToWorkspaceUp => String::from("Move Column to Workspace Up"),
         Action::MoveWindowToWorkspaceDown => String::from("Move Window to Workspace Down"),


### PR DESCRIPTION
Hi, I added a flag for not moving the cursor when focussing a window via ipc. Seems like I was the only one interested in that, but it was a personal pet peeve of mine.
https://github.com/YaLTeR/niri/discussions/935

Thanks for the amazing compositor.
