### PR TITLE
Add Shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3040c8291884ddf39445dc033c70abc2bc44a42f0a3a00571a0f483a83f0cd"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,6 +2222,7 @@ dependencies = [
  "calloop 0.14.2",
  "calloop-wayland-source 0.4.0",
  "clap",
+ "clap_complete",
  "directories",
  "drm-ffi",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ bitflags.workspace = true
 bytemuck = { version = "1.22.0", features = ["derive"] }
 calloop = { version = "0.14.2", features = ["executor", "futures-io"] }
 clap = { workspace = true, features = ["string"] }
+clap_complete = "4.5.45"
 directories = "6.0.0"
 drm-ffi = "0.9.0"
 fastrand = "2.3.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use clap_complete::Shell;
 use niri_ipc::{Action, OutputAction};
 
 use crate::utils::version;
@@ -54,6 +55,8 @@ pub enum Sub {
     },
     /// Cause a panic to check if the backtraces are good.
     Panic,
+    /// Generate completions for [`Shell`]
+    Completions { shell: Shell },
 }
 
 #[derive(Subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,7 +55,7 @@ pub enum Sub {
     },
     /// Cause a panic to check if the backtraces are good.
     Panic,
-    /// Generate completions for [`Shell`]
+    /// Generate shell completions.
     Completions { shell: Shell },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, mem};
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use directories::ProjectDirs;
 use niri::cli::{Cli, Sub};
 #[cfg(feature = "dbus")]
@@ -106,6 +106,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 return Ok(());
             }
             Sub::Panic => cause_panic(),
+            Sub::Completions { shell } => {
+                clap_complete::generate(shell, &mut Cli::command(), "niri", &mut io::stdout());
+                return Ok(());
+            }
         }
     }
 


### PR DESCRIPTION
Simple setup to generate shell completions using `clap_complete`.
That is probably not the best way to *distribute* the shell completions, but it
is at good enough for development purposes.

There is probably a smart way to generate and package the completions as part of
the release workflow, but I haven't looked into what the best way to do that is
yet.
