### PR TITLE
WIP: Implement `hyprland-global-shortcuts-v1`

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1623,6 +1623,7 @@ pub enum Action {
     ToggleWindowRuleOpacity,
     #[knuffel(skip)]
     ToggleWindowRuleOpacityById(u64),
+    TriggerGlobalShortcut(#[knuffel(argument)] String, #[knuffel(argument)] String),
 }
 
 impl From<niri_ipc::Action> for Action {
@@ -1854,6 +1855,9 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::ToggleWindowRuleOpacity { id: None } => Self::ToggleWindowRuleOpacity,
             niri_ipc::Action::ToggleWindowRuleOpacity { id: Some(id) } => {
                 Self::ToggleWindowRuleOpacityById(id)
+            }
+            niri_ipc::Action::TriggerGlobalShortcut { app_id, id } => {
+                Self::TriggerGlobalShortcut(app_id, id)
             }
         }
     }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -59,6 +59,8 @@ pub enum Request {
     Layers,
     /// Request information about the configured keyboard layouts.
     KeyboardLayouts,
+    /// Request information about global shortcuts.
+    GlobalShortcuts,
     /// Request information about the focused output.
     FocusedOutput,
     /// Request information about the focused window.
@@ -125,6 +127,8 @@ pub enum Response {
     Layers(Vec<LayerSurface>),
     /// Information about the keyboard layout.
     KeyboardLayouts(KeyboardLayouts),
+    /// Information about global shortcuts.
+    GlobalShortcuts(Vec<GlobalShortcut>),
     /// Information about the focused output.
     FocusedOutput(Option<Output>),
     /// Information about the focused window.
@@ -648,6 +652,15 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(long))]
         id: Option<u64>,
     },
+    /// Trigger (press and release) a global shortcut.
+    TriggerGlobalShortcut {
+        /// Application id of the global shortcut.
+        #[cfg_attr(feature = "clap", arg())]
+        app_id: String,
+        /// Id of the global shortcut.
+        #[cfg_attr(feature = "clap", arg())]
+        id: String,
+    },
 }
 
 /// Change in window or column size.
@@ -1057,6 +1070,19 @@ pub struct LayerSurface {
     pub keyboard_interactivity: LayerSurfaceKeyboardInteractivity,
 }
 
+/// A registered global shortcut.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GlobalShortcut {
+    /// A unique id for the shortcut.
+    pub id: String,
+    /// The app_id of the application requesting the shortcut.
+    pub app_id: String,
+    /// User-readable text describing what the shortcut does.
+    pub description: String,
+    /// User-readable text describing how to trigger the shortcut for the client to render.
+    pub trigger_description: String,
+}
+
 /// A compositor event.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
@@ -1125,6 +1151,22 @@ pub enum Event {
     KeyboardLayoutSwitched {
         /// Index of the newly active layout.
         idx: u8,
+    },
+    // FIXME: Which one is better?
+    // /// A global shortcut was registered.
+    // GlobalShortcutRegistered {
+    //     /// Id of the newly registered global shortcut.
+    //     id: String,
+    // },
+    // /// A global shortcut was destroyed.
+    // GlobalShortcutDestroyed {
+    //     /// Id of the destroyed global shortcut.
+    //     id: String,
+    // },
+    /// The registered global shortcuts have changed.
+    GlobalShortcutsChanged {
+        /// The new list of registered global shortcuts.
+        global_shortcuts: Vec<GlobalShortcut>,
     },
 }
 

