### PR TITLE
feat(cli): add `niri validate --json` to print report as json

### DIFF
--- a/niri-config/src/ipc_diagnostic.rs
+++ b/niri-config/src/ipc_diagnostic.rs
@@ -1,5 +1,5 @@
 use miette::{LabeledSpan, SourceCode, SourceSpan, SpanContents};
-use niri_ipc::diagnostic::{Diagnostic, Label, LineSpan, Severity, Span};
+use niri_ipc::diagnostic::{Diagnostic, Label, LinePosition, Severity, Span};
 
 pub fn convert_to_ipc(diagnostic: &dyn miette::Diagnostic) -> Diagnostic {
     diagnostic_to_ipc(diagnostic, None)
@@ -78,11 +78,11 @@ fn convert_severity(value: miette::Severity) -> Severity {
 fn line_span_from_label<S: SourceCode + ?Sized>(
     code: Option<&S>,
     span: &SourceSpan,
-) -> Option<LineSpan> {
+) -> Option<LinePosition> {
     let code = code?;
     let content = code.read_span(span, 0, 0).ok()?;
-    Some(LineSpan {
+    Some(LinePosition {
         line: content.line(),
-        col: content.column(),
+        character: content.column(),
     })
 }

--- a/niri-config/src/ipc_diagnostic.rs
+++ b/niri-config/src/ipc_diagnostic.rs
@@ -36,7 +36,6 @@ fn diagnostic_to_ipc(
                     .and_then(SpanContents::name)
                     .map(ToOwned::to_owned)
             })
-            .unwrap_or_default()
         },
         labels: diagnostic
             .labels()

--- a/niri-config/src/ipc_diagnostic.rs
+++ b/niri-config/src/ipc_diagnostic.rs
@@ -1,0 +1,89 @@
+use miette::{LabeledSpan, SourceCode, SourceSpan, SpanContents};
+use niri_ipc::diagnostic::{Diagnostic, Label, LineSpan, Severity, Span};
+
+pub fn convert_to_ipc(diagnostic: &dyn miette::Diagnostic) -> Diagnostic {
+    diagnostic_to_ipc(diagnostic, None)
+}
+
+/// Implementation based on [`miette::JSONReportHandler::render_report()`].
+fn diagnostic_to_ipc(
+    diagnostic: &dyn miette::Diagnostic,
+    parent_src: Option<&dyn SourceCode>,
+) -> Diagnostic {
+    let src = diagnostic.source_code().or(parent_src);
+    Diagnostic {
+        message: diagnostic.to_string(),
+        severity: diagnostic
+            .severity()
+            .map(convert_severity)
+            .unwrap_or(Severity::Error),
+        url: diagnostic.url().as_ref().map(ToString::to_string),
+        help: diagnostic.help().as_ref().map(ToString::to_string),
+        filename: {
+            // If there are no labels available, fall back to a meaningless default span as we
+            // **really** just want the file name.
+            // (Though if that fails because (0,0) is out of bounds that isn't too bad)
+            let span = diagnostic
+                .labels()
+                .as_mut()
+                .and_then(Iterator::next)
+                .unwrap_or(LabeledSpan::new_with_span(None, SourceSpan::from((0, 0))));
+
+            src.and_then(|src| {
+                src.read_span(span.inner(), 0, 0)
+                    .ok()
+                    .as_deref()
+                    .and_then(SpanContents::name)
+                    .map(ToOwned::to_owned)
+            })
+            .unwrap_or_default()
+        },
+        labels: diagnostic
+            .labels()
+            .map(|iter| {
+                iter.map(|label| Label {
+                    label: label.label().map(ToOwned::to_owned).unwrap_or_default(),
+                    span: Span {
+                        offset: label.offset(),
+                        length: label.len(),
+                        start: line_span_from_label(src, label.inner()),
+                        // Because miette doesn't just give us the ending line + column for
+                        // some reason.
+                        end: line_span_from_label(src, &{
+                            let label = label.inner();
+                            SourceSpan::from(label.len() + label.offset())
+                        }),
+                    },
+                })
+                .collect()
+            })
+            .unwrap_or_default(),
+        related: diagnostic
+            .related()
+            .map(|iter| {
+                iter.map(|diagnostic| diagnostic_to_ipc(diagnostic, src))
+                    .collect()
+            })
+            .unwrap_or_default(),
+    }
+}
+
+fn convert_severity(value: miette::Severity) -> Severity {
+    match value {
+        miette::Severity::Advice => Severity::Advice,
+        miette::Severity::Warning => Severity::Warning,
+        miette::Severity::Error => Severity::Error,
+    }
+}
+
+fn line_span_from_label<S: SourceCode + ?Sized>(
+    code: Option<&S>,
+    span: &SourceSpan,
+) -> Option<LineSpan> {
+    let code = code?;
+    let content = code.read_span(span, 0, 0).ok()?;
+    Some(LineSpan {
+        line: content.line(),
+        col: content.column(),
+    })
+}

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -30,6 +30,8 @@ pub mod layer_rule;
 mod utils;
 pub use utils::RegexEq;
 
+pub mod ipc_diagnostic;
+
 #[derive(knuffel::Decode, Debug, PartialEq)]
 pub struct Config {
     #[knuffel(child, default)]

--- a/niri-ipc/src/diagnostic.rs
+++ b/niri-ipc/src/diagnostic.rs
@@ -1,0 +1,76 @@
+//! Config parsing diagnostics.
+//!
+//! The types in this module are based on `Report` and `Diagnostic` from [miette], which is what
+//! niri's config parsing uses.
+//!
+//! [miette]: https://crates.io/crates/miette
+
+use serde::Serialize;
+
+// Doc-comments in this file are losely based on ones from miette, licensed under Apache-2.0.
+//
+// https://github.com/zkat/miette
+
+/// Diagnostic from parsing a file.
+#[derive(Serialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct Diagnostic {
+    /// Printable message.
+    pub message: String,
+    /// Diagnostic severity.
+    pub severity: Severity,
+    /// URL to visit for a more detailed explanation.
+    pub url: Option<String>,
+    /// Additional help about this diagnostic.
+    pub help: Option<String>,
+    /// Name of the file where the diagnostic occurred.
+    pub filename: String,
+    /// Labels to apply to this diagnostic's file.
+    pub labels: Vec<Label>,
+    /// Additional related diagnostics.
+    pub related: Vec<Diagnostic>,
+}
+
+/// Diagnostic severity.
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub enum Severity {
+    /// Just some help.
+    Advice,
+    /// Warning to take note of.
+    Warning,
+    /// Critical failure.
+    Error,
+}
+
+/// Labeled [`Span`].
+#[derive(Serialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct Label {
+    /// Label string.
+    pub label: String,
+    /// Span the label applies to.
+    pub span: Span,
+}
+
+/// Span within a source file.
+#[derive(Serialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct Span {
+    /// The 0-based starting byte offset.
+    pub offset: usize,
+    /// Number of bytes this span spans.
+    pub length: usize,
+    pub start: Option<LineSpan>,
+    pub end: Option<LineSpan>,
+}
+
+#[derive(Serialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct LineSpan {
+    /// The 0-indexed line into the file.
+    pub line: usize,
+    /// The 0-indexed column into the file, relative to `line`.
+    pub col: usize,
+}

