### PR TITLE
Implement focus-monitor, move-window-to-monitor and move-column-to-monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "niri"
-version = "25.1.0"
+version = "25.2.0"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "niri-config"
-version = "25.1.0"
+version = "25.2.0"
 dependencies = [
  "bitflags 2.8.0",
  "csscolorparser",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "niri-ipc"
-version = "25.1.0"
+version = "25.2.0"
 dependencies = [
  "clap",
  "schemars",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "niri-visual-tests"
-version = "25.1.0"
+version = "25.2.0"
 dependencies = [
  "anyhow",
  "gtk4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libdisplay-info"
@@ -2072,9 +2072,9 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "loom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3360,7 +3360,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smithay"
 version = "0.4.0"
-source = "git+https://github.com/Smithay/smithay.git#0cd3345c59f7cb139521f267956a1a4e33248393"
+source = "git+https://github.com/Smithay/smithay.git#c24b431cc44458172f31276ca0fbade1ae09bdd9"
 dependencies = [
  "appendlist",
  "bitflags 2.8.0",
@@ -3431,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#0cd3345c59f7cb139521f267956a1a4e33248393"
+source = "git+https://github.com/Smithay/smithay.git#c24b431cc44458172f31276ca0fbade1ae09bdd9"
 dependencies = [
  "drm",
  "libdisplay-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2847,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "ppv-lite86"
@@ -3188,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -3200,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "jobserver",
  "libc",
@@ -943,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -1183,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6efc7705f7863d37b12ad6974cbb310d35d054f5108cdc1e69037742f573c4c"
+checksum = "7563afd6ff0a221edfbb70a78add5075b8d9cb48e637a40a24c3ece3fea414d0"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
@@ -1208,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0196720118f880f71fe7da971eff58cc43a89c9cf73f46076b7cb1e60889b15"
+checksum = "4850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60"
 dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
@@ -1223,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-sys"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b0e1340bd15e7a78810cf39fed9e5d85f0a8f80b1d999d384ca17dcc452b60"
+checksum = "6f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -1286,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a517657589a174be9f60c667f1fec8b7ac82ed5db4ebf56cf073a3b5955d8e2e"
+checksum = "a4f00c70f8029d84ea7572dd0e1aaa79e5329667b4c17f329d79ffb1e6277487"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8446d9b475730ebef81802c1738d972db42fde1c5a36a627ebc4d665fc87db04"
+checksum = "160eb5250a26998c3e1b54e6a3d4ea15c6c7762a6062a19a7b63eff6e2b33f9e"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1353,9 +1353,9 @@ checksum = "17fcdf9683c406c2fc4d124afd29c0d595e22210d633cbdb8695ba9935ab1dc6"
 
 [[package]]
 name = "glib"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f969edf089188d821a30cde713b6f9eb08b20c63fc2e584aba2892a7984a8cc0"
+checksum = "707b819af8059ee5395a2de9f2317d87a53dbad8846a2f089f0bb44703f37686"
 dependencies = [
  "bitflags 2.8.0",
  "futures-channel",
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b360ff0f90d71de99095f79c526a5888c9c92fc9ee1b19da06c6f5e75f0c2a53"
+checksum = "a8928869a44cfdd1fccb17d6746e4ff82c8f82e41ce705aa026a52ca8dc3aefb"
 dependencies = [
  "libc",
  "system-deps 7.0.3",
@@ -1403,9 +1403,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gobject-sys"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a56235e971a63bfd75abb13ef70064e1346388723422a68580d8a6fbac6423"
+checksum = "c773a3cb38a419ad9c26c81d177d96b4b08980e8bdbbf32dace883e96e96e7e3"
 dependencies = [
  "glib-sys",
  "libc",
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-rs"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39d3bcd2e24fd9c2874a56f277b72c03e728de9bdc95a8d4ef4c962f10ced98"
+checksum = "3cbc5911bfb32d68dcfa92c9510c462696c2f715548fcd7f3f1be424c739de19"
 dependencies = [
  "glib",
  "graphene-sys",
@@ -1437,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b9188db0a6219e708b6b6e7225718e459def664023dbddb8395ca1486d8102"
+checksum = "61f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855"
 dependencies = [
  "cairo-rs",
  "gdk4",
@@ -1452,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4-sys"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca10fc65d68528a548efa3d8747934adcbe7058b73695c9a7f43a25352fce14"
+checksum = "755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
@@ -1468,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b697ff938136625f6acf75f01951220f47a45adcf0060ee55b4671cf734dac44"
+checksum = "af1c491051f030994fd0cde6f3c44f3f5640210308cff1298c7673c47408091d"
 dependencies = [
  "cairo-rs",
  "field-offset",
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-sys"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af4b680cee5d2f786a2f91f1c77e95ecf2254522f0ca4edf3a2dce6cb35cecf"
+checksum = "41e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -2628,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "pango-sys"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71787e0019b499a5eda889279e4adb455a4f3fdd6870cd5ab7f4a5aa25df6699"
+checksum = "0dbb9b751673bd8fe49eb78620547973a1e719ed431372122b20abd12445bab5"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3347,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "smawk"
@@ -3559,9 +3559,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3811,9 +3811,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4516,9 +4516,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,8 +3359,8 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "smithay"
-version = "0.4.0"
-source = "git+https://github.com/Smithay/smithay.git#c24b431cc44458172f31276ca0fbade1ae09bdd9"
+version = "0.5.0"
+source = "git+https://github.com/Smithay/smithay.git#25cf3cf41c5027ffeb55f90c683736726a81d71f"
 dependencies = [
  "appendlist",
  "bitflags 2.8.0",
@@ -3431,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#c24b431cc44458172f31276ca0fbade1ae09bdd9"
+source = "git+https://github.com/Smithay/smithay.git#25cf3cf41c5027ffeb55f90c683736726a81d71f"
 dependencies = [
  "drm",
  "libdisplay-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.80.1"
 [workspace.dependencies]
 anyhow = "1.0.96"
 bitflags = "2.8.0"
-clap = { version = "4.5.30", features = ["derive"] }
+clap = { version = "4.5.31", features = ["derive"] }
 insta = "1.42.1"
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.139"
@@ -77,7 +77,7 @@ pango = { version = "0.20.9", features = ["v1_44"] }
 pangocairo = "0.20.7"
 pipewire = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs.git", optional = true, features = ["v0_3_33"] }
 png = "0.17.16"
-portable-atomic = { version = "1.10.0", default-features = false, features = ["float"] }
+portable-atomic = { version = "1.11.0", default-features = false, features = ["float"] }
 profiling = "1.0.16"
 sd-notify = "0.4.5"
 serde.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,9 @@ git-version = "0.3.9"
 glam = "0.30.0"
 input = { version = "0.9.1", features = ["libinput_1_21"] }
 keyframe = { version = "1.1.1", default-features = false }
-libc = "0.2.169"
+libc = "0.2.170"
 libdisplay-info = "0.2.2"
-log = { version = "0.4.25", features = ["max_level_trace", "release_max_level_debug"] }
+log = { version = "0.4.26", features = ["max_level_trace", "release_max_level_debug"] }
 niri-config = { version = "25.2.0", path = "niri-config" }
 niri-ipc = { version = "25.2.0", path = "niri-ipc", features = ["clap"] }
 ordered-float = "5.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "25.1.0"
+version = "25.2.0"
 description = "A scrollable-tiling Wayland compositor"
 authors = ["Ivan Molodetskikh <yalterz@gmail.com>"]
 license = "GPL-3.0-or-later"
@@ -70,8 +70,8 @@ keyframe = { version = "1.1.1", default-features = false }
 libc = "0.2.169"
 libdisplay-info = "0.2.2"
 log = { version = "0.4.25", features = ["max_level_trace", "release_max_level_debug"] }
-niri-config = { version = "25.1.0", path = "niri-config" }
-niri-ipc = { version = "25.1.0", path = "niri-ipc", features = ["clap"] }
+niri-config = { version = "25.2.0", path = "niri-config" }
+niri-ipc = { version = "25.2.0", path = "niri-ipc", features = ["clap"] }
 ordered-float = "5.0.0"
 pango = { version = "0.20.9", features = ["v1_44"] }
 pangocairo = "0.20.7"
@@ -151,7 +151,7 @@ insta.opt-level = 3
 similar.opt-level = 3
 
 [package.metadata.generate-rpm]
-version = "25.01"
+version = "25.02"
 assets = [
     { source = "target/release/niri", dest = "/usr/bin/", mode = "755" },
     { source = "resources/niri-session", dest = "/usr/bin/", mode = "755" },

--- a/niri-config/Cargo.toml
+++ b/niri-config/Cargo.toml
@@ -12,7 +12,7 @@ bitflags.workspace = true
 csscolorparser = "0.7.0"
 knuffel = "3.2.0"
 miette = { version = "5.10.0", features = ["fancy-no-backtrace"] }
-niri-ipc = { version = "25.1.0", path = "../niri-ipc" }
+niri-ipc = { version = "25.2.0", path = "../niri-ipc" }
 regex = "1.11.1"
 smithay = { workspace = true, features = ["backend_libinput"] }
 tracing.workspace = true

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -185,6 +185,8 @@ pub struct Touchpad {
     pub dwt: bool,
     #[knuffel(child)]
     pub dwtp: bool,
+    #[knuffel(child, unwrap(argument))]
+    pub drag: Option<bool>,
     #[knuffel(child)]
     pub drag_lock: bool,
     #[knuffel(child)]
@@ -3559,6 +3561,7 @@ mod tests {
                     tap
                     dwt
                     dwtp
+                    drag true
                     click-method "clickfinger"
                     accel-speed 0.2
                     accel-profile "flat"
@@ -3820,6 +3823,9 @@ mod tests {
                     tap: true,
                     dwt: true,
                     dwtp: true,
+                    drag: Some(
+                        true,
+                    ),
                     drag_lock: false,
                     natural_scroll: false,
                     click_method: Some(

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1557,6 +1557,7 @@ pub enum Action {
     FocusMonitorUp,
     FocusMonitorPrevious,
     FocusMonitorNext,
+    FocusMonitor(#[knuffel(argument)] String),
     MoveWindowToMonitorLeft,
     MoveWindowToMonitorRight,
     MoveWindowToMonitorDown,
@@ -1758,6 +1759,7 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::FocusMonitorUp {} => Self::FocusMonitorUp,
             niri_ipc::Action::FocusMonitorPrevious {} => Self::FocusMonitorPrevious,
             niri_ipc::Action::FocusMonitorNext {} => Self::FocusMonitorNext,
+            niri_ipc::Action::FocusMonitor { output } => Self::FocusMonitor(output),
             niri_ipc::Action::MoveWindowToMonitorLeft {} => Self::MoveWindowToMonitorLeft,
             niri_ipc::Action::MoveWindowToMonitorRight {} => Self::MoveWindowToMonitorRight,
             niri_ipc::Action::MoveWindowToMonitorDown {} => Self::MoveWindowToMonitorDown,
@@ -3755,6 +3757,7 @@ mod tests {
                 Mod+T allow-when-locked=true { spawn "alacritty"; }
                 Mod+Q hotkey-overlay-title=null { close-window; }
                 Mod+Shift+H { focus-monitor-left; }
+                Mod+Shift+O { focus-monitor "eDP-1"; }
                 Mod+Ctrl+Shift+L { move-window-to-monitor-right; }
                 Mod+Comma { consume-window-into-column; }
                 Mod+1 { focus-workspace 1; }
@@ -4581,6 +4584,24 @@ mod tests {
                             ),
                         },
                         action: FocusMonitorLeft,
+                        repeat: true,
+                        cooldown: None,
+                        allow_when_locked: false,
+                        allow_inhibiting: true,
+                        hotkey_overlay_title: None,
+                    },
+                    Bind {
+                        key: Key {
+                            trigger: Keysym(
+                                XK_o,
+                            ),
+                            modifiers: Modifiers(
+                                SHIFT | COMPOSITOR,
+                            ),
+                        },
+                        action: FocusMonitor(
+                            "eDP-1",
+                        ),
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1564,12 +1564,14 @@ pub enum Action {
     MoveWindowToMonitorUp,
     MoveWindowToMonitorPrevious,
     MoveWindowToMonitorNext,
+    MoveWindowToMonitor(#[knuffel(argument)] String),
     MoveColumnToMonitorLeft,
     MoveColumnToMonitorRight,
     MoveColumnToMonitorDown,
     MoveColumnToMonitorUp,
     MoveColumnToMonitorPrevious,
     MoveColumnToMonitorNext,
+    MoveColumnToMonitor(#[knuffel(argument)] String),
     SetWindowWidth(#[knuffel(argument, str)] SizeChange),
     #[knuffel(skip)]
     SetWindowWidthById {
@@ -1766,12 +1768,14 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::MoveWindowToMonitorUp {} => Self::MoveWindowToMonitorUp,
             niri_ipc::Action::MoveWindowToMonitorPrevious {} => Self::MoveWindowToMonitorPrevious,
             niri_ipc::Action::MoveWindowToMonitorNext {} => Self::MoveWindowToMonitorNext,
+            niri_ipc::Action::MoveWindowToMonitor { output } => Self::MoveWindowToMonitor(output),
             niri_ipc::Action::MoveColumnToMonitorLeft {} => Self::MoveColumnToMonitorLeft,
             niri_ipc::Action::MoveColumnToMonitorRight {} => Self::MoveColumnToMonitorRight,
             niri_ipc::Action::MoveColumnToMonitorDown {} => Self::MoveColumnToMonitorDown,
             niri_ipc::Action::MoveColumnToMonitorUp {} => Self::MoveColumnToMonitorUp,
             niri_ipc::Action::MoveColumnToMonitorPrevious {} => Self::MoveColumnToMonitorPrevious,
             niri_ipc::Action::MoveColumnToMonitorNext {} => Self::MoveColumnToMonitorNext,
+            niri_ipc::Action::MoveColumnToMonitor { output } => Self::MoveColumnToMonitor(output),
             niri_ipc::Action::SetWindowWidth { id: None, change } => Self::SetWindowWidth(change),
             niri_ipc::Action::SetWindowWidth {
                 id: Some(id),
@@ -3759,6 +3763,8 @@ mod tests {
                 Mod+Shift+H { focus-monitor-left; }
                 Mod+Shift+O { focus-monitor "eDP-1"; }
                 Mod+Ctrl+Shift+L { move-window-to-monitor-right; }
+                Mod+Ctrl+Alt+O { move-window-to-monitor "eDP-1"; }
+                Mod+Ctrl+Alt+P { move-column-to-monitor "DP-1"; }
                 Mod+Comma { consume-window-into-column; }
                 Mod+1 { focus-workspace 1; }
                 Mod+Shift+1 { focus-workspace "workspace-1"; }
@@ -4618,6 +4624,42 @@ mod tests {
                             ),
                         },
                         action: MoveWindowToMonitorRight,
+                        repeat: true,
+                        cooldown: None,
+                        allow_when_locked: false,
+                        allow_inhibiting: true,
+                        hotkey_overlay_title: None,
+                    },
+                    Bind {
+                        key: Key {
+                            trigger: Keysym(
+                                XK_o,
+                            ),
+                            modifiers: Modifiers(
+                                CTRL | ALT | COMPOSITOR,
+                            ),
+                        },
+                        action: MoveWindowToMonitor(
+                            "eDP-1",
+                        ),
+                        repeat: true,
+                        cooldown: None,
+                        allow_when_locked: false,
+                        allow_inhibiting: true,
+                        hotkey_overlay_title: None,
+                    },
+                    Bind {
+                        key: Key {
+                            trigger: Keysym(
+                                XK_p,
+                            ),
+                            modifiers: Modifiers(
+                                CTRL | ALT | COMPOSITOR,
+                            ),
+                        },
+                        action: MoveColumnToMonitor(
+                            "DP-1",
+                        ),
                         repeat: true,
                         cooldown: None,
                         allow_when_locked: false,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -349,6 +349,8 @@ pub struct Tablet {
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
 pub struct Touch {
+    #[knuffel(child)]
+    pub off: bool,
     #[knuffel(child, unwrap(argument))]
     pub map_to_output: Option<String>,
 }
@@ -3909,6 +3911,7 @@ mod tests {
                     left_handed: false,
                 },
                 touch: Touch {
+                    off: false,
                     map_to_output: Some(
                         "eDP-1",
                     ),

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1355,6 +1355,10 @@ pub enum RelativeTo {
     TopRight,
     BottomLeft,
     BottomRight,
+    Top,
+    Bottom,
+    Left,
+    Right,
 }
 
 #[derive(Debug, Default, PartialEq)]

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2020,6 +2020,8 @@ pub struct DebugConfig {
     pub disable_monitor_names: bool,
     #[knuffel(child)]
     pub strict_new_window_focus_policy: bool,
+    #[knuffel(child)]
+    pub honor_xdg_activation_with_invalid_serial: bool,
 }
 
 #[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq)]
@@ -4801,6 +4803,7 @@ mod tests {
                 keep_laptop_panel_on_when_lid_is_closed: false,
                 disable_monitor_names: false,
                 strict_new_window_focus_policy: false,
+                honor_xdg_activation_with_invalid_serial: false,
             },
             workspaces: [
                 Workspace {

--- a/niri-ipc/Cargo.toml
+++ b/niri-ipc/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 clap = { workspace = true, optional = true }
-schemars = { version = "0.8.21", optional = true }
+schemars = { version = "0.8.22", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/niri-ipc/README.md
+++ b/niri-ipc/README.md
@@ -12,5 +12,5 @@ Use an exact version requirement to avoid breaking changes:
 
 ```toml
 [dependencies]
-niri-ipc = "=25.1.0"
+niri-ipc = "=25.2.0"
 ```

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -63,6 +63,8 @@ pub enum Request {
     FocusedOutput,
     /// Request information about the focused window.
     FocusedWindow,
+    /// Request picking a window and get its information.
+    PickWindow,
     /// Perform an action.
     Action(Action),
     /// Change output configuration temporarily.
@@ -129,6 +131,8 @@ pub enum Response {
     FocusedOutput(Option<Output>),
     /// Information about the focused window.
     FocusedWindow(Option<Window>),
+    /// Information about the picked window.
+    PickedWindow(Option<Window>),
     /// Output configuration change result.
     OutputConfigChanged(OutputConfigChanged),
 }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -445,6 +445,16 @@ pub enum Action {
     FocusMonitorPrevious {},
     /// Focus the next monitor.
     FocusMonitorNext {},
+    /// Focus a specific monitor.
+    #[cfg_attr(
+        feature = "clap",
+        clap(about = "Focus a specific monitor")
+    )]
+    FocusMonitor {
+        /// The target output name.
+        #[cfg_attr(feature = "clap", arg())]
+        output: String,
+    },
     /// Move the focused window to the monitor to the left.
     MoveWindowToMonitorLeft {},
     /// Move the focused window to the monitor to the right.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -467,6 +467,16 @@ pub enum Action {
     MoveWindowToMonitorPrevious {},
     /// Move the focused window to the next monitor.
     MoveWindowToMonitorNext {},
+    /// Move the focused window to a specific monitor.
+    #[cfg_attr(
+        feature = "clap",
+        clap(about = "Move the focused window to a specific monitor")
+    )]
+    MoveWindowToMonitor {
+        /// The target output name.
+        #[cfg_attr(feature = "clap", arg())]
+        output: String,
+    },
     /// Move the focused column to the monitor to the left.
     MoveColumnToMonitorLeft {},
     /// Move the focused column to the monitor to the right.
@@ -479,6 +489,16 @@ pub enum Action {
     MoveColumnToMonitorPrevious {},
     /// Move the focused column to the next monitor.
     MoveColumnToMonitorNext {},
+    /// Move the focused column to a specific monitor.
+    #[cfg_attr(
+        feature = "clap",
+        clap(about = "Move the focused column to a specific monitor")
+    )]
+    MoveColumnToMonitor {
+        /// The target output name.
+        #[cfg_attr(feature = "clap", arg())]
+        output: String,
+    },
     /// Change the width of a window.
     #[cfg_attr(
         feature = "clap",

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! niri-ipc = "=25.1.0"
+//! niri-ipc = "=25.2.0"
 //! ```
 //!
 //! ## Features

--- a/niri-visual-tests/Cargo.toml
+++ b/niri-visual-tests/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 adw = { version = "0.7.1", package = "libadwaita", features = ["v1_4"] }
 anyhow.workspace = true
 gtk = { version = "0.9.6", package = "gtk4", features = ["v4_12"] }
-niri = { version = "25.1.0", path = ".." }
-niri-config = { version = "25.1.0", path = "../niri-config" }
+niri = { version = "25.2.0", path = ".." }
+niri-config = { version = "25.2.0", path = "../niri-config" }
 smithay.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/niri-visual-tests/Cargo.toml
+++ b/niri-visual-tests/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 [dependencies]
 adw = { version = "0.7.1", package = "libadwaita", features = ["v1_4"] }
 anyhow.workspace = true
-gtk = { version = "0.9.5", package = "gtk4", features = ["v4_12"] }
+gtk = { version = "0.9.6", package = "gtk4", features = ["v4_12"] }
 niri = { version = "25.1.0", path = ".." }
 niri-config = { version = "25.1.0", path = "../niri-config" }
 smithay.workspace = true

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -25,6 +25,7 @@ input {
         tap
         // dwt
         // dwtp
+        // drag false
         // drag-lock
         natural-scroll
         // accel-speed 0.2

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,8 @@ pub enum Msg {
     FocusedOutput,
     /// Print information about the focused window.
     FocusedWindow,
+    /// Pick a window with the mouse and print information about it.
+    PickWindow,
     /// Perform an action.
     Action {
         #[command(subcommand)]

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -75,19 +75,22 @@ impl CursorManager {
 
                 RenderCursor::Surface { hotspot, surface }
             }
-            CursorImageStatus::Named(icon) => self
-                .get_cursor_with_name(icon, scale)
-                .map(|cursor| RenderCursor::Named {
-                    icon,
-                    scale,
-                    cursor,
-                })
-                .unwrap_or_else(|| RenderCursor::Named {
-                    icon: Default::default(),
-                    scale,
-                    cursor: self.get_default_cursor(scale),
-                }),
+            CursorImageStatus::Named(icon) => self.get_render_cursor_named(icon, scale),
         }
+    }
+
+    fn get_render_cursor_named(&self, icon: CursorIcon, scale: i32) -> RenderCursor {
+        self.get_cursor_with_name(icon, scale)
+            .map(|cursor| RenderCursor::Named {
+                icon,
+                scale,
+                cursor,
+            })
+            .unwrap_or_else(|| RenderCursor::Named {
+                icon: Default::default(),
+                scale,
+                cursor: self.get_default_cursor(scale),
+            })
     }
 
     pub fn is_current_cursor_animated(&self, scale: i32) -> bool {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1433,6 +1433,15 @@ impl State {
                     }
                 }
             }
+            Action::MoveWindowToMonitor(output) => {
+                if let Some(output) = self.niri.output_by_name_match(&output).cloned() {
+                    self.niri.layout.move_to_output(None, &output, None);
+                    self.niri.layout.focus_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
+                }
+            }
             Action::MoveColumnToMonitorLeft => {
                 if let Some(output) = self.niri.output_left() {
                     self.niri.layout.move_column_to_output(&output);
@@ -1480,6 +1489,15 @@ impl State {
             }
             Action::MoveColumnToMonitorNext => {
                 if let Some(output) = self.niri.output_next() {
+                    self.niri.layout.move_column_to_output(&output);
+                    self.niri.layout.focus_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
+                }
+            }
+            Action::MoveColumnToMonitor(output) => {
+                if let Some(output) = self.niri.output_by_name_match(&output).cloned() {
                     self.niri.layout.move_column_to_output(&output);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3361,6 +3361,13 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
         let _ = device.config_left_handed_set(c.left_handed);
         let _ = device.config_middle_emulation_set_enabled(c.middle_emulation);
 
+        if let Some(drag) = c.drag {
+            let _ = device.config_tap_set_drag_enabled(drag);
+        } else {
+            let default = device.config_tap_default_drag_enabled();
+            let _ = device.config_tap_set_drag_enabled(default);
+        }
+
         if let Some(accel_profile) = c.accel_profile {
             let _ = device.config_accel_set_profile(accel_profile.into());
         } else if let Some(default) = device.config_accel_default_profile() {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3539,6 +3539,16 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
 
         let _ = device.config_left_handed_set(c.left_handed);
     }
+
+    let is_touch = device.has_capability(input::DeviceCapability::Touch);
+    if is_touch {
+        let c = &config.touch;
+        let _ = device.config_send_events_set_mode(if c.off {
+            input::SendEventsMode::DISABLED
+        } else {
+            input::SendEventsMode::ENABLED
+        });
+    }
 }
 
 pub fn mods_with_binds(

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1370,6 +1370,15 @@ impl State {
                     self.niri.layer_shell_on_demand_focus = None;
                 }
             }
+            Action::FocusMonitor(output) => {
+                if let Some(output) = self.niri.output_by_name_match(&output).cloned() {
+                    self.niri.layout.focus_output(&output);
+                    if !self.maybe_warp_cursor_to_focus_centered() {
+                        self.move_cursor_to_output(&output);
+                    }
+                    self.niri.layer_shell_on_demand_focus = None;
+                }
+            }
             Action::MoveWindowToMonitorLeft => {
                 if let Some(output) = self.niri.output_left() {
                     self.niri.layout.move_to_output(None, &output, None);

--- a/src/input/pick_window_grab.rs
+++ b/src/input/pick_window_grab.rs
@@ -1,0 +1,167 @@
+use smithay::backend::input::ButtonState;
+use smithay::input::pointer::{
+    AxisFrame, ButtonEvent, CursorImageStatus, GestureHoldBeginEvent, GestureHoldEndEvent,
+    GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent,
+    GestureSwipeEndEvent, GestureSwipeUpdateEvent, GrabStartData as PointerGrabStartData,
+    MotionEvent, PointerGrab, PointerInnerHandle, RelativeMotionEvent,
+};
+use smithay::input::SeatHandler;
+use smithay::utils::{Logical, Point};
+
+use crate::niri::State;
+use crate::window::Mapped;
+
+pub struct PickWindowGrab {
+    start_data: PointerGrabStartData<State>,
+}
+
+impl PickWindowGrab {
+    pub fn new(start_data: PointerGrabStartData<State>) -> Self {
+        Self { start_data }
+    }
+
+    fn on_ungrab(&mut self, state: &mut State) {
+        if let Some(tx) = state.niri.pick_window.take() {
+            let _ = tx.send_blocking(None);
+        }
+        state
+            .niri
+            .cursor_manager
+            .set_cursor_image(CursorImageStatus::default_named());
+        // Redraw to update the cursor.
+        state.niri.queue_redraw_all();
+    }
+}
+
+impl PointerGrab<State> for PickWindowGrab {
+    fn motion(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        _focus: Option<(<State as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
+        event: &MotionEvent,
+    ) {
+        handle.motion(data, None, event);
+    }
+
+    fn relative_motion(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        _focus: Option<(<State as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
+        event: &RelativeMotionEvent,
+    ) {
+        handle.relative_motion(data, None, event);
+    }
+
+    fn button(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &ButtonEvent,
+    ) {
+        if event.state == ButtonState::Pressed {
+            if let Some(tx) = data.niri.pick_window.take() {
+                let _ = tx.send_blocking(
+                    data.niri
+                        .window_under(handle.current_location())
+                        .map(Mapped::id),
+                );
+            }
+            handle.unset_grab(self, data, event.serial, event.time, true);
+        }
+    }
+
+    fn axis(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        details: AxisFrame,
+    ) {
+        handle.axis(data, details);
+    }
+
+    fn frame(&mut self, data: &mut State, handle: &mut PointerInnerHandle<'_, State>) {
+        handle.frame(data);
+    }
+
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event);
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event);
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event);
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event);
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event);
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event);
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event);
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event);
+    }
+
+    fn start_data(&self) -> &PointerGrabStartData<State> {
+        &self.start_data
+    }
+
+    fn unset(&mut self, data: &mut State) {
+        self.on_ungrab(data);
+    }
+}

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -19,6 +19,7 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
         Msg::Outputs => Request::Outputs,
         Msg::FocusedWindow => Request::FocusedWindow,
         Msg::FocusedOutput => Request::FocusedOutput,
+        Msg::PickWindow => Request::PickWindow,
         Msg::Action { action } => Request::Action(action.clone()),
         Msg::Output { output, action } => Request::Output {
             output: output.clone(),
@@ -250,6 +251,23 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                 print_output(output)?;
             } else {
                 println!("No output is focused.");
+            }
+        }
+        Msg::PickWindow => {
+            let Response::PickedWindow(window) = response else {
+                bail!("unexpected response: expected PickedWindow, got {response:?}");
+            };
+
+            if json {
+                let window = serde_json::to_string(&window).context("error formatting response")?;
+                println!("{window}");
+                return Ok(());
+            }
+
+            if let Some(window) = window {
+                print_window(&window);
+            } else {
+                println!("No window selected.");
             }
         }
         Msg::Action { .. } => {

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1206,11 +1206,23 @@ impl<W: LayoutElement> FloatingSpace<W> {
                 let area = self.working_area;
 
                 let mut pos = Point::from((pos.x.0, pos.y.0));
-                if relative_to == RelativeTo::TopRight || relative_to == RelativeTo::BottomRight {
+                if relative_to == RelativeTo::TopRight
+                    || relative_to == RelativeTo::BottomRight
+                    || relative_to == RelativeTo::Right
+                {
                     pos.x = area.size.w - size.w - pos.x;
                 }
-                if relative_to == RelativeTo::BottomLeft || relative_to == RelativeTo::BottomRight {
+                if relative_to == RelativeTo::BottomLeft
+                    || relative_to == RelativeTo::BottomRight
+                    || relative_to == RelativeTo::Bottom
+                {
                     pos.y = area.size.h - size.h - pos.y;
+                }
+                if relative_to == RelativeTo::Top || relative_to == RelativeTo::Bottom {
+                    pos.x += area.size.w / 2.0 - size.w / 2.0
+                }
+                if relative_to == RelativeTo::Left || relative_to == RelativeTo::Right {
+                    pos.y += area.size.h / 2.0 - size.h / 2.0
                 }
 
                 pos + self.working_area.loc

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1778,36 +1778,36 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn move_left(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.move_left();
+        workspace.move_left();
     }
 
     pub fn move_right(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.move_right();
+        workspace.move_right();
     }
 
     pub fn move_column_to_first(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.move_column_to_first();
+        workspace.move_column_to_first();
     }
 
     pub fn move_column_to_last(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.move_column_to_last();
+        workspace.move_column_to_last();
     }
 
     pub fn move_column_left_or_to_output(&mut self, output: &Output) -> bool {
-        if let Some(monitor) = self.active_monitor() {
-            if monitor.move_left() {
+        if let Some(workspace) = self.active_workspace_mut() {
+            if workspace.move_left() {
                 return false;
             }
         }
@@ -1817,8 +1817,8 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn move_column_right_or_to_output(&mut self, output: &Output) -> bool {
-        if let Some(monitor) = self.active_monitor() {
-            if monitor.move_right() {
+        if let Some(workspace) = self.active_workspace_mut() {
+            if workspace.move_right() {
                 return false;
             }
         }
@@ -1828,17 +1828,17 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn move_down(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.move_down();
+        workspace.move_down();
     }
 
     pub fn move_up(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.move_up();
+        workspace.move_up();
     }
 
     pub fn move_down_or_to_workspace_down(&mut self) {
@@ -1902,50 +1902,50 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn focus_left(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_left();
+        workspace.focus_left();
     }
 
     pub fn focus_right(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_right();
+        workspace.focus_right();
     }
 
     pub fn focus_column_first(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_column_first();
+        workspace.focus_column_first();
     }
 
     pub fn focus_column_last(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_column_last();
+        workspace.focus_column_last();
     }
 
     pub fn focus_column_right_or_first(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_column_right_or_first();
+        workspace.focus_column_right_or_first();
     }
 
     pub fn focus_column_left_or_last(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_column_left_or_last();
+        workspace.focus_column_left_or_last();
     }
 
     pub fn focus_window_up_or_output(&mut self, output: &Output) -> bool {
-        if let Some(monitor) = self.active_monitor() {
-            if monitor.focus_up() {
+        if let Some(workspace) = self.active_workspace_mut() {
+            if workspace.focus_up() {
                 return false;
             }
         }
@@ -1955,8 +1955,8 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn focus_window_down_or_output(&mut self, output: &Output) -> bool {
-        if let Some(monitor) = self.active_monitor() {
-            if monitor.focus_down() {
+        if let Some(workspace) = self.active_workspace_mut() {
+            if workspace.focus_down() {
                 return false;
             }
         }
@@ -1966,8 +1966,8 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn focus_column_left_or_output(&mut self, output: &Output) -> bool {
-        if let Some(monitor) = self.active_monitor() {
-            if monitor.focus_left() {
+        if let Some(workspace) = self.active_workspace_mut() {
+            if workspace.focus_left() {
                 return false;
             }
         }
@@ -1977,8 +1977,8 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn focus_column_right_or_output(&mut self, output: &Output) -> bool {
-        if let Some(monitor) = self.active_monitor() {
-            if monitor.focus_right() {
+        if let Some(workspace) = self.active_workspace_mut() {
+            if workspace.focus_right() {
                 return false;
             }
         }
@@ -1988,52 +1988,52 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn focus_window_in_column(&mut self, index: u8) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_window_in_column(index);
+        workspace.focus_window_in_column(index);
     }
 
     pub fn focus_down(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_down();
+        workspace.focus_down();
     }
 
     pub fn focus_up(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_up();
+        workspace.focus_up();
     }
 
     pub fn focus_down_or_left(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_down_or_left();
+        workspace.focus_down_or_left();
     }
 
     pub fn focus_down_or_right(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_down_or_right();
+        workspace.focus_down_or_right();
     }
 
     pub fn focus_up_or_left(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_up_or_left();
+        workspace.focus_up_or_left();
     }
 
     pub fn focus_up_or_right(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_up_or_right();
+        workspace.focus_up_or_right();
     }
 
     pub fn focus_window_or_workspace_down(&mut self) {
@@ -2051,31 +2051,31 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn focus_window_top(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_window_top();
+        workspace.focus_window_top();
     }
 
     pub fn focus_window_bottom(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_window_bottom();
+        workspace.focus_window_bottom();
     }
 
     pub fn focus_window_down_or_top(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_window_down_or_top();
+        workspace.focus_window_down_or_top();
     }
 
     pub fn focus_window_up_or_bottom(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.focus_window_up_or_bottom();
+        workspace.focus_window_up_or_bottom();
     }
 
     pub fn move_to_workspace_up(&mut self) {
@@ -2181,45 +2181,45 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn consume_into_column(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.consume_into_column();
+        workspace.consume_into_column();
     }
 
     pub fn expel_from_column(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.expel_from_column();
+        workspace.expel_from_column();
     }
 
     pub fn swap_window_in_direction(&mut self, direction: ScrollDirection) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.swap_window_in_direction(direction);
+        workspace.swap_window_in_direction(direction);
     }
 
     pub fn toggle_column_tabbed_display(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.toggle_column_tabbed_display();
+        workspace.toggle_column_tabbed_display();
     }
 
     pub fn set_column_display(&mut self, display: ColumnDisplay) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.set_column_display(display);
+        workspace.set_column_display(display);
     }
 
     pub fn center_column(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.center_column();
+        workspace.center_column();
     }
 
     pub fn center_window(&mut self, id: Option<&W::Id>) {
@@ -2842,10 +2842,10 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn toggle_width(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.toggle_width();
+        workspace.toggle_width();
     }
 
     pub fn toggle_window_width(&mut self, window: Option<&W::Id>) {
@@ -2895,17 +2895,17 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn toggle_full_width(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.toggle_full_width();
+        workspace.toggle_full_width();
     }
 
     pub fn set_column_width(&mut self, change: SizeChange) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.set_column_width(change);
+        workspace.set_column_width(change);
     }
 
     pub fn set_window_width(&mut self, window: Option<&W::Id>, change: SizeChange) {
@@ -2978,10 +2978,10 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn expand_column_to_available_width(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
+        let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        monitor.expand_column_to_available_width();
+        workspace.expand_column_to_available_width();
     }
 
     pub fn toggle_window_floating(&mut self, window: Option<&W::Id>) {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -2,14 +2,13 @@ use std::cmp::min;
 use std::rc::Rc;
 use std::time::Duration;
 
-use niri_ipc::{ColumnDisplay, SizeChange};
 use smithay::backend::renderer::element::utils::{
     CropRenderElement, Relocate, RelocateRenderElement,
 };
 use smithay::output::Output;
 use smithay::utils::{Logical, Point, Rectangle, Size};
 
-use super::scrolling::{Column, ColumnWidth, ScrollDirection};
+use super::scrolling::{Column, ColumnWidth};
 use super::tile::Tile;
 use super::workspace::{
     OutputId, Workspace, WorkspaceAddWindowTarget, WorkspaceId, WorkspaceRenderElement,
@@ -397,30 +396,6 @@ impl<W: LayoutElement> Monitor<W> {
         true
     }
 
-    pub fn move_left(&mut self) -> bool {
-        self.active_workspace().move_left()
-    }
-
-    pub fn move_right(&mut self) -> bool {
-        self.active_workspace().move_right()
-    }
-
-    pub fn move_column_to_first(&mut self) {
-        self.active_workspace().move_column_to_first();
-    }
-
-    pub fn move_column_to_last(&mut self) {
-        self.active_workspace().move_column_to_last();
-    }
-
-    pub fn move_down(&mut self) {
-        self.active_workspace().move_down();
-    }
-
-    pub fn move_up(&mut self) {
-        self.active_workspace().move_up();
-    }
-
     pub fn move_down_or_to_workspace_down(&mut self) {
         if !self.active_workspace().move_down() {
             self.move_to_workspace_down();
@@ -433,58 +408,6 @@ impl<W: LayoutElement> Monitor<W> {
         }
     }
 
-    pub fn focus_left(&mut self) -> bool {
-        self.active_workspace().focus_left()
-    }
-
-    pub fn focus_right(&mut self) -> bool {
-        self.active_workspace().focus_right()
-    }
-
-    pub fn focus_column_first(&mut self) {
-        self.active_workspace().focus_column_first();
-    }
-
-    pub fn focus_column_last(&mut self) {
-        self.active_workspace().focus_column_last();
-    }
-
-    pub fn focus_column_right_or_first(&mut self) {
-        self.active_workspace().focus_column_right_or_first();
-    }
-
-    pub fn focus_column_left_or_last(&mut self) {
-        self.active_workspace().focus_column_left_or_last();
-    }
-
-    pub fn focus_window_in_column(&mut self, index: u8) {
-        self.active_workspace().focus_window_in_column(index);
-    }
-
-    pub fn focus_down(&mut self) -> bool {
-        self.active_workspace().focus_down()
-    }
-
-    pub fn focus_up(&mut self) -> bool {
-        self.active_workspace().focus_up()
-    }
-
-    pub fn focus_down_or_left(&mut self) {
-        self.active_workspace().focus_down_or_left();
-    }
-
-    pub fn focus_down_or_right(&mut self) {
-        self.active_workspace().focus_down_or_right();
-    }
-
-    pub fn focus_up_or_left(&mut self) {
-        self.active_workspace().focus_up_or_left();
-    }
-
-    pub fn focus_up_or_right(&mut self) {
-        self.active_workspace().focus_up_or_right();
-    }
-
     pub fn focus_window_or_workspace_down(&mut self) {
         if !self.active_workspace().focus_down() {
             self.switch_workspace_down();
@@ -495,22 +418,6 @@ impl<W: LayoutElement> Monitor<W> {
         if !self.active_workspace().focus_up() {
             self.switch_workspace_up();
         }
-    }
-
-    pub fn focus_window_top(&mut self) {
-        self.active_workspace().focus_window_top();
-    }
-
-    pub fn focus_window_bottom(&mut self) {
-        self.active_workspace().focus_window_bottom();
-    }
-
-    pub fn focus_window_down_or_top(&mut self) {
-        self.active_workspace().focus_window_down_or_top();
-    }
-
-    pub fn focus_window_up_or_bottom(&mut self) {
-        self.active_workspace().focus_window_up_or_bottom();
     }
 
     pub fn move_to_workspace_up(&mut self) {
@@ -720,30 +627,6 @@ impl<W: LayoutElement> Monitor<W> {
         }
     }
 
-    pub fn consume_into_column(&mut self) {
-        self.active_workspace().consume_into_column();
-    }
-
-    pub fn expel_from_column(&mut self) {
-        self.active_workspace().expel_from_column();
-    }
-
-    pub fn swap_window_in_direction(&mut self, direction: ScrollDirection) {
-        self.active_workspace().swap_window_in_direction(direction);
-    }
-
-    pub fn toggle_column_tabbed_display(&mut self) {
-        self.active_workspace().toggle_column_tabbed_display();
-    }
-
-    pub fn set_column_display(&mut self, display: ColumnDisplay) {
-        self.active_workspace().set_column_display(display);
-    }
-
-    pub fn center_column(&mut self) {
-        self.active_workspace().center_column();
-    }
-
     pub fn active_window(&self) -> Option<&W> {
         self.active_workspace_ref().active_window()
     }
@@ -826,22 +709,6 @@ impl<W: LayoutElement> Monitor<W> {
         }
 
         self.options = options;
-    }
-
-    pub fn toggle_width(&mut self) {
-        self.active_workspace().toggle_width();
-    }
-
-    pub fn toggle_full_width(&mut self) {
-        self.active_workspace().toggle_full_width();
-    }
-
-    pub fn set_column_width(&mut self, change: SizeChange) {
-        self.active_workspace().set_column_width(change);
-    }
-
-    pub fn expand_column_to_available_width(&mut self) {
-        self.active_workspace().expand_column_to_available_width();
     }
 
     pub fn move_workspace_down(&mut self) {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -631,10 +631,6 @@ impl<W: LayoutElement> Monitor<W> {
         self.active_workspace_ref().active_window()
     }
 
-    pub fn is_active_fullscreen(&self) -> bool {
-        self.active_workspace_ref().is_active_fullscreen()
-    }
-
     pub fn advance_animations(&mut self) {
         if let Some(WorkspaceSwitch::Animation(anim)) = &mut self.workspace_switch {
             if anim.is_done() {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -29,8 +29,7 @@ use smithay::backend::renderer::element::utils::{
     select_dmabuf_feedback, Relocate, RelocateRenderElement,
 };
 use smithay::backend::renderer::element::{
-    default_primary_scanout_output_compare, Element as _, Id, Kind, PrimaryScanoutOutput,
-    RenderElementStates,
+    default_primary_scanout_output_compare, Id, Kind, PrimaryScanoutOutput, RenderElementStates,
 };
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::backend::renderer::sync::SyncPoint;
@@ -145,8 +144,8 @@ use crate::render_helpers::primary_gpu_texture::PrimaryGpuTextureRenderElement;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::texture::TextureBuffer;
 use crate::render_helpers::{
-    render_to_dmabuf, render_to_encompassing_texture, render_to_shm, render_to_texture,
-    render_to_vec, shaders, RenderTarget, SplitElements,
+    encompassing_geo, render_to_dmabuf, render_to_encompassing_texture, render_to_shm,
+    render_to_texture, render_to_vec, shaders, RenderTarget, SplitElements,
 };
 use crate::ui::config_error_notification::ConfigErrorNotification;
 use crate::ui::exit_confirm_dialog::ExitConfirmDialog;
@@ -4735,12 +4734,7 @@ impl Niri {
             alpha,
             RenderTarget::ScreenCapture,
         );
-        let geo = elements
-            .iter()
-            .map(|ele| ele.geometry(scale))
-            .reduce(|a, b| a.merge(b))
-            .unwrap_or_default();
-
+        let geo = encompassing_geo(scale, elements.iter());
         let elements = elements.iter().rev().map(|elem| {
             RelocateRenderElement::from_element(elem, geo.loc.upscale(-1), Relocate::Relative)
         });

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -159,6 +159,7 @@ use crate::utils::{
     center, center_f64, expand_home, get_monotonic_time, ipc_transform_to_smithay, logical_output,
     make_screenshot_path, output_matches_name, output_size, send_scale_transform, write_png_rgba8,
 };
+use crate::window::mapped::MappedId;
 use crate::window::{InitialConfigureState, Mapped, ResolvedWindowRules, Unmapped, WindowRef};
 
 const CLEAR_COLOR_LOCKED: [f32; 4] = [0.3, 0.1, 0.1, 1.];
@@ -355,6 +356,8 @@ pub struct Niri {
     pub config_error_notification: ConfigErrorNotification,
     pub hotkey_overlay: HotkeyOverlay,
     pub exit_confirm_dialog: Option<ExitConfirmDialog>,
+
+    pub pick_window: Option<async_channel::Sender<Option<MappedId>>>,
 
     pub debug_draw_opaque_regions: bool,
     pub debug_draw_damage: bool,
@@ -2171,6 +2174,8 @@ impl Niri {
             config_error_notification,
             hotkey_overlay,
             exit_confirm_dialog,
+
+            pick_window: None,
 
             debug_draw_opaque_regions: false,
             debug_draw_damage: false,

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -170,7 +170,7 @@ pub fn render_to_encompassing_texture(
         .reduce(|a, b| a.merge(b))
         .unwrap_or_default();
     let elements = elements.iter().rev().map(|ele| {
-        RelocateRenderElement::from_element(ele, (-geo.loc.x, -geo.loc.y), Relocate::Relative)
+        RelocateRenderElement::from_element(ele, geo.loc.upscale(-1), Relocate::Relative)
     });
 
     let (texture, sync_point) =

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -157,6 +157,16 @@ impl ToRenderElement for BakedBuffer<SolidColorBuffer> {
     }
 }
 
+pub fn encompassing_geo(
+    scale: Scale<f64>,
+    elements: impl Iterator<Item = impl RenderElement<GlesRenderer>>,
+) -> Rectangle<i32, Physical> {
+    elements
+        .map(|ele| ele.geometry(scale))
+        .reduce(|a, b| a.merge(b))
+        .unwrap_or_default()
+}
+
 pub fn render_to_encompassing_texture(
     renderer: &mut GlesRenderer,
     scale: Scale<f64>,
@@ -164,11 +174,7 @@ pub fn render_to_encompassing_texture(
     fourcc: Fourcc,
     elements: &[impl RenderElement<GlesRenderer>],
 ) -> anyhow::Result<(GlesTexture, SyncPoint, Rectangle<i32, Physical>)> {
-    let geo = elements
-        .iter()
-        .map(|ele| ele.geometry(scale))
-        .reduce(|a, b| a.merge(b))
-        .unwrap_or_default();
+    let geo = encompassing_geo(scale, elements.iter());
     let elements = elements.iter().rev().map(|ele| {
         RelocateRenderElement::from_element(ele, geo.loc.upscale(-1), Relocate::Relative)
     });

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -95,7 +95,7 @@ pub struct Mapped {
     /// Serials of commits that should be animated.
     animate_serials: Vec<Serial>,
 
-    /// Snapshot right before an animated commit.
+    /// Snapshot right before an animated commit, without popups.
     animation_snapshot: Option<LayoutElementRenderSnapshot>,
 
     /// State for the logic to request a size once (for floating windows).
@@ -290,6 +290,7 @@ impl Mapped {
         self.need_to_recompute_rules = true;
     }
 
+    /// Renders a snapshot of the window without popups.
     fn render_snapshot(&self, renderer: &mut GlesRenderer) -> LayoutElementRenderSnapshot {
         let _span = tracy_client::span!("Mapped::render_snapshot");
 
@@ -309,17 +310,6 @@ impl Mapped {
         let mut contents = vec![];
 
         let surface = self.toplevel().wl_surface();
-        for (popup, popup_offset) in PopupManager::popups_for_surface(surface) {
-            let offset = self.window.geometry().loc + popup_offset - popup.geometry().loc;
-
-            render_snapshot_from_surface_tree(
-                renderer,
-                popup.wl_surface(),
-                buf_pos + offset.to_f64(),
-                &mut contents,
-            );
-        }
-
         render_snapshot_from_surface_tree(renderer, surface, buf_pos, &mut contents);
 
         RenderSnapshot {

--- a/wiki/Application-Issues.md
+++ b/wiki/Application-Issues.md
@@ -6,6 +6,9 @@ Apparently, VSCode currently unconditionally queries the X server for a keymap.
 
 ### WezTerm
 
+> [!NOTE]
+> Both of these issues seem to be fixed in the nightly build of WezTerm.
+
 There's [a bug](https://github.com/wez/wezterm/issues/4708) in WezTerm that it waits for a zero-sized Wayland configure event, so its window never shows up in niri. To work around it, put this window rule in the niri config (included in the default config):
 
 ```kdl

--- a/wiki/Configuration:-Debug-Options.md
+++ b/wiki/Configuration:-Debug-Options.md
@@ -27,6 +27,7 @@ debug {
     keep-laptop-panel-on-when-lid-is-closed
     disable-monitor-names
     strict-new-window-focus-policy
+    honor-xdg-activation-with-invalid-serial 
 }
 
 binds {
@@ -235,6 +236,25 @@ Only windows that activate themselves with a valid xdg-activation token will be 
 ```kdl
 debug {
     strict-new-window-focus-policy
+}
+```
+
+### `honor-xdg-activation-with-invalid-serial`
+
+<sup>Since: next release</sup>
+
+Widely-used clients such as Discord and Telegram make fresh xdg-activation tokens upon clicking on their tray icon or on their notification.
+Most of the time, these fresh tokens will have invalid serials, because the app needs to be focused to get a valid serial, and if the user clicks on a tray icon or a notification, it is usually because the app *isn't* focused, and the user wants to focus it.
+
+By default, niri ignores xdg-activation tokens with invalid serials, to prevent windows from randomly stealing focus.
+This debug flag makes niri honor such tokens, making the aforementioned widely-used apps get focus when clicking on their tray icon or notification.
+
+Amusingly, clicking on a notification sends the app a perfectly valid activation token from the notification daemon, but these apps seem to simply ignore it.
+Maybe in the future these apps/toolkits (Electron, Qt) are fixed, making this debug flag unnecessary.
+
+```kdl
+debug {
+    honor-xdg-activation-with-invalid-serial
 }
 ```
 

--- a/wiki/Configuration:-Gestures.md
+++ b/wiki/Configuration:-Gestures.md
@@ -1,6 +1,6 @@
 ### Overview
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 The `gestures` config section contains gesture settings.
 For an overview of all niri gestures, see the [Gestures](./Gestures.md) wiki page.

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -30,6 +30,7 @@ input {
         tap
         // dwt
         // dwtp
+        // drag false
         // drag-lock
         natural-scroll
         // accel-speed 0.2
@@ -186,6 +187,7 @@ Settings specific to `touchpad`s:
 - `tap`: tap-to-click.
 - `dwt`: disable-when-typing.
 - `dwtp`: disable-when-trackpointing.
+- `drag`: can be `true` or `false`, controls if tap-and-drag is enabled.
 - `drag-lock`: <sup>Since: 25.02</sup> if set, lifting the finger off for a short time while dragging will not drop the dragged item. See the [libinput documentation](https://wayland.freedesktop.org/libinput/doc/latest/tapping.html#tap-and-drag).
 - `tap-button-map`: can be `left-right-middle` or `left-middle-right`, controls which button corresponds to a two-finger tap and a three-finger tap.
 - `click-method`: can be `button-areas` or `clickfinger`, changes the [click method](https://wayland.freedesktop.org/libinput/doc/latest/clickpad-softbuttons.html).

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -117,7 +117,7 @@ input {
 
 > [!TIP]
 >
-> <sup>Since: next release</sup>
+> <sup>Since: 25.02</sup>
 >
 > Alternatively, you can directly set a path to a .xkb file containing an xkb keymap.
 > This overrides all other xkb settings.
@@ -185,7 +185,7 @@ Settings specific to `touchpad`s:
 - `tap`: tap-to-click.
 - `dwt`: disable-when-typing.
 - `dwtp`: disable-when-trackpointing.
-- `drag-lock`: <sup>Since: next release</sup> if set, lifting the finger off for a short time while dragging will not drop the dragged item. See the [libinput documentation](https://wayland.freedesktop.org/libinput/doc/latest/tapping.html#tap-and-drag).
+- `drag-lock`: <sup>Since: 25.02</sup> if set, lifting the finger off for a short time while dragging will not drop the dragged item. See the [libinput documentation](https://wayland.freedesktop.org/libinput/doc/latest/tapping.html#tap-and-drag).
 - `tap-button-map`: can be `left-right-middle` or `left-middle-right`, controls which button corresponds to a two-finger tap and a three-finger tap.
 - `click-method`: can be `button-areas` or `clickfinger`, changes the [click method](https://wayland.freedesktop.org/libinput/doc/latest/clickpad-softbuttons.html).
 - `disabled-on-external-mouse`: do not send events while external pointer device is plugged in.
@@ -200,7 +200,7 @@ Settings specific to `touchpad`, `mouse` and `tablet`:
 
 Settings specific to `tablet`s:
 
-- `calibration-matrix`: <sup>Since: next release</sup> set to six floating point numbers to change the calibration matrix. See the [`LIBINPUT_CALIBRATION_MATRIX` documentation](https://wayland.freedesktop.org/libinput/doc/latest/device-configuration-via-udev.html) for examples.
+- `calibration-matrix`: <sup>Since: 25.02</sup> set to six floating point numbers to change the calibration matrix. See the [`LIBINPUT_CALIBRATION_MATRIX` documentation](https://wayland.freedesktop.org/libinput/doc/latest/device-configuration-via-udev.html) for examples.
 
 Tablets and touchscreens are absolute pointing devices that can be mapped to a specific output like so:
 

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -85,6 +85,7 @@ input {
     }
 
     touch {
+        // off
         map-to-output "eDP-1"
     }
 

--- a/wiki/Configuration:-Key-Bindings.md
+++ b/wiki/Configuration:-Key-Bindings.md
@@ -121,7 +121,7 @@ Note that binding `Mod+MouseLeft` or `Mod+MouseRight` will override the correspo
 
 ### Custom Hotkey Overlay Titles
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 The hotkey overlay (the Important Hotkeys dialog) shows a hardcoded list of binds.
 You can customize this list using the `hotkey-overlay-title` property.
@@ -309,7 +309,7 @@ binds {
 Take a screenshot of the focused screen or window respectively.
 The screenshot is both stored to the clipboard and saved to disk, according to the [`screenshot-path` option](./Configuration:-Miscellaneous.md).
 
-<sup>Since: next release</sup> You can disable saving to disk for a specific bind with the `write-to-disk=false` property:
+<sup>Since: 25.02</sup> You can disable saving to disk for a specific bind with the `write-to-disk=false` property:
 
 ```kdl
 binds {

--- a/wiki/Configuration:-Layer-Rules.md
+++ b/wiki/Configuration:-Layer-Rules.md
@@ -111,7 +111,7 @@ layer-rule {
 
 #### `shadow`
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 Override the shadow options for the surface.
 
@@ -142,7 +142,7 @@ layer-rule {
 
 #### `geometry-corner-radius`
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 Set the corner radius of the surface.
 

--- a/wiki/Configuration:-Layout.md
+++ b/wiki/Configuration:-Layout.md
@@ -142,7 +142,7 @@ layout {
 
 ### `default-column-display`
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 Sets the default display mode for new columns.
 Can be `normal` or `tabbed`.
@@ -168,7 +168,7 @@ Set the widths that the `switch-preset-column-width` action (Mod+R) toggles betw
 For example, you can perfectly fit four windows sized `proportion 0.25` on an output, regardless of the gaps setting.
 The default preset widths are <sup>1</sup>&frasl;<sub>3</sub>, <sup>1</sup>&frasl;<sub>2</sub> and <sup>2</sup>&frasl;<sub>3</sub> of the output.
 
-`fixed` sets the width in logical pixels exactly.
+`fixed` sets the window width in logical pixels exactly.
 
 ```kdl
 layout {
@@ -181,13 +181,6 @@ layout {
     }
 }
 ```
-
-> [!NOTE]
-> Until next release, a preset `fixed` width does not take borders into account in the tiling layout.
-> I.e., preset `fixed 1000` with 4-wide borders will make the window 992 logical pixels wide.
-> This may eventually be corrected.
->
-> All other ways of using `fixed` (i.e. `default-column-width` or `set-column-width`) do take borders into account and give you the exact window width that you request.
 
 ### `default-column-width`
 
@@ -369,7 +362,7 @@ layout {
 
 ### `shadow`
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 Shadow rendered behind a window.
 
@@ -415,7 +408,7 @@ prefer-no-csd
 
 ### `tab-indicator`
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 Controls the appearance of the tab indicator that appears next to columns in tabbed display mode.
 

--- a/wiki/Configuration:-Named-Workspaces.md
+++ b/wiki/Configuration:-Named-Workspaces.md
@@ -42,6 +42,6 @@ Before, it could only use the connector name.
 
 <sup>Since: 25.01</sup> You can use `set-workspace-name` and `unset-workspace-name` actions to change workspace names dynamically.
 
-<sup>Since: next release</sup> Named workspaces no longer update/forget their original output when opening a new window on them (unnamed workspaces will keep doing that).
+<sup>Since: 25.02</sup> Named workspaces no longer update/forget their original output when opening a new window on them (unnamed workspaces will keep doing that).
 This means that named workspaces "stick" to their original output in more cases, reflecting their more permanent nature.
 Explicitly moving a named workspace to a different monitor will still update its original output.

--- a/wiki/Configuration:-Overview.md
+++ b/wiki/Configuration:-Overview.md
@@ -11,6 +11,7 @@ You can find documentation for various sections of the config on these wiki page
 * [`window-rule {}`](./Configuration:-Window-Rules.md)
 * [`layer-rule {}`](./Configuration:-Layer-Rules.md)
 * [`animations {}`](./Configuration:-Animations.md)
+* [`gestures {}`](./Configuration:-Gestures.md)
 * [`debug {}`](./Configuration:-Debug-Options.md)
 
 ### Loading

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -242,7 +242,7 @@ window-rule {
 
 #### `is-window-cast-target`
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 Can be `true` or `false`.
 Matches `true` for windows that are target of an ongoing window screencast.
@@ -579,7 +579,7 @@ window-rule {
 
 #### `default-column-display`
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 Set the default display mode for columns created from this window.
 
@@ -630,7 +630,7 @@ window-rule {
 
 #### `scroll-factor`
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 Set a scroll factor for all scroll events sent to a window.
 
@@ -693,7 +693,7 @@ window-rule {
 
 #### `shadow`
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 Override the shadow options for the window.
 
@@ -715,7 +715,7 @@ window-rule {
 
 #### `tab-indicator`
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 Override the tab indicator options for the window.
 

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -609,10 +609,11 @@ Afterward, the window will remember its last floating position.
 By default, new floating windows open at the center of the screen, and windows from the tiling layout open close to their visual screen position.
 
 The position uses logical coordinates relative to the working area.
-By default, they are relative to the top-left corner of the working area, but you can change this by setting `relative-to` to one of these values: `top-left`, `top-right`, `bottom-left`, `bottom-right`.
+By default, they are relative to the top-left corner of the working area, but you can change this by setting `relative-to` to one of these values: `top-left`, `top-right`, `bottom-left`, `bottom-right`, `top`, `bottom`, `left`, or `right`.
 
 For example, if you have a bar at the top, then `x=0 y=0` will put the top-left corner of the window directly below the bar.
 If instead you write `x=0 y=0 relative-to="top-right"`, then the top-right corner of the window will align with the top-right corner of the workspace, also directly below the bar.
+When only one side is specified (e.g. top) the window will align to the center of that side.
 
 The coordinates change direction based on `relative-to`.
 For example, by default (top-left), `x=100 y=200` will put the window 100 pixels to the right and 200 pixels down from the top-left corner.
@@ -625,6 +626,27 @@ window-rule {
     match app-id="firefox$" title="^Picture-in-Picture$"
 
     default-floating-position x=32 y=32 relative-to="bottom-left"
+}
+```
+
+You can use single-side `relative-to` to get a dropdown-like effect.
+
+```kdl
+// Example: a "dropdown" terminal.
+window-rule {
+    // Match by "dropdown" app ID.
+    // You need to set this app ID when running your terminal, e.g.:
+    // spawn "alacritty" "--class" "dropdown"
+    match app-id="^dropdown$"
+
+    // Open it as floating.
+    open-floating true
+    // Anchor to the top edge of the screen.
+    default-floating-position x=0 y=0 relative-to="top"
+    // Half of the screen high.
+    default-window-height { proportion 0.5; }
+    // 80% of the screen wide.
+    default-column-width { proportion 0.8; }
 }
 ```
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -17,13 +17,6 @@ This is because windows using client-side decorations can have an arbitrary shap
 
 You can also override this behavior with the `draw-border-with-background` [window rule](./Configuration:-Window-Rules.md).
 
-### Why is the Waybar pop-up menu showing behind windows?
-
-Set `"layer": "top"` in your Waybar config.
-
-Niri currently draws pop-up menus on the same layer as their parent surface.
-By default, Waybar is on the `bottom` layer, which is behind windows, so Waybar pop-up menus also show behind windows.
-
 ### How to enable rounded corners for all windows?
 
 Put this window rule in your config:

--- a/wiki/Gestures.md
+++ b/wiki/Gestures.md
@@ -64,7 +64,7 @@ Move the view horizontally with three-finger horizontal swipes.
 
 #### Drag-and-Drop Edge View Scroll
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 Scroll the tiling view when moving the mouse cursor against a monitor edge during drag-and-drop (DnD).
 Also works on a touchscreen.

--- a/wiki/Tabs.md
+++ b/wiki/Tabs.md
@@ -1,6 +1,6 @@
 ### Overview
 
-<sup>Since: next release</sup>
+<sup>Since: 25.02</sup>
 
 You can switch a column to present windows as tabs, rather than as vertical tiles.
 All tabs in a column have the same window size, so this is useful to get more vertical space.


### PR DESCRIPTION
I noticed that there was no option to bind moving between monitor. I am often switching between three monitors and being able to access those directly would neatly fit my existing muscle memory. :)

This patch implements:

 * focus-monitor
 * move-window-to-monitor
 * move-column-to-monitor

Thank you so much for building niri!