### PR TITLE
Niri-IPC: introduce WindowAreaChanged

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -925,6 +925,22 @@ pub enum Transform {
     Flipped270,
 }
 
+/// Window Area
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct WindowArea {
+    /// The left top x of window
+    pub x: i32,
+    /// The left top y of window
+    pub y: i32,
+    /// The width of window
+    pub w: i32,
+    /// The height of window
+    pub h: i32,
+    /// Window floating state
+    pub is_floating: bool,
+}
+
 /// Toplevel window.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
@@ -1096,6 +1112,15 @@ pub enum Event {
         /// This configuration completely replaces the previous configuration. I.e. if any windows
         /// are missing from here, then they were closed.
         windows: Vec<Window>,
+    },
+    /// The window location has changed.
+    WindowAreaChanged {
+        /// Id of the workspace
+        workspace_id: Option<u64>,
+        /// Unique id of this window.
+        window_id: u64,
+        /// The new window area configuration.
+        area: Option<WindowArea>,
     },
     /// A new toplevel window was opened, or an existing toplevel window changed.
     WindowOpenedOrChanged {

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -9,7 +9,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
-use crate::{Event, KeyboardLayouts, Window, Workspace};
+use crate::{Event, KeyboardLayouts, Window, WindowArea, Workspace};
 
 /// Part of the state communicated via the event stream.
 pub trait EventStreamStatePart {
@@ -54,6 +54,8 @@ pub struct WorkspacesState {
 pub struct WindowsState {
     /// Map from a window id to the window.
     pub windows: HashMap<u64, Window>,
+    /// Map from a window id to the window area.
+    pub window_areas: HashMap<u64, WindowArea>,
 }
 
 /// The keyboard layout state communicated over the event stream.
@@ -162,6 +164,18 @@ impl EventStreamStatePart for WindowsState {
                     win.is_focused = Some(win.id) == id;
                 }
             }
+            Event::WindowAreaChanged {
+                workspace_id: _,
+                window_id,
+                area,
+            } => match area {
+                Some(area) => {
+                    self.window_areas.insert(window_id, area);
+                }
+                None => {
+                    self.window_areas.remove(&window_id);
+                }
+            },
             event => return Some(event),
         }
         None

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -396,6 +396,13 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                     Event::KeyboardLayoutSwitched { idx } => {
                         println!("Keyboard layout switched: {idx}");
                     }
+                    Event::WindowAreaChanged {
+                        workspace_id: _,
+                        window_id,
+                        area,
+                    } => {
+                        println!("Window area changed: {window_id}, {area:?}");
+                    }
                 }
             }
         }

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -322,6 +322,16 @@ impl<W: LayoutElement> FloatingSpace<W> {
         })
     }
 
+    pub fn tiles_with_areas(
+        &self,
+    ) -> impl Iterator<Item = (&Tile<W>, Rectangle<f64, Logical>)> + '_ {
+        self.tiles_with_offsets().map(move |(tile, offset)| {
+            let pos = offset + tile.render_offset();
+            let size = tile.tile_size().clone();
+            (tile, Rectangle::new(pos, size))
+        })
+    }
+
     pub fn new_window_toplevel_bounds(&self, rules: &ResolvedWindowRules) -> Size<i32, Logical> {
         let border_config = rules.border.resolve_against(self.options.border);
         compute_toplevel_bounds(border_config, self.working_area.size)

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -380,6 +380,10 @@ impl<W: LayoutElement> Workspace<W> {
         self.tiles_mut().map(Tile::window_mut)
     }
 
+    pub fn windows_with_areas(&self) -> impl Iterator<Item = (&W, Rectangle<f64, Logical>)> {
+        self.tiles_with_areas().map(|(t, r)| (t.window(), r))
+    }
+
     pub fn tiles(&self) -> impl Iterator<Item = &Tile<W>> + '_ {
         let scrolling = self.scrolling.tiles();
         let floating = self.floating.tiles();
@@ -389,6 +393,14 @@ impl<W: LayoutElement> Workspace<W> {
     pub fn tiles_mut(&mut self) -> impl Iterator<Item = &mut Tile<W>> + '_ {
         let scrolling = self.scrolling.tiles_mut();
         let floating = self.floating.tiles_mut();
+        scrolling.chain(floating)
+    }
+
+    pub fn tiles_with_areas(
+        &self,
+    ) -> impl Iterator<Item = (&Tile<W>, Rectangle<f64, Logical>)> + '_ {
+        let scrolling = self.scrolling.tiles_with_areas();
+        let floating = self.floating.tiles_with_areas();
         scrolling.chain(floating)
     }
 


### PR DESCRIPTION
Response to #624 .

I have observed that the author has recently been developing many fascinating features, such as floating windows, shadow effects, and tab indicators. I am deeply grateful for the author's diligent work in these areas. After personal experimentation, I found these features not only fascinating but also stable, without any performance degradation.

Compared to other features, this one is relatively minor, yet in the relevant discussions, I have not found anyone submitting a pull request here, so I decided to give it a try myself.

In general, I have introduced a new message type called `WindowAreaChanged`, which includes coordinates, dimensions, and whether it is a floating window.

When dealing with scrolling layouts, I found that it is not possible to use relative screen coordinates directly, as other window managers do. Therefore, I believe that floating windows and tiled windows should adopt two different coordinate systems(for `x`), hence the introduction of the `is_floating` configuration in `WindowArea`.

During the traversal of scrolling layouts, the system calculates the sum of xy coordinates, while floating windows directly use the method `tiles_with_offsets`.

The effect after using the `niri msg -j event-stream` command is as follows:

```
{"WindowAreaChanged":{"workspace_id":8,"window_id":65,"area":{"x":676,"y":-306,"w":947,"h":1022,"is_floating":true}}}
```