### PR TITLE
Added top, left, bottom and right floating windows alignement

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1353,6 +1353,10 @@ pub enum RelativeTo {
     TopRight,
     BottomLeft,
     BottomRight,
+    Top,
+    Bottom,
+    Left,
+    Right,
 }
 
 #[derive(Debug, Default, PartialEq)]

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -315,10 +315,22 @@ window-rule {
     geometry-corner-radius 12
     clip-to-geometry true
 }
+// Example: drop down terminal from the bottom of the screen
+// (This example rule is commented out with a "/-" in front.)
+/-window-rule {
+    match app-id="dropdown"
+    open-focused true
+    open-floating true
+    default-floating-position x=0 y=0 relative-to="bottom"
+    default-window-height { proportion 0.500; }
+    default-column-width { proportion 0.8; }  
+}
+
 
 binds {
     // Keys consist of modifiers separated by + signs, followed by an XKB key name
     // in the end. To find an XKB name for a particular key, you may use a program
+// (This example rule is commented out with a "/-" in front.)
     // like wev.
     //
     // "Mod" is a special modifier equal to Super when running on a TTY, and to Alt

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -315,17 +315,6 @@ window-rule {
     geometry-corner-radius 12
     clip-to-geometry true
 }
-// Example: drop down terminal from the bottom of the screen
-// (This example rule is commented out with a "/-" in front.)
-/-window-rule {
-    match app-id="dropdown"
-    open-focused true
-    open-floating true
-    default-floating-position x=0 y=0 relative-to="bottom"
-    default-window-height { proportion 0.500; }
-    default-column-width { proportion 0.8; }  
-}
-
 
 binds {
     // Keys consist of modifiers separated by + signs, followed by an XKB key name

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -319,7 +319,6 @@ window-rule {
 binds {
     // Keys consist of modifiers separated by + signs, followed by an XKB key name
     // in the end. To find an XKB name for a particular key, you may use a program
-// (This example rule is commented out with a "/-" in front.)
     // like wev.
     //
     // "Mod" is a special modifier equal to Super when running on a TTY, and to Alt

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1219,10 +1219,10 @@ impl<W: LayoutElement> FloatingSpace<W> {
                     pos.y = area.size.h - size.h - pos.y;
                 }
                 if relative_to == RelativeTo::Top || relative_to == RelativeTo::Bottom {
-                    pos.x = area.size.w / 2.0 - size.w / 2.0 - pos.x
+                    pos.x = area.size.w / 2.0 - size.w / 2.0 + pos.x
                 }
                 if relative_to == RelativeTo::Left || relative_to == RelativeTo::Right {
-                    pos.y = area.size.h / 2.0 - size.h / 2.0 - pos.y
+                    pos.y = area.size.h / 2.0 - size.h / 2.0 + pos.y
                 }
 
                 pos + self.working_area.loc

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1206,11 +1206,23 @@ impl<W: LayoutElement> FloatingSpace<W> {
                 let area = self.working_area;
 
                 let mut pos = Point::from((pos.x.0, pos.y.0));
-                if relative_to == RelativeTo::TopRight || relative_to == RelativeTo::BottomRight {
+                if relative_to == RelativeTo::TopRight
+                    || relative_to == RelativeTo::BottomRight
+                    || relative_to == RelativeTo::Right
+                {
                     pos.x = area.size.w - size.w - pos.x;
                 }
-                if relative_to == RelativeTo::BottomLeft || relative_to == RelativeTo::BottomRight {
+                if relative_to == RelativeTo::BottomLeft
+                    || relative_to == RelativeTo::BottomRight
+                    || relative_to == RelativeTo::Bottom
+                {
                     pos.y = area.size.h - size.h - pos.y;
+                }
+                if relative_to == RelativeTo::Top || relative_to == RelativeTo::Bottom {
+                    pos.x = area.size.w / 2.0 - size.w / 2.0 - pos.x
+                }
+                if relative_to == RelativeTo::Left || relative_to == RelativeTo::Right {
+                    pos.y = area.size.h / 2.0 - size.h / 2.0 - pos.y
                 }
 
                 pos + self.working_area.loc

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1219,10 +1219,10 @@ impl<W: LayoutElement> FloatingSpace<W> {
                     pos.y = area.size.h - size.h - pos.y;
                 }
                 if relative_to == RelativeTo::Top || relative_to == RelativeTo::Bottom {
-                    pos.x = area.size.w / 2.0 - size.w / 2.0 + pos.x
+                    pos.x += area.size.w / 2.0 - size.w / 2.0
                 }
                 if relative_to == RelativeTo::Left || relative_to == RelativeTo::Right {
-                    pos.y = area.size.h / 2.0 - size.h / 2.0 + pos.y
+                    pos.y += area.size.h / 2.0 - size.h / 2.0
                 }
 
                 pos + self.working_area.loc

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -609,11 +609,11 @@ Afterward, the window will remember its last floating position.
 By default, new floating windows open at the center of the screen, and windows from the tiling layout open close to their visual screen position.
 
 The position uses logical coordinates relative to the working area.
-By default, they are relative to the top-left corner of the working area, but you can change this by setting `relative-to` to one of these values: `top-left`, `top-right`, `bottom-left`, `bottom-right`, `top`, `bottom`, `left` or `right`.
+By default, they are relative to the top-left corner of the working area, but you can change this by setting `relative-to` to one of these values: `top-left`, `top-right`, `bottom-left`, `bottom-right`, `top`, `bottom`, `left`, or `right`.
 
 For example, if you have a bar at the top, then `x=0 y=0` will put the top-left corner of the window directly below the bar.
 If instead you write `x=0 y=0 relative-to="top-right"`, then the top-right corner of the window will align with the top-right corner of the workspace, also directly below the bar.
-When only one side is secified (e.g. top) the window will allign to the center of that side.
+When only one side is specified (e.g. top) the window will allign to the center of that side.
 
 The coordinates change direction based on `relative-to`.
 For example, by default (top-left), `x=100 y=200` will put the window 100 pixels to the right and 200 pixels down from the top-left corner.
@@ -629,6 +629,20 @@ window-rule {
 }
 ```
 
+Below a simple dropdown application that fill 80% of the width and it is anchored to the top
+of the screen.
+
+```kdl
+// Example: drop down terminal from the bottom of the screen
+window-rule {
+    match app-id="dropdown"
+    open-focused true
+    open-floating true
+    default-floating-position x=0 y=0 relative-to="top"
+    default-window-height { proportion 0.500; }
+    default-column-width { proportion 0.8; }  
+}
+```
 #### `scroll-factor`
 
 <sup>Since: 25.02</sup>

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -613,7 +613,7 @@ By default, they are relative to the top-left corner of the working area, but yo
 
 For example, if you have a bar at the top, then `x=0 y=0` will put the top-left corner of the window directly below the bar.
 If instead you write `x=0 y=0 relative-to="top-right"`, then the top-right corner of the window will align with the top-right corner of the workspace, also directly below the bar.
-When only one side is specified (e.g. top) the window will allign to the center of that side.
+When only one side is specified (e.g. top) the window will align to the center of that side.
 
 The coordinates change direction based on `relative-to`.
 For example, by default (top-left), `x=100 y=200` will put the window 100 pixels to the right and 200 pixels down from the top-left corner.
@@ -629,20 +629,27 @@ window-rule {
 }
 ```
 
-Below a simple dropdown application that fill 80% of the width and it is anchored to the top
-of the screen.
+You can use single-side `relative-to` to get a dropdown-like effect.
 
 ```kdl
-// Example: drop down terminal from the bottom of the screen
+// Example: a "dropdown" terminal.
 window-rule {
-    match app-id="dropdown"
-    open-focused true
+    // Match by "dropdown" app ID.
+    // You need to set this app ID when running your terminal, e.g.:
+    // spawn "alacritty" "--class" "dropdown"
+    match app-id="^dropdown$"
+
+    // Open it as floating.
     open-floating true
+    // Anchor to the top edge of the screen.
     default-floating-position x=0 y=0 relative-to="top"
-    default-window-height { proportion 0.500; }
-    default-column-width { proportion 0.8; }  
+    // Half of the screen high.
+    default-window-height { proportion 0.5; }
+    // 80% of the screen wide.
+    default-column-width { proportion 0.8; }
 }
 ```
+
 #### `scroll-factor`
 
 <sup>Since: 25.02</sup>

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -609,10 +609,11 @@ Afterward, the window will remember its last floating position.
 By default, new floating windows open at the center of the screen, and windows from the tiling layout open close to their visual screen position.
 
 The position uses logical coordinates relative to the working area.
-By default, they are relative to the top-left corner of the working area, but you can change this by setting `relative-to` to one of these values: `top-left`, `top-right`, `bottom-left`, `bottom-right`.
+By default, they are relative to the top-left corner of the working area, but you can change this by setting `relative-to` to one of these values: `top-left`, `top-right`, `bottom-left`, `bottom-right`, `top`, `bottom`, `left` or `right`.
 
 For example, if you have a bar at the top, then `x=0 y=0` will put the top-left corner of the window directly below the bar.
 If instead you write `x=0 y=0 relative-to="top-right"`, then the top-right corner of the window will align with the top-right corner of the workspace, also directly below the bar.
+When only one side is secified (e.g. top) the window will allign to the center of that side.
 
 The coordinates change direction based on `relative-to`.
 For example, by default (top-left), `x=100 y=200` will put the window 100 pixels to the right and 200 pixels down from the top-left corner.


### PR DESCRIPTION
As discussed in #1168 instead of adding the relative position I added 4 new options for the alignment of floating windows to the side of the screen.


https://github.com/user-attachments/assets/601a7041-96a4-4b3f-b071-2c2c0cbc983e

