### PR TITLE
niri-ipc: implement MultiSocket wrapper

### DIFF
--- a/niri-ipc/src/socket.rs
+++ b/niri-ipc/src/socket.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::os::unix::net::UnixStream;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::{Event, Reply, Request};
 
@@ -14,24 +14,30 @@ pub const SOCKET_PATH_ENV: &str = "NIRI_SOCKET";
 /// Helper for blocking communication over the niri socket.
 ///
 /// This struct is used to communicate with the niri IPC server. It handles the socket connection
-/// and serialization/deserialization of messages.
+/// and serialization/deserialization of messages. This class allows you to use `send` only once.
+/// After first call of `send` you have to call `connect` again to communicate with server.
 pub struct Socket {
     stream: UnixStream,
 }
 
 impl Socket {
+    /// Get path to the default niri IPC socket.
+    ///
+    /// This returns path taken from the [`SOCKET_PATH_ENV`] environment variable.
+    pub fn default_socket_path() -> io::Result<impl AsRef<Path>> {
+        env::var_os(SOCKET_PATH_ENV).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("{SOCKET_PATH_ENV} is not set, are you running this within niri?"),
+            )
+        })
+    }
     /// Connects to the default niri IPC socket.
     ///
     /// This is equivalent to calling [`Self::connect_to`] with the path taken from the
     /// [`SOCKET_PATH_ENV`] environment variable.
     pub fn connect() -> io::Result<Self> {
-        let socket_path = env::var_os(SOCKET_PATH_ENV).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("{SOCKET_PATH_ENV} is not set, are you running this within niri?"),
-            )
-        })?;
-        Self::connect_to(socket_path)
+        Self::connect_to(Self::default_socket_path()?)
     }
 
     /// Connects to the niri IPC socket at the given path.
@@ -73,5 +79,43 @@ impl Socket {
         };
 
         Ok((reply, events))
+    }
+}
+
+/// Wrapper on [Socket] which allows to reuse single object for many `send` calls.
+pub struct MultiSocket {
+    path: PathBuf,
+}
+
+impl MultiSocket {
+    /// Equivalent to [Socket::connect]
+    ///
+    /// This stores path taken from [`SOCKET_PATH_ENV`] environment variable.
+    pub fn connect() -> io::Result<Self> {
+        Ok(Self::connect_to(Socket::default_socket_path()?))
+    }
+
+    /// Equivalent to [Socket::connect_to]
+    ///
+    /// This stores path passed from argument.
+    pub fn connect_to(path_ref: impl AsRef<Path>) -> Self {
+        let mut path = PathBuf::new();
+        path.push(path_ref);
+        Self { path }
+    }
+
+    /// Wrapper on [Socket::send]
+    ///
+    /// Creates temporary [Socket] object, calls its [`send`](Socket::send) method
+    /// and returns its result
+    pub fn send(&self, request: Request) -> io::Result<(Reply, impl FnMut() -> io::Result<Event>)> {
+        self.get_socket()?.send(request)
+    }
+
+    /// Returns [Socket]
+    ///
+    /// Uses stored socket path to create and return [Socket] object
+    pub fn get_socket(&self) -> io::Result<Socket> {
+        Socket::connect_to(&self.path)
     }
 }


### PR DESCRIPTION
Each time, when using `Socket::send` we have to reopen it. This patch adds `MultiSocket` class which wraps `Socket` and allows you to reuse single object with many `send` calls. This is handy when you are implementing complex scenario.

I am not sure, is this really have to be inside mainstream, but each time, I implements my new scenario, I have to create such [wrapper](https://github.com/ein-shved/niri-single-output/blob/master/src/lib.rs#L96) by myself