### PR TITLE
Allow waiting for frames to complete rendering via GPU before sending to PipeWire consumers

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2039,6 +2039,8 @@ pub struct DebugConfig {
     #[knuffel(child)]
     pub wait_for_frame_completion_before_queueing: bool,
     #[knuffel(child)]
+    pub wait_for_frame_completion_in_pipewire: bool,
+    #[knuffel(child)]
     pub enable_overlay_planes: bool,
     #[knuffel(child)]
     pub disable_cursor_plane: bool,
@@ -4837,6 +4839,7 @@ mod tests {
                 preview_render: None,
                 dbus_interfaces_in_non_session_instances: false,
                 wait_for_frame_completion_before_queueing: false,
+                wait_for_frame_completion_in_pipewire: false,
                 enable_overlay_planes: false,
                 disable_cursor_plane: false,
                 disable_direct_scanout: false,

--- a/wiki/Configuration:-Debug-Options.md
+++ b/wiki/Configuration:-Debug-Options.md
@@ -21,6 +21,7 @@ debug {
     force-pipewire-invalid-modifier
     dbus-interfaces-in-non-session-instances
     wait-for-frame-completion-before-queueing
+    wait-for-frame-completion-in-pipewire
     emulate-zero-presentation-time
     disable-resize-throttling
     disable-transactions
@@ -149,6 +150,22 @@ Useful for diagnosing certain synchronization and performance problems.
 ```kdl
 debug {
     wait-for-frame-completion-before-queueing
+}
+```
+
+### `wait-for-frame-completion-in-pipewire`
+
+<sup>Since: next release</sup>
+
+Wait until every screencast frame is done rendering before handing it over to PipeWire.
+
+Sometimes helps on NVIDIA to prevent glitched frames when screencasting.
+
+This debug flag will eventually be removed once we handle this properly (via explicit sync in PipeWire).
+
+```kdl
+debug {
+    wait-for-frame-completion-in-pipewire
 }
 ```
 


### PR DESCRIPTION
Implemented `sync_point.wait()` optional functionality if enabled in debug options via `config.kdl` with `wait-for-gpu-sync-in-screencasting`. Added a documentation entry in the Wiki under debug options (_made it simplistic, to the point, following the other entries in the wiki so it isn't hard to understand_)