### PR TITLE
Add option to warp-mouse-to-focus to always center

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -95,7 +95,7 @@ pub struct Input {
     #[knuffel(child)]
     pub disable_power_key_handling: bool,
     #[knuffel(child)]
-    pub warp_mouse_to_focus: bool,
+    pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     #[knuffel(child)]
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
     #[knuffel(child)]
@@ -367,6 +367,32 @@ pub struct Touch {
 pub struct FocusFollowsMouse {
     #[knuffel(property, str)]
     pub max_scroll_amount: Option<Percent>,
+}
+
+#[derive(knuffel::Decode, Debug, PartialEq, Eq, Clone, Copy)]
+pub struct WarpMouseToFocus {
+    #[knuffel(property, str)]
+    pub mode: Option<WarpMouseToFocusMode>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum WarpMouseToFocusMode {
+    CenterXy,
+    CenterXyAlways,
+}
+
+impl FromStr for WarpMouseToFocusMode {
+    type Err = miette::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "center-xy" => Ok(Self::CenterXy),
+            "center-xy-always" => Ok(Self::CenterXyAlways),
+            _ => Err(miette!(
+                r#"invalid mode for warp-mouse-to-focus, can be "center-xy" or "center-xy-always" (or leave unset for separate centering)"#
+            )),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -4023,7 +4049,11 @@ mod tests {
                     ),
                 },
                 disable_power_key_handling: true,
-                warp_mouse_to_focus: true,
+                warp_mouse_to_focus: Some(
+                    WarpMouseToFocus {
+                        mode: None,
+                    },
+                ),
                 focus_follows_mouse: Some(
                     FocusFollowsMouse {
                         max_scroll_amount: None,

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -243,11 +243,26 @@ input {
 
 Makes the mouse warp to newly focused windows.
 
-X and Y coordinates are computed separately, i.e. if moving the mouse only horizontally is enough to put it inside the newly focused window, then it will move only horizontally.
+Does not make the cursor visible if it had been hidden.
 
 ```kdl
 input {
     warp-mouse-to-focus
+}
+```
+
+By default, the cursor warps *separately* horizontally and vertically.
+I.e. if moving the mouse only horizontally is enough to put it inside the newly focused window, then the mouse will move only horizontally, and not vertically.
+
+<sup>Since: next release</sup> You can customize this with the `mode` property.
+
+- `mode="center-xy"`: warps by both X and Y coordinates together.
+So if the mouse was anywhere outside the newly focused window, it will warp to the center of the window.
+- `mode="center-xy-always"`: warps by both X and Y coordinates together, even if the mouse was already somewhere inside the newly focused window.
+
+```kdl
+input {
+    warp-mouse-to-focus mode="center-xy"
 }
 ```
 


### PR DESCRIPTION
For my mental model, it's important that the mouse always warps to the center of the focused window.  Niri right now only centers X or Y, but not both, depending on where the mouse was.

This PR adds an option to wrap-mouse-to-focus called 'force-center' which enables centering both, always.