### PR TITLE
Allow disabling tap-and-drag

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -185,6 +185,8 @@ pub struct Touchpad {
     pub dwt: bool,
     #[knuffel(child)]
     pub dwtp: bool,
+    #[knuffel(child, unwrap(argument))]
+    pub drag: Option<bool>,
     #[knuffel(child)]
     pub drag_lock: bool,
     #[knuffel(child)]
@@ -3553,6 +3555,7 @@ mod tests {
                     tap
                     dwt
                     dwtp
+                    drag true
                     click-method "clickfinger"
                     accel-speed 0.2
                     accel-profile "flat"
@@ -3811,6 +3814,9 @@ mod tests {
                     tap: true,
                     dwt: true,
                     dwtp: true,
+                    drag: Some(
+                        true,
+                    ),
                     drag_lock: false,
                     natural_scroll: false,
                     click_method: Some(

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -25,6 +25,7 @@ input {
         tap
         // dwt
         // dwtp
+        // drag false
         // drag-lock
         natural-scroll
         // accel-speed 0.2

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3334,6 +3334,13 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
         let _ = device.config_left_handed_set(c.left_handed);
         let _ = device.config_middle_emulation_set_enabled(c.middle_emulation);
 
+        if let Some(drag) = c.drag {
+            let _ = device.config_tap_set_drag_enabled(drag);
+        } else {
+            let default = device.config_tap_default_drag_enabled();
+            let _ = device.config_tap_set_drag_enabled(default);
+        }
+
         if let Some(accel_profile) = c.accel_profile {
             let _ = device.config_accel_set_profile(accel_profile.into());
         } else if let Some(default) = device.config_accel_default_profile() {

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -30,6 +30,7 @@ input {
         tap
         // dwt
         // dwtp
+        // drag false
         // drag-lock
         natural-scroll
         // accel-speed 0.2
@@ -186,6 +187,7 @@ Settings specific to `touchpad`s:
 - `tap`: tap-to-click.
 - `dwt`: disable-when-typing.
 - `dwtp`: disable-when-trackpointing.
+- `drag`: can be `true` or `false`, controls if tap-to-drag is enabled.
 - `drag-lock`: <sup>Since: 25.02</sup> if set, lifting the finger off for a short time while dragging will not drop the dragged item. See the [libinput documentation](https://wayland.freedesktop.org/libinput/doc/latest/tapping.html#tap-and-drag).
 - `tap-button-map`: can be `left-right-middle` or `left-middle-right`, controls which button corresponds to a two-finger tap and a three-finger tap.
 - `click-method`: can be `button-areas` or `clickfinger`, changes the [click method](https://wayland.freedesktop.org/libinput/doc/latest/clickpad-softbuttons.html).

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -187,7 +187,7 @@ Settings specific to `touchpad`s:
 - `tap`: tap-to-click.
 - `dwt`: disable-when-typing.
 - `dwtp`: disable-when-trackpointing.
-- `drag`: can be `true` or `false`, controls if tap-to-drag is enabled.
+- `drag`: can be `true` or `false`, controls if tap-and-drag is enabled.
 - `drag-lock`: <sup>Since: 25.02</sup> if set, lifting the finger off for a short time while dragging will not drop the dragged item. See the [libinput documentation](https://wayland.freedesktop.org/libinput/doc/latest/tapping.html#tap-and-drag).
 - `tap-button-map`: can be `left-right-middle` or `left-middle-right`, controls which button corresponds to a two-finger tap and a three-finger tap.
 - `click-method`: can be `button-areas` or `clickfinger`, changes the [click method](https://wayland.freedesktop.org/libinput/doc/latest/clickpad-softbuttons.html).


### PR DESCRIPTION
Similar to https://github.com/YaLTeR/niri/pull/1088, this adds a new touchpad `drag` configuration option that configures tap-and-drag behavior.

Currently tap-and-drag is always enabled when the `tap` setting is enabled, but other compositors allow setting this separately.