### PR TITLE
doc: fix wrongly formatted link that `rustdoc` kept complaining about

### DIFF
--- a/src/utils/scale.rs
+++ b/src/utils/scale.rs
@@ -1,7 +1,7 @@
 //! Default monitor scale calculation.
 //!
 //! This module follows logic and tests from Mutter:
-//! https://gitlab.gnome.org/GNOME/mutter/-/blob/gnome-46/src/backends/meta-monitor.c
+//! <https://gitlab.gnome.org/GNOME/mutter/-/blob/gnome-46/src/backends/meta-monitor.c>
 
 use smithay::utils::{Physical, Raw, Size};
 


### PR DESCRIPTION
The lint in question:

![image](https://github.com/user-attachments/assets/5743c913-16ef-4e6c-862f-97e42333cb3b)

Before:

![image](https://github.com/user-attachments/assets/eb99945f-ed23-4d2f-ad4f-3c3552ffba04)

After:

![image](https://github.com/user-attachments/assets/1784100b-6ad8-4e28-a713-305057eba923)
