### PR TITLE
Add `keep-focus-when-hidden` option

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -761,6 +761,8 @@ pub struct Cursor {
     pub xcursor_size: u8,
     #[knuffel(child)]
     pub hide_when_typing: bool,
+    #[knuffel(child)]
+    pub keep_focus_when_hidden: bool,
     #[knuffel(child, unwrap(argument))]
     pub hide_after_inactive_ms: Option<u32>,
 }
@@ -771,6 +773,7 @@ impl Default for Cursor {
             xcursor_theme: String::from("default"),
             xcursor_size: 24,
             hide_when_typing: false,
+            keep_focus_when_hidden: false,
             hide_after_inactive_ms: None,
         }
     }
@@ -3766,6 +3769,7 @@ mod tests {
                     xcursor_size: 16,
                     hide_when_typing: true,
                     hide_after_inactive_ms: Some(3000),
+                    keep_focus_when_hidden: false
                 },
                 screenshot_path: Some(String::from("~/Screenshots/screenshot.png")),
                 clipboard: Clipboard {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -815,7 +815,9 @@ impl State {
 
         let pointer = &self.niri.seat.get_pointer().unwrap();
         let location = pointer.current_location();
-        let under = if self.niri.pointer_hidden {
+        let under = if self.niri.pointer_hidden
+            && !self.niri.config.borrow().cursor.keep_focus_when_hidden
+        {
             PointContents::default()
         } else {
             self.niri.contents_under(location)

--- a/wiki/Configuration:-Miscellaneous.md
+++ b/wiki/Configuration:-Miscellaneous.md
@@ -23,6 +23,7 @@ cursor {
 
     hide-when-typing
     hide-after-inactive-ms 1000
+    keep-focus-when-hidden
 }
 
 clipboard {
@@ -139,6 +140,16 @@ If set, the cursor will automatically hide once this number of milliseconds pass
 cursor {
     // Hide the cursor after one second of inactivity.
     hide-after-inactive-ms 1000
+}
+```
+
+#### `keep-focus-when-hidden`
+
+When the cursor is hidden, pointer focus will be kept. This will leave items hovered upon, keep tooltips open, etc.
+
+```kdl
+cursor {
+    keep-focus-when-hidden
 }
 ```
 


### PR DESCRIPTION
This option helps with situations where you want to do something like read a tooltip and have the inactive timer set. It can hide while you're reading, so you have to keep it moving.

From the comments, I understand this behaviour is expected so that tooltips and whatnot get removed when using touch input. So, I've created this option.