### PR TITLE
Allow negative shadow spread + documentation improvements

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -653,7 +653,7 @@ pub struct Shadow {
     #[knuffel(child, unwrap(argument), default = Self::default().softness)]
     pub softness: FloatOrInt<0, 1024>,
     #[knuffel(child, unwrap(argument), default = Self::default().spread)]
-    pub spread: FloatOrInt<0, 1024>,
+    pub spread: FloatOrInt<-1024, 1024>,
     #[knuffel(child, unwrap(argument), default = Self::default().draw_behind_window)]
     pub draw_behind_window: bool,
     #[knuffel(child, default = Self::default().color)]
@@ -1319,7 +1319,7 @@ pub struct ShadowRule {
     #[knuffel(child, unwrap(argument))]
     pub softness: Option<FloatOrInt<0, 1024>>,
     #[knuffel(child, unwrap(argument))]
-    pub spread: Option<FloatOrInt<0, 1024>>,
+    pub spread: Option<FloatOrInt<-1024, 1024>>,
     #[knuffel(child, unwrap(argument))]
     pub draw_behind_window: Option<bool>,
     #[knuffel(child)]
@@ -2238,6 +2238,12 @@ impl CornerRadius {
         }
         if self.bottom_left > 0. {
             self.bottom_left += width;
+        }
+        if width < 0. {
+            self.top_left = self.top_left.max(0.);
+            self.top_right = self.top_right.max(0.);
+            self.bottom_left = self.bottom_left.max(0.);
+            self.bottom_right = self.bottom_right.max(0.);
         }
 
         self

--- a/src/layout/shadow.rs
+++ b/src/layout/shadow.rs
@@ -62,7 +62,11 @@ impl Shadow {
 
         let win_radius = radius.fit_to(win_size.w as f32, win_size.h as f32);
 
-        let box_size = win_size + Size::from((spread, spread)).upscale(2.);
+        let box_size = if spread >= 0. {
+            win_size + Size::from((spread, spread)).upscale(2.)
+        } else {
+            win_size - Size::from((-spread, -spread)).upscale(2.)
+        };
         let radius = win_radius.expanded_by(spread as f32);
 
         let shader_size = box_size + Size::from((width, width)).upscale(2.);

--- a/wiki/Configuration:-Layout.md
+++ b/wiki/Configuration:-Layout.md
@@ -368,12 +368,15 @@ Shadow rendered behind a window.
 
 Set `on` to enable the shadow.
 
-`softness` controls the shadow softness/size in logical pixels, same as CSS box-shadow *blur radius*.
+[CSS box-shadow]: https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#values "MDN documentation for CSS box-shadow"
+
+`softness` controls the shadow softness/size in logical pixels, same as [CSS box-shadow] *blur radius*.
 Setting `softness 0` will give you hard shadows.
 
-`spread` is the distance to expand the window rectangle in logical pixels, same as CSS box-shadow spread.
+`spread` is the distance to expand the window rectangle in logical pixels, same as [CSS box-shadow] spread.
 
-`offset` moves the shadow relative to the window in logical pixels, same as CSS box-shadow offset.
+`offset` moves the shadow relative to the window in logical pixels, same as [CSS box-shadow] offset.
+For example, `offset x=2 y=2` will move the shadow 2 logical pixels downwards and to the right.
 
 Set `draw-behind-window` to `true` to make shadows draw behind the window rather than just around it.
 Note that niri has no way of knowing about the CSD window corner radius.


### PR DESCRIPTION
The documentation part is things I ran into when reading that part of the wiki for the first time.

As for the shadow spread, this is something that you can do with CSS and I was missing for mako (the shadows seem too big for its notifications).

I hope that I did this correctly, I spent a while figuring out what can and can't be a negative number.
I'm not familiar with the codebase so I'm not sure if there are any other requirements/assumptions I may have missed.

Here is a snippet of the updated code with some extra comments showing my thought process:
```rust
let spread = ceil(self.config.spread.0);
// I'm assuming Point can be negative
let offset = offset - Point::from((spread, spread));

let win_radius = radius.fit_to(win_size.w as f32, win_size.h as f32);

// Size must be positive according to smithay documentation
let box_size = if spread >= 0. {
    win_size + Size::from((spread, spread)).upscale(2.)
} else {
    win_size - Size::from((-spread, -spread)).upscale(2.)
};
// I added a check to `CornerRadius::expanded_by` to ensure corner radii won't become negative with a negative argument
let radius = win_radius.expanded_by(spread as f32);

let shader_size = box_size + Size::from((width, width)).upscale(2.);
```