--- a/niri-ipc/src/diagnostic.rs
+++ b/niri-ipc/src/diagnostic.rs
@@ -63,9 +63,9 @@ pub struct Span {
     /// Number of bytes this span spans.
     pub length: usize,
     /// Starting line position of this span
-    pub start: Option<LinePosition>,
+    pub start: LinePosition,
     /// Ending line position of this span
-    pub end: Option<LinePosition>,
+    pub end: LinePosition,
 }
 
 /// Position in a document in terms of line number + character offset.

--- a/niri-ipc/src/diagnostic.rs
+++ b/niri-ipc/src/diagnostic.rs
@@ -62,15 +62,21 @@ pub struct Span {
     pub offset: usize,
     /// Number of bytes this span spans.
     pub length: usize,
-    pub start: Option<LineSpan>,
-    pub end: Option<LineSpan>,
+    /// Starting line position of this span
+    pub start: Option<LinePosition>,
+    /// Ending line position of this span
+    pub end: Option<LinePosition>,
 }
 
+/// Position in a document in terms of line number + character offset.
+///
+/// Note that this counts line numbers as declared by the KDL specification:
+/// <https://kdl.dev/spec/#section-3.18>
 #[derive(Serialize)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
-pub struct LineSpan {
-    /// The 0-indexed line into the file.
+pub struct LinePosition {
+    /// The 0-indexed line position in the file.
     pub line: usize,
-    /// The 0-indexed column into the file, relative to `line`.
-    pub col: usize,
+    /// The 0-indexed character offset into the file, relative to `line`.
+    pub character: usize,
 }

--- a/niri-ipc/src/diagnostic.rs
+++ b/niri-ipc/src/diagnostic.rs
@@ -24,7 +24,7 @@ pub struct Diagnostic {
     /// Additional help about this diagnostic.
     pub help: Option<String>,
     /// Name of the file where the diagnostic occurred.
-    pub filename: String,
+    pub filename: Option<String>,
     /// Labels to apply to this diagnostic's file.
     pub labels: Vec<Label>,
     /// Additional related diagnostics.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -40,6 +40,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
+pub mod diagnostic;
 pub mod socket;
 pub mod state;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,6 +52,9 @@ pub enum Sub {
         /// command line argument takes precedence.
         #[arg(short, long)]
         config: Option<PathBuf>,
+        /// Format config errors as JSON to stdout.
+        #[arg(short, long)]
+        json: bool,
     },
     /// Cause a panic to check if the backtraces are good.
     Panic,

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 };
 
                 if json {
-                    let diagnostic = ipc_diagnostic::convert_to_ipc(&*report);
+                    let diagnostic = ipc_diagnostic::convert_to_ipc(&*report)?;
                     serde_json::to_writer(BufWriter::new(io::stdout()), &diagnostic)?;
                 }
 


### PR DESCRIPTION
This can be used to more or less trivially integrate the errors that `niri
validate` returns into your editor.

For example I wrote script that converts the json output into neovim
diagnostics on-save. (I haven't committed + pushed it yet, but when I do I will make
sure to add the link here)

![image](https://github.com/user-attachments/assets/7bae2180-2f19-48e9-9b57-d67d8a8d068c)

One thing to note is that this PR also moves the `tracing` output from `stdout`
to `stderr`, (I **really** don't understand why that's not the default of `tracing_subscriber::fmt()`?!),
which *technically* might be a breaking change if there are any tools out there
trying to parse those logs.

But I think doing so is **definitely** the right thing to do *regardless* of
this PR, considering that `niri msg --json` prints its output to `stdout` as
well, which would cause the logging and the json output to interleave if both
are present. (AFAIK there is no instance of that *currently* happening that I
know of, but I could imagine some code adding a log statement somewhere and
with that causing the logging to the json output to interleave.