--- a/resources/hyprland-global-shortcuts-v1.xml
+++ b/resources/hyprland-global-shortcuts-v1.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="hyprland_global_shortcuts_v1">
+  <copyright>
+    Copyright © 2022 Vaxry
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  </copyright>
+
+  <description summary="registering global shortcuts">
+    This protocol allows a client to register triggerable actions,
+    meant to be global shortcuts.
+  </description>
+
+  <interface name="hyprland_global_shortcuts_manager_v1" version="1">
+    <description summary="manager to register global shortcuts">
+      This object is a manager which offers requests to create global shortcuts.
+    </description>
+
+    <request name="register_shortcut">
+      <description summary="register a shortcut">
+        Register a new global shortcut.
+
+        A global shortcut is anonymous, meaning the app does not know what key(s) trigger it.
+
+        The shortcut's keybinding shall be dealt with by the compositor.
+
+        In the case of a duplicate app_id + id combination, the already_taken protocol error is raised.
+      </description>
+      <arg name="shortcut" type="new_id" interface="hyprland_global_shortcut_v1"/>
+      <arg name="id" type="string" summary="a unique id for the shortcut"/>
+      <arg name="app_id" type="string" summary="the app_id of the application requesting the shortcut"/>
+      <arg name="description" type="string" summary="user-readable text describing what the shortcut does."/>
+      <arg name="trigger_description" type="string" summary="user-readable text describing how to trigger the shortcut for the client to render."/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="already_taken" value="0"
+        summary="the app_id + id combination has already been registered."/>
+    </enum>
+  </interface>
+
+  <interface name="hyprland_global_shortcut_v1" version="1">
+    <description summary="a shortcut">
+      This object represents a single shortcut.
+    </description>
+
+    <event name="pressed">
+      <description summary="keystroke pressed">
+        The keystroke was pressed.
+
+        tv_ values hold the timestamp of the occurrence.
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+
+    <event name="released">
+      <description summary="keystroke released">
+        The keystroke was released.
+
+        tv_ values hold the timestamp of the occurrence.
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object, used or not">
+        Destroys the shortcut. Can be sent at any time by the client.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,6 +68,8 @@ pub enum Msg {
     Layers,
     /// Get the configured keyboard layouts.
     KeyboardLayouts,
+    /// List registered global shortcuts.
+    GlobalShortcuts,
     /// Print information about the focused output.
     FocusedOutput,
     /// Print information about the focused window.

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -81,6 +81,9 @@ use crate::protocols::foreign_toplevel::{
     self, ForeignToplevelHandler, ForeignToplevelManagerState,
 };
 use crate::protocols::gamma_control::{GammaControlHandler, GammaControlManagerState};
+use crate::protocols::hyprland_global_shortcuts::{
+    HyprlandGlobalShortcut, HyprlandGlobalShortcutsHandler, HyprlandGlobalShortcutsManagerState,
+};
 use crate::protocols::mutter_x11_interop::MutterX11InteropHandler;
 use crate::protocols::output_management::{OutputManagementHandler, OutputManagementManagerState};
 use crate::protocols::screencopy::{Screencopy, ScreencopyHandler, ScreencopyManagerState};
@@ -91,8 +94,9 @@ use crate::protocols::virtual_pointer::{
 };
 use crate::utils::{output_size, send_scale_transform, with_toplevel_role};
 use crate::{
-    delegate_foreign_toplevel, delegate_gamma_control, delegate_mutter_x11_interop,
-    delegate_output_management, delegate_screencopy, delegate_virtual_pointer,
+    delegate_foreign_toplevel, delegate_gamma_control, delegate_hyprland_global_shortcuts,
+    delegate_mutter_x11_interop, delegate_output_management, delegate_screencopy,
+    delegate_virtual_pointer,
 };
 
 pub const XDG_ACTIVATION_TOKEN_TIMEOUT: Duration = Duration::from_secs(10);
@@ -763,5 +767,20 @@ delegate_output_management!(State);
 
 impl MutterX11InteropHandler for State {}
 delegate_mutter_x11_interop!(State);
+
+impl HyprlandGlobalShortcutsHandler for State {
+    fn hyprland_global_shortcuts_state(&mut self) -> &mut HyprlandGlobalShortcutsManagerState {
+        &mut self.niri.hyprland_global_shortcuts_state
+    }
+
+    fn shortcut_registered(&mut self, _shortcut: &HyprlandGlobalShortcut) {
+        self.ipc_global_shortcuts_changed();
+    }
+
+    fn shortcut_destroyed(&mut self, _shortcut: &HyprlandGlobalShortcut) {
+        self.ipc_global_shortcuts_changed();
+    }
+}
+delegate_hyprland_global_shortcuts!(State);
 
 delegate_single_pixel_buffer!(State);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1704,6 +1704,17 @@ impl State {
                     }
                 }
             }
+            Action::TriggerGlobalShortcut(app_id, id) => {
+                if let Some(shortcut) = self
+                    .niri
+                    .hyprland_global_shortcuts_state
+                    .shortcut(app_id, id)
+                {
+                    let timestamp = get_monotonic_time();
+                    shortcut.press(timestamp);
+                    shortcut.release(timestamp);
+                }
+            }
         }
     }
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::iter::Peekable;
 use std::slice;
 
@@ -5,8 +6,8 @@ use anyhow::{anyhow, bail, Context};
 use niri_config::OutputName;
 use niri_ipc::socket::Socket;
 use niri_ipc::{
-    Event, KeyboardLayouts, LogicalOutput, Mode, Output, OutputConfigChanged, Request, Response,
-    Transform, Window,
+    Event, GlobalShortcut, KeyboardLayouts, LogicalOutput, Mode, Output, OutputConfigChanged,
+    Request, Response, Transform, Window,
 };
 use serde_json::json;
 
@@ -28,6 +29,7 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
         Msg::Windows => Request::Windows,
         Msg::Layers => Request::Layers,
         Msg::KeyboardLayouts => Request::KeyboardLayouts,
+        Msg::GlobalShortcuts => Request::GlobalShortcuts,
         Msg::EventStream => Request::EventStream,
         Msg::RequestError => Request::ReturnError,
     };
@@ -343,6 +345,45 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                 println!("{is_active}{idx} {name}");
             }
         }
+        Msg::GlobalShortcuts => {
+            let Response::GlobalShortcuts(shortcuts) = response else {
+                bail!("unexpected response: expected GlobalShortcuts, got {response:?}");
+            };
+
+            if json {
+                let response =
+                    serde_json::to_string(&shortcuts).context("error formatting response")?;
+                println!("{response}");
+                return Ok(());
+            }
+
+            if shortcuts.is_empty() {
+                println!("No global shortcuts.");
+                return Ok(());
+            }
+
+            for (app_id, shortcuts) in shortcuts.iter().fold(HashMap::new(), |mut map, shortcut| {
+                map.entry(shortcut.app_id.clone())
+                    .or_default()
+                    .push(shortcut);
+                map
+            }) {
+                println!("App ID \"{app_id}\":");
+
+                for GlobalShortcut {
+                    id,
+                    app_id: _,
+                    description,
+                    trigger_description,
+                } in shortcuts
+                {
+                    println!("  Global shortcut \"{id}\":");
+                    println!("    Description: {description}");
+                    println!("    Trigger Description: {trigger_description}");
+                    println!();
+                }
+            }
+        }
         Msg::EventStream => {
             let Response::Handled = response else {
                 bail!("unexpected response: expected Handled, got {response:?}");
@@ -395,6 +436,9 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                     }
                     Event::KeyboardLayoutSwitched { idx } => {
                         println!("Keyboard layout switched: {idx}");
+                    }
+                    Event::GlobalShortcutsChanged { global_shortcuts } => {
+                        println!("Global shortcuts changed: {global_shortcuts:?}");
                     }
                 }
             }

--- a/src/protocols/hyprland_global_shortcuts.rs
+++ b/src/protocols/hyprland_global_shortcuts.rs
@@ -1,0 +1,229 @@
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::time::Duration;
+
+use hyprland_global_shortcut_v1::HyprlandGlobalShortcutV1;
+use hyprland_global_shortcuts_manager_v1::HyprlandGlobalShortcutsManagerV1;
+use smithay::reexports::wayland_server::{
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+};
+
+use super::raw::hyprland_global_shortcuts::v1::server::{
+    hyprland_global_shortcut_v1, hyprland_global_shortcuts_manager_v1,
+};
+
+const VERSION: u32 = 1;
+
+pub struct HyprlandGlobalShortcutsManagerState {
+    // Keys are app_id + id pairs
+    shortcuts: HashMap<(String, String), HyprlandGlobalShortcut>,
+}
+
+pub struct HyprlandGlobalShortcutsManagerGlobalData {
+    filter: Box<dyn for<'c> Fn(&'c Client) -> bool + Send + Sync>,
+}
+
+pub trait HyprlandGlobalShortcutsHandler {
+    fn hyprland_global_shortcuts_state(&mut self) -> &mut HyprlandGlobalShortcutsManagerState;
+    fn shortcut_registered(&mut self, shortcut: &HyprlandGlobalShortcut);
+    fn shortcut_destroyed(&mut self, shortcut: &HyprlandGlobalShortcut);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HyprlandGlobalShortcut {
+    shortcut: HyprlandGlobalShortcutV1,
+    pub id: String,
+    pub app_id: String,
+    pub description: String,
+    pub trigger_description: String,
+}
+
+#[derive(Debug)]
+pub struct HyprlandGlobalShortcutUserData {
+    id: String,
+    app_id: String,
+}
+
+impl HyprlandGlobalShortcut {
+    pub fn press(&self, timestamp: Duration) {
+        let tv_sec_hi = (timestamp.as_secs() >> 32) as u32;
+        let tv_sec_lo = (timestamp.as_secs() & 0xFFFFFFFF) as u32;
+        let tv_nsec = timestamp.subsec_nanos();
+        self.shortcut.pressed(tv_sec_hi, tv_sec_lo, tv_nsec);
+    }
+    pub fn release(&self, timestamp: Duration) {
+        let tv_sec_hi = (timestamp.as_secs() >> 32) as u32;
+        let tv_sec_lo = (timestamp.as_secs() & 0xFFFFFFFF) as u32;
+        let tv_nsec = timestamp.subsec_nanos();
+        self.shortcut.pressed(tv_sec_hi, tv_sec_lo, tv_nsec);
+    }
+}
+
+impl HyprlandGlobalShortcutsManagerState {
+    pub fn new<D, F>(display: &DisplayHandle, filter: F) -> Self
+    where
+        D: GlobalDispatch<
+            HyprlandGlobalShortcutsManagerV1,
+            HyprlandGlobalShortcutsManagerGlobalData,
+        >,
+        D: Dispatch<HyprlandGlobalShortcutsManagerV1, ()>,
+        D: HyprlandGlobalShortcutsHandler,
+        D: 'static,
+        F: for<'c> Fn(&'c Client) -> bool + Send + Sync + 'static,
+    {
+        let global_data = HyprlandGlobalShortcutsManagerGlobalData {
+            filter: Box::new(filter),
+        };
+        display.create_global::<D, HyprlandGlobalShortcutsManagerV1, _>(VERSION, global_data);
+
+        Self {
+            shortcuts: HashMap::new(),
+        }
+    }
+
+    pub fn shortcut(&self, app_id: String, id: String) -> Option<HyprlandGlobalShortcut> {
+        self.shortcuts.get(&(app_id, id)).cloned()
+    }
+
+    pub fn shortcuts(&self) -> impl Iterator<Item = &HyprlandGlobalShortcut> {
+        self.shortcuts.values()
+    }
+}
+
+impl<D>
+    GlobalDispatch<HyprlandGlobalShortcutsManagerV1, HyprlandGlobalShortcutsManagerGlobalData, D>
+    for HyprlandGlobalShortcutsManagerState
+where
+    D: GlobalDispatch<HyprlandGlobalShortcutsManagerV1, HyprlandGlobalShortcutsManagerGlobalData>,
+    D: Dispatch<HyprlandGlobalShortcutsManagerV1, ()>,
+    D: HyprlandGlobalShortcutsHandler,
+    D: 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        manager: New<HyprlandGlobalShortcutsManagerV1>,
+        _manager_state: &HyprlandGlobalShortcutsManagerGlobalData,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(manager, ());
+    }
+
+    fn can_view(client: Client, global_data: &HyprlandGlobalShortcutsManagerGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+impl<D> Dispatch<HyprlandGlobalShortcutsManagerV1, (), D> for HyprlandGlobalShortcutsManagerState
+where
+    D: Dispatch<HyprlandGlobalShortcutsManagerV1, ()>,
+    D: Dispatch<HyprlandGlobalShortcutV1, HyprlandGlobalShortcutUserData>,
+    D: HyprlandGlobalShortcutsHandler,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        resource: &HyprlandGlobalShortcutsManagerV1,
+        request: <HyprlandGlobalShortcutsManagerV1 as Resource>::Request,
+        _data: &(),
+        _dhandle: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            hyprland_global_shortcuts_manager_v1::Request::RegisterShortcut {
+                shortcut,
+                id,
+                app_id,
+                description,
+                trigger_description,
+            } => {
+                let shortcut = HyprlandGlobalShortcut {
+                    shortcut: data_init.init(
+                        shortcut,
+                        HyprlandGlobalShortcutUserData {
+                            app_id: app_id.clone(),
+                            id: id.clone(),
+                        },
+                    ),
+                    id: id.clone(),
+                    app_id: app_id.clone(),
+                    description,
+                    trigger_description,
+                };
+                let shortcuts_state = state.hyprland_global_shortcuts_state();
+                match shortcuts_state.shortcuts.entry((app_id, id)) {
+                    Entry::Occupied(_) => {
+                        resource.post_error(
+                            hyprland_global_shortcuts_manager_v1::Error::AlreadyTaken,
+                            "app_id and id combination already taken",
+                        );
+                        return;
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(shortcut.clone());
+                    }
+                }
+                state.shortcut_registered(&shortcut);
+            }
+            hyprland_global_shortcuts_manager_v1::Request::Destroy => (),
+        }
+    }
+}
+
+impl<D> Dispatch<HyprlandGlobalShortcutV1, HyprlandGlobalShortcutUserData, D>
+    for HyprlandGlobalShortcutsManagerState
+where
+    D: Dispatch<HyprlandGlobalShortcutV1, HyprlandGlobalShortcutUserData>,
+    D: HyprlandGlobalShortcutsHandler,
+    D: 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &Client,
+        _resource: &HyprlandGlobalShortcutV1,
+        request: <HyprlandGlobalShortcutV1 as Resource>::Request,
+        _data: &HyprlandGlobalShortcutUserData,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        match request {
+            hyprland_global_shortcut_v1::Request::Destroy => (),
+        }
+    }
+
+    fn destroyed(
+        state: &mut D,
+        _client: wayland_backend::server::ClientId,
+        _resource: &HyprlandGlobalShortcutV1,
+        data: &HyprlandGlobalShortcutUserData,
+    ) {
+        let shortcuts_state = state.hyprland_global_shortcuts_state();
+        if let Some(shortcut) = shortcuts_state
+            .shortcuts
+            .remove(&(data.app_id.clone(), data.id.clone()))
+        {
+            state.shortcut_destroyed(&shortcut);
+        } else {
+            warn!("destroyed global shortcut object with missing global shortcut");
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_hyprland_global_shortcuts {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        smithay::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::protocols::raw::hyprland_global_shortcuts::v1::server::hyprland_global_shortcuts_manager_v1::HyprlandGlobalShortcutsManagerV1: $crate::protocols::hyprland_global_shortcuts::HyprlandGlobalShortcutsManagerGlobalData
+        ] => $crate::protocols::hyprland_global_shortcuts::HyprlandGlobalShortcutsManagerState);
+
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::protocols::raw::hyprland_global_shortcuts::v1::server::hyprland_global_shortcuts_manager_v1::HyprlandGlobalShortcutsManagerV1: ()
+        ] => $crate::protocols::hyprland_global_shortcuts::HyprlandGlobalShortcutsManagerState);
+
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::protocols::raw::hyprland_global_shortcuts::v1::server::hyprland_global_shortcut_v1::HyprlandGlobalShortcutV1:  $crate::protocols::hyprland_global_shortcuts::HyprlandGlobalShortcutUserData
+        ] => $crate::protocols::hyprland_global_shortcuts::HyprlandGlobalShortcutsManagerState);
+    };
+}

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -1,5 +1,6 @@
 pub mod foreign_toplevel;
 pub mod gamma_control;
+pub mod hyprland_global_shortcuts;
 pub mod mutter_x11_interop;
 pub mod output_management;
 pub mod screencopy;

--- a/src/protocols/raw.rs
+++ b/src/protocols/raw.rs
@@ -1,3 +1,33 @@
+pub mod hyprland_global_shortcuts {
+    pub mod v1 {
+        pub use self::generated::server;
+
+        mod generated {
+            pub mod server {
+                #![allow(dead_code, non_camel_case_types, unused_unsafe, unused_variables)]
+                #![allow(non_upper_case_globals, non_snake_case, unused_imports)]
+                #![allow(missing_docs, clippy::all)]
+
+                use smithay::reexports::wayland_server;
+                use wayland_server::protocol::*;
+
+                pub mod __interfaces {
+                    use smithay::reexports::wayland_server;
+                    use wayland_server::protocol::__interfaces::*;
+                    wayland_scanner::generate_interfaces!(
+                        "resources/hyprland-global-shortcuts-v1.xml"
+                    );
+                }
+                use self::__interfaces::*;
+
+                wayland_scanner::generate_server_code!(
+                    "resources/hyprland-global-shortcuts-v1.xml"
+                );
+            }
+        }
+    }
+}
+
 pub mod mutter_x11_interop {
     pub mod v1 {
         pub use self::generated::server;


### PR DESCRIPTION
I made a simple client for testing: https://github.com/bbb651/global-shortcuts-test (and tested that it works correctly in hyprland)

I haven't tested it yet but it should work with the `GlobalShortcuts` portals with `~/.config/xdg-desktop-portal/portals.conf`:
```ini
[preferred]
default=gnome
org.freedesktop.impl.portal.GlobalShortcuts=hyprland
```

Unresolved questions:
- What happens with there are other implementations of the `GlobalShortcuts` portal? Wlroots stopped adding protocols, ext seems likely to happen at some point, I think they'll be pretty similar (they'll both be following the portal pretty closely) so don't think it'll be hard to support both of them (and maybe remove the hyprland one at some point if clients aren't using it?). Gnome seems more problematic assuming it'll be DBus based, I think there's still value in having supporting a wayland protocol even if we support the Gnome one for layer-shell use cases so I don't think this should be a blocker.
- How does it interact with binds? I'm currently made a `Action::TriggerGlobalShortcut` action that immediately presses and releases the shortcut, but this doesn't match the capabilities of the protocol (and the `GlobalShortcuts` portal). Once we have release binds we could have separate `Action::PressGlobalShortcut` & `Action::ReleaseGlobalShortcut` actions, which is the most flexible but is a bit verbose. I like the idea of "hold actions" that are continuous instead of discrete and are bound to both an entire bind press and release, this works for other continuous actions like resizing and translating the view, but I'm not sure about a design that plays nice with both multiple actions per bind and release binds.
- Representing the shortcuts as `HashMap<(String, String), HyprlandGlobalShortcut>` is a bit awkward in some places, the key reference becomes `&(String, String)` and in `niri msg global-shortcuts` I think it makes more sense to print them by app id. Hyprland seems to join them with `:` and store and accepts them like that, this doesn't work correctly for app ids containing `:` but they are technically invalid. Either way I still prefer separate arguments in the config and cli.   

Also currently ipc doesn't quite work (and I've just realized I've broken handling of duplicate shortcuts by creating the `HyprlandGlobalShortcutV1` object even when it errors later to try to workaround lifetimes..), the protocol implementation is a bit messy and clone strings a lot and [CI fails](https://github.com/bbb651/niri/actions/runs/13488048470/job/37681792570) (something is really wrong with my rust/cargo today, rust-analyzer repeatedly failed to run, it seemed to constantly be doing full rebuilds and it apparently didn't recompile ipc client...).