### PR TITLE
Added missing "Since: 25.02" to clipboard config documentation

### DIFF
--- a/wiki/Configuration:-Miscellaneous.md
+++ b/wiki/Configuration:-Miscellaneous.md
@@ -144,6 +144,8 @@ cursor {
 
 ### `clipboard`
 
+<sup>Since: 25.02</sup>
+
 Clipboard settings.
 
 Set the `disable-primary` flag to disable the primary clipboard (middle-click paste).


### PR DESCRIPTION
Noticed that this is in the 25.02 changelog but the wiki doesn't mention when it was added.