### PR TITLE
Slightly clearer wording in Tabs.md

### DIFF
--- a/wiki/Tabs.md
+++ b/wiki/Tabs.md
@@ -2,7 +2,7 @@
 
 <sup>Since: next release</sup>
 
-You can switch a column to display windows as tabs, rather than as vertical tiles.
+You can switch a column to present windows as tabs, rather than as vertical tiles.
 All tabs in a column have the same window size, so this is useful to get more vertical space.
 
 ![Terminal with a tab indicator on the left.](https://github.com/user-attachments/assets/0e94ac0d-796d-4f85-a264-c105ef41c13f)


### PR DESCRIPTION
When reading first words of the Tabs.md page, I was like: what are "display windows"? 
Replacing the word "display" with "present" makes it quicker to understand, as the word "display" is often a noun.

Also in the same line, the word "switch" could be replaced by "ask" to also arguably improve readability. 

Thanks