### PR TITLE
Floating windows default proportional position

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1336,14 +1336,16 @@ pub struct TabIndicatorRule {
     pub inactive_gradient: Option<Gradient>,
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
 pub struct FloatingPosition {
-    #[knuffel(property)]
-    pub x: FloatOrInt<-65535, 65535>,
-    #[knuffel(property)]
-    pub y: FloatOrInt<-65535, 65535>,
-    #[knuffel(property, default)]
-    pub relative_to: RelativeTo,
+    #[knuffel(child, unwrap(argument))]
+    pub x: Option<FloatOrInt<-65000, 65000>>,
+    #[knuffel(child, unwrap(argument))]
+    pub y: Option<FloatOrInt<-65000, 65000>>,
+    #[knuffel(child, unwrap(argument))]
+    pub relative_to: Option<RelativeTo>,
+    #[knuffel(child, unwrap(argument))]
+    pub mode: Option<PositionMode>,
 }
 
 #[derive(knuffel::DecodeScalar, Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -1353,6 +1355,13 @@ pub enum RelativeTo {
     TopRight,
     BottomLeft,
     BottomRight,
+}
+
+#[derive(knuffel::DecodeScalar, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum PositionMode {
+    #[default]
+    Fixed,
+    Proportional,
 }
 
 #[derive(Debug, Default, PartialEq)]
@@ -3727,7 +3736,12 @@ mod tests {
                 open-focused true
                 default-window-height { fixed 500; }
                 default-column-display "tabbed"
-                default-floating-position x=100 y=-200 relative-to="bottom-left"
+                default-floating-position {
+                  x 100
+                  y -200
+                  relative-to "bottom-left"
+                  mode "proportional"
+                }
 
                 focus-ring {
                     off
@@ -3742,6 +3756,7 @@ mod tests {
                 tab-indicator {
                     active-color "#f00"
                 }
+
             }
 
             layer-rule {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1360,8 +1360,8 @@ pub enum RelativeTo {
 #[derive(knuffel::DecodeScalar, Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum PositionMode {
     #[default]
-    Fixed,
-    Proportional,
+    Absolute,
+    Relative,
 }
 
 #[derive(Debug, Default, PartialEq)]
@@ -3740,7 +3740,7 @@ mod tests {
                   x 100
                   y -200
                   relative-to "bottom-left"
-                  mode "proportional"
+                  mode "absolute"
                 }
 
                 focus-ring {

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -332,7 +332,7 @@ window-rule {
     // 
     default-floating-position {
         relative-to "top-left"
-        mode "proportional"    // proportional position in order to match multi display setup
+        mode "relative"    // proportional position in order to match multi display setup
         x 0.1 // 10% left of the screen
         y 0  
     }

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -316,6 +316,28 @@ window-rule {
     clip-to-geometry true
 }
 
+// Example: a floating drop down terminal with proportional size and position
+// (This example rule is commented out with a "/-" in front.)
+/-window-rule {
+    match app-id="dropdown"
+    // open focused and floating
+    open-focused true
+    open-floating true
+    // no corner radius
+    geometry-corner-radius 0
+    // half screen height
+    default-window-height { proportion 0.500; }
+    // 80% screen width
+    default-column-width { proportion 0.8; }
+    // 
+    default-floating-position {
+        relative-to "top-left"
+        mode "proportional"    // proportional position in order to match multi display setup
+        x 0.1 // 10% left of the screen
+        y 0  
+    }
+}
+
 binds {
     // Keys consist of modifiers separated by + signs, followed by an XKB key name
     // in the end. To find an XKB name for a particular key, you may use a program

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1203,7 +1203,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
             tile.window().rules().default_floating_position.map(|pos| {
                 let mode = match pos.mode {
                     Some(p) => p,
-                    None => PositionMode::Fixed,
+                    None => PositionMode::Absolute,
                 };
                 let relative_to = match pos.relative_to {
                     Some(p) => p,
@@ -1223,8 +1223,8 @@ impl<W: LayoutElement> FloatingSpace<W> {
 
                 let transform = |p: f64, dim: f64, mode| -> f64 {
                     match mode {
-                        PositionMode::Fixed => p,
-                        PositionMode::Proportional => p * dim,
+                        PositionMode::Absolute => p,
+                        PositionMode::Relative => p * dim,
                     }
                 };
 

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -54,7 +54,12 @@ window-rule {
     // block-out-from "screen-capture"
     variable-refresh-rate true
     default-column-display "tabbed"
-    default-floating-position x=100 y=200 relative-to="bottom-left"
+    default-floating-position {
+        mode "fixed" // fixed: size in px; proportional: relative size to the work area
+        relative-to "bottom-left"
+        x 100
+        y 200
+    }
     scroll-factor 0.75
 
     focus-ring {
@@ -609,14 +614,19 @@ Afterward, the window will remember its last floating position.
 By default, new floating windows open at the center of the screen, and windows from the tiling layout open close to their visual screen position.
 
 The position uses logical coordinates relative to the working area.
+The coordinates can be absolutes (default) or relatives to the size of the working area, by setting `mode` to one of these values: `absolute`, `relative`
 By default, they are relative to the top-left corner of the working area, but you can change this by setting `relative-to` to one of these values: `top-left`, `top-right`, `bottom-left`, `bottom-right`.
 
-For example, if you have a bar at the top, then `x=0 y=0` will put the top-left corner of the window directly below the bar.
-If instead you write `x=0 y=0 relative-to="top-right"`, then the top-right corner of the window will align with the top-right corner of the workspace, also directly below the bar.
+For example, if you have a bar at the top, then `{ x 0; y 0; }` will put the top-left corner of the window directly below the bar.
+If instead you write `{ x 0; y 0; relative-to "top-right"; }`, then the top-right corner of the window will align with the top-right corner of the workspace, also directly below the bar.
 
 The coordinates change direction based on `relative-to`.
-For example, by default (top-left), `x=100 y=200` will put the window 100 pixels to the right and 200 pixels down from the top-left corner.
-If you use `x=100 y=200 relative-to="bottom-left"`, it will put the window 100 pixels to the right and 200 pixels *up* from the bottom-left corner.
+For example, by default (top-left), `{ x 100; y 200; }` will put the window 100 pixels to the right and 200 pixels down from the top-left corner.
+If you use `{ x 100; y 200; relative-to "bottom-left"; }`, it will put the window 100 pixels to the right and 200 pixels *up* from the bottom-left corner.
+
+If you want to use proportinal coordinates you can do it by setting `mode "relative"`.
+For example `{ x 0.1; y 0.05; mode "relative"; }` will put the windows 10% of the working area width to the right and 5% of the working area height down from the top-left corner.
+This is particularly useful if combined with proportional window size. 
 
 ```kdl
 // Open the Firefox picture-in-picture window at the bottom-left corner of the screen
@@ -624,7 +634,7 @@ If you use `x=100 y=200 relative-to="bottom-left"`, it will put the window 100 p
 window-rule {
     match app-id="firefox$" title="^Picture-in-Picture$"
 
-    default-floating-position x=32 y=32 relative-to="bottom-left"
+    default-floating-position { mode "absolute"; x 32; y 32; relative-to "bottom-left"; }
 }
 ```
 


### PR DESCRIPTION
Hi, 
I added the possibility to have the default position of floating windows expressed as a proportion of the working space size.
This will allow to better match the windows that have size proportional to the working area in particular in setup with multiple outputs.

https://github.com/user-attachments/assets/0759a6e0-67a4-43c3-b119-d0bc925ef148

Thank you very much for this amazing project!

Cheers!