### PR TITLE
(WIP) niri-ipc: Include window positions within the workspace columns in Window state and output

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1156,12 +1156,16 @@ pub struct Window {
     /// Whether this window requests your attention.
     pub is_urgent: bool,
     /// Position- and size-related properties of the window.
-    pub location: WindowLayout,
+    pub layout: WindowLayout,
 }
 
 /// Position- and size-related properties of a [`Window`].
 ///
 /// Optional properties will be unset for some windows, do not rely on them always being present.
+///
+/// All sizes and positions are in *logical pixels* unless stated otherwise. Logical sizes may be
+/// fractional. For example, at 1.25 monitor scale, a 2-physical-pixel-wide window border is 1.6
+/// logical pixels wide.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct WindowLayout {
@@ -1170,9 +1174,12 @@ pub struct WindowLayout {
     pub pos_in_scrolling_layout: Option<(usize, usize)>,
     /// Size of the tile this window is in, including decorations like borders.
     pub tile_size: (f64, f64),
-    /// Size of the window itself.
+    /// Size of the window's visual geometry itself.
     ///
-    /// Note that Wayland windows can only be integer sized.
+    /// Does not include niri decorations like borders.
+    ///
+    /// Currently, Wayland toplevel windows can only be integer-sized in logical pixels, even
+    /// though it doesn't necessarily align to physical pixels.
     pub window_size: (i32, i32),
     /// Tile position within the current view of the workspace.
     ///

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1155,6 +1155,35 @@ pub struct Window {
     pub is_floating: bool,
     /// Whether this window requests your attention.
     pub is_urgent: bool,
+    /// Position- and size-related properties of the window.
+    pub location: WindowLayout,
+}
+
+/// Position- and size-related properties of a [`Window`].
+///
+/// Optional properties will be unset for some windows, do not rely on them always being present.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct WindowLayout {
+    /// Location of a tiled window within a workspace in terms of (column index, tile index in
+    /// column).
+    pub pos_in_scrolling_layout: Option<(usize, usize)>,
+    /// Size of the tile this window is in, including decorations like borders.
+    pub tile_size: (f64, f64),
+    /// Size of the window itself.
+    ///
+    /// Note that Wayland windows can only be integer sized.
+    pub window_size: (i32, i32),
+    /// Tile position within the current view of the workspace.
+    ///
+    /// This is the same "workspace view" as in gradients' `relative-to` in the niri config.
+    pub tile_pos_in_workspace_view: Option<(f64, f64)>,
+    /// Window position within the current view of the workspace.
+    ///
+    /// Unlike `tile_pos_in_workspace_view`, this is the position of the window contents, excluding
+    /// borders and other decorations. You probably want to use `tile_pos_in_workspace_view`
+    /// instead, since borders are a part of the window, as far as the user is concerned.
+    pub window_pos_in_workspace_view: Option<(f64, f64)>,
 }
 
 /// Output configuration change result.
@@ -1330,6 +1359,11 @@ pub enum Event {
         id: u64,
         /// The new urgency state of the window.
         urgent: bool,
+    },
+    /// The layout of one or more windows has changed.
+    WindowLayoutsChanged {
+        /// Pairs consisting of a window id and new layout information for the window.
+        changes: Vec<(u64, WindowLayout)>,
     },
     /// The configured keyboard layouts have changed.
     KeyboardLayoutsChanged {

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1178,8 +1178,11 @@ pub struct Window {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct WindowLayout {
-    /// Location of a tiled window within a workspace in terms of (column index, tile index in
-    /// column).
+    /// Location of a tiled window within a workspace: (column index, tile index in column).
+    ///
+    /// The indices are 1-based, i.e. the leftmost column is at index 1 and the topmost tile in a
+    /// column is at index 1. This is consistent with [`Action::FocusColumn`] and
+    /// [`Action::FocusWindowInColumn`].
     pub pos_in_scrolling_layout: Option<(usize, usize)>,
     /// Size of the tile this window is in, including decorations like borders.
     pub tile_size: (f64, f64),

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1161,11 +1161,20 @@ pub struct Window {
 
 /// Position- and size-related properties of a [`Window`].
 ///
-/// Optional properties will be unset for some windows, do not rely on them always being present.
+/// Optional properties will be unset for some windows, do not rely on them being present. Whether
+/// some optional properties are present or absent for certain window types may change across niri
+/// releases.
 ///
 /// All sizes and positions are in *logical pixels* unless stated otherwise. Logical sizes may be
 /// fractional. For example, at 1.25 monitor scale, a 2-physical-pixel-wide window border is 1.6
 /// logical pixels wide.
+///
+/// This struct contains positions and sizes both for full tiles ([`Self::tile_size`],
+/// [`Self::tile_pos_in_workspace_view`]) and the window geometry ([`Self::window_size`],
+/// [`Self::window_offset_in_tile`]). For visual displays, use the tile properties, as they
+/// correspond to what the user visually considers "window". The window properties on the other
+/// hand are mainly useful when you need to know the underlying Wayland window sizes, e.g. for
+/// application debugging.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct WindowLayout {
@@ -1185,12 +1194,12 @@ pub struct WindowLayout {
     ///
     /// This is the same "workspace view" as in gradients' `relative-to` in the niri config.
     pub tile_pos_in_workspace_view: Option<(f64, f64)>,
-    /// Window position within the current view of the workspace.
+    /// Location of the window's visual geometry within its tile.
     ///
-    /// Unlike `tile_pos_in_workspace_view`, this is the position of the window contents, excluding
-    /// borders and other decorations. You probably want to use `tile_pos_in_workspace_view`
-    /// instead, since borders are a part of the window, as far as the user is concerned.
-    pub window_pos_in_workspace_view: Option<(f64, f64)>,
+    /// This includes things like border sizes. For fullscreened fixed-size windows this includes
+    /// the distance from the corner of the black backdrop to the corner of the (centered) window
+    /// contents.
+    pub window_offset_in_tile: (f64, f64),
 }
 
 /// Output configuration change result.

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -151,6 +151,15 @@ impl EventStreamStatePart for WindowsState {
             Event::WindowsChanged { windows } => {
                 self.windows = windows.into_iter().map(|win| (win.id, win)).collect();
             }
+            Event::WindowLayoutsChanged { changes } => {
+                for (id, update) in changes {
+                    let w = self
+                        .windows
+                        .get_mut(&id)
+                        .expect("changed window was missing from the map");
+                    w.location = update;
+                }
+            }
             Event::WindowOpenedOrChanged { window } => {
                 let (id, is_focused) = match self.windows.entry(window.id) {
                     Entry::Occupied(mut entry) => {

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -151,15 +151,6 @@ impl EventStreamStatePart for WindowsState {
             Event::WindowsChanged { windows } => {
                 self.windows = windows.into_iter().map(|win| (win.id, win)).collect();
             }
-            Event::WindowLayoutsChanged { changes } => {
-                for (id, update) in changes {
-                    let w = self
-                        .windows
-                        .get_mut(&id)
-                        .expect("changed window was missing from the map");
-                    w.location = update;
-                }
-            }
             Event::WindowOpenedOrChanged { window } => {
                 let (id, is_focused) = match self.windows.entry(window.id) {
                     Entry::Occupied(mut entry) => {
@@ -196,6 +187,13 @@ impl EventStreamStatePart for WindowsState {
                         win.is_urgent = urgent;
                         break;
                     }
+                }
+            }
+            Event::WindowLayoutsChanged { changes } => {
+                for (id, update) in changes {
+                    let win = self.windows.get_mut(&id);
+                    let win = win.expect("changed window was missing from the map");
+                    win.layout = update;
                 }
             }
             event => return Some(event),

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -447,6 +447,9 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                     Event::WindowUrgencyChanged { id, urgent } => {
                         println!("Window {id}: urgency changed to {urgent}");
                     }
+                    Event::WindowLayoutsChanged { changes } => {
+                        println!("Window layouts changed: {changes:?}");
+                    }
                     Event::KeyboardLayoutsChanged { keyboard_layouts } => {
                         println!("Keyboard layouts changed: {keyboard_layouts:?}");
                     }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -7,7 +7,7 @@ use niri_config::OutputName;
 use niri_ipc::socket::Socket;
 use niri_ipc::{
     Event, KeyboardLayouts, LogicalOutput, Mode, Output, OutputConfigChanged, Overview, Request,
-    Response, Transform, Window,
+    Response, Transform, Window, WindowLayout,
 };
 use serde_json::json;
 
@@ -614,5 +614,66 @@ fn print_window(window: &Window) {
         println!("  Workspace ID: {workspace_id}");
     } else {
         println!("  Workspace ID: (none)");
+    }
+
+    let WindowLayout {
+        pos_in_scrolling_layout,
+        tile_size,
+        window_size,
+        tile_pos_in_workspace_view,
+        window_offset_in_tile,
+    } = window.layout;
+
+    println!("  Layout:");
+    println!(
+        "    Tile size: {} x {}",
+        fmt_rounded(tile_size.0),
+        fmt_rounded(tile_size.1)
+    );
+
+    if let Some(pos) = pos_in_scrolling_layout {
+        println!("    Scrolling position: column {}, tile {}", pos.0, pos.1);
+    }
+
+    if let Some(pos) = tile_pos_in_workspace_view {
+        println!(
+            "    Workspace-view position: {}, {}",
+            fmt_rounded(pos.0),
+            fmt_rounded(pos.1)
+        );
+    }
+
+    println!("    Window size: {} x {}", window_size.0, window_size.1);
+    println!(
+        "    Window offset in tile: {} x {}",
+        fmt_rounded(window_offset_in_tile.0),
+        fmt_rounded(window_offset_in_tile.1)
+    );
+}
+
+fn fmt_rounded(x: f64) -> String {
+    let r = x.round();
+    if (r - x).abs() <= 0.005 {
+        format!("{r}")
+    } else {
+        format!("{x:.2}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    #[test]
+    fn test_fmt_rounded() {
+        assert_snapshot!(fmt_rounded(1.9), @"1.90");
+        assert_snapshot!(fmt_rounded(1.994), @"1.99");
+        assert_snapshot!(fmt_rounded(1.996), @"2");
+        assert_snapshot!(fmt_rounded(2.0), @"2");
+        assert_snapshot!(fmt_rounded(2.004), @"2");
+        assert_snapshot!(fmt_rounded(2.006), @"2.01");
+        assert_snapshot!(fmt_rounded(2.1), @"2.10");
     }
 }

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -3,7 +3,7 @@ use std::iter::zip;
 use std::rc::Rc;
 
 use niri_config::{PresetSize, RelativeTo};
-use niri_ipc::{PositionChange, SizeChange};
+use niri_ipc::{PositionChange, SizeChange, WindowLayout};
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Logical, Point, Rectangle, Scale, Serial, Size};
 
@@ -319,6 +319,16 @@ impl<W: LayoutElement> FloatingSpace<W> {
                 pos = pos.to_physical_precise_round(scale).to_logical(scale);
             }
             (tile, pos)
+        })
+    }
+
+    pub fn tiles_with_ipc_layouts(&self) -> impl Iterator<Item = (&Tile<W>, WindowLayout)> {
+        self.tiles_with_render_positions().map(move |(tile, pos)| {
+            let layout = WindowLayout {
+                tile_pos_in_workspace_view: Some(pos.into()),
+                ..tile.ipc_layout_template()
+            };
+            (tile, layout)
         })
     }
 

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -323,7 +323,13 @@ impl<W: LayoutElement> FloatingSpace<W> {
     }
 
     pub fn tiles_with_ipc_layouts(&self) -> impl Iterator<Item = (&Tile<W>, WindowLayout)> {
-        self.tiles_with_render_positions().map(move |(tile, pos)| {
+        let scale = self.scale;
+        self.tiles_with_offsets().map(move |(tile, offset)| {
+            // Do not include animated render offset here to avoid IPC spam.
+            let pos = offset;
+            // Round to physical pixels.
+            let pos = pos.to_physical_precise_round(scale).to_logical(scale);
+
             let layout = WindowLayout {
                 tile_pos_in_workspace_view: Some(pos.into()),
                 ..tile.ipc_layout_template()

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1742,13 +1742,6 @@ impl<W: LayoutElement> Layout<W> {
         moving_window.chain(mon_windows)
     }
 
-    pub fn current_interactive_move_tile(&self) -> Option<&Tile<W>> {
-        match &self.interactive_move {
-            Some(InteractiveMoveState::Moving(move_)) => Some(&move_.tile),
-            _ => None,
-        }
-    }
-
     pub fn with_windows(
         &self,
         mut f: impl FnMut(&W, Option<&Output>, Option<WorkspaceId>, WindowLayout),
@@ -1759,7 +1752,7 @@ impl<W: LayoutElement> Layout<W> {
                 Some(&move_.output),
                 None,
                 WindowLayout {
-                    tile_pos_in_scrolling_layout: None,
+                    pos_in_scrolling_layout: None,
                     tile_size: move_.tile.tile_size().into(),
                     window_size: move_.tile.window().size().into(),
                     tile_pos_in_workspace_view: None,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1756,7 +1756,7 @@ impl<W: LayoutElement> Layout<W> {
                     tile_size: move_.tile.tile_size().into(),
                     window_size: move_.tile.window().size().into(),
                     tile_pos_in_workspace_view: None,
-                    window_pos_in_workspace_view: None,
+                    window_offset_in_tile: move_.tile.window_loc().into(),
                 },
             );
         }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1747,41 +1747,25 @@ impl<W: LayoutElement> Layout<W> {
         mut f: impl FnMut(&W, Option<&Output>, Option<WorkspaceId>, WindowLayout),
     ) {
         if let Some(InteractiveMoveState::Moving(move_)) = &self.interactive_move {
-            f(
-                move_.tile.window(),
-                Some(&move_.output),
-                None,
-                WindowLayout {
-                    pos_in_scrolling_layout: None,
-                    tile_size: move_.tile.tile_size().into(),
-                    window_size: move_.tile.window().size().into(),
-                    tile_pos_in_workspace_view: None,
-                    window_offset_in_tile: move_.tile.window_loc().into(),
-                },
-            );
+            // We don't fill any positions for interactively moved windows.
+            let layout = move_.tile.ipc_layout_template();
+            f(move_.tile.window(), Some(&move_.output), None, layout);
         }
 
         match &self.monitor_set {
             MonitorSet::Normal { monitors, .. } => {
                 for mon in monitors {
                     for ws in &mon.workspaces {
-                        // for (tile, cell) in ws.tiles_with_workspace_positions() {
-                        for (tile, window_layout) in ws.tiles_with_window_layouts() {
-                            f(
-                                tile.window(),
-                                Some(&mon.output),
-                                Some(ws.id()),
-                                window_layout,
-                            );
+                        for (tile, layout) in ws.tiles_with_ipc_layouts() {
+                            f(tile.window(), Some(&mon.output), Some(ws.id()), layout);
                         }
                     }
                 }
             }
             MonitorSet::NoOutputs { workspaces } => {
                 for ws in workspaces {
-                    // for (tile, cell) in ws.tiles_with_workspace_positions() {
-                    for (tile, window_layout) in ws.tiles_with_window_layouts() {
-                        f(tile.window(), None, Some(ws.id()), window_layout);
+                    for (tile, layout) in ws.tiles_with_ipc_layouts() {
+                        f(tile.window(), None, Some(ws.id()), layout);
                     }
                 }
             }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -42,7 +42,7 @@ use niri_config::{
     CenterFocusedColumn, Config, CornerRadius, FloatOrInt, PresetSize, Struts,
     Workspace as WorkspaceConfig, WorkspaceReference,
 };
-use niri_ipc::{ColumnDisplay, PositionChange, SizeChange};
+use niri_ipc::{ColumnDisplay, PositionChange, SizeChange, WindowLayout};
 use scrolling::{Column, ColumnWidth};
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::utils::RescaleRenderElement;
@@ -1742,25 +1742,53 @@ impl<W: LayoutElement> Layout<W> {
         moving_window.chain(mon_windows)
     }
 
-    pub fn with_windows(&self, mut f: impl FnMut(&W, Option<&Output>, Option<WorkspaceId>)) {
+    pub fn current_interactive_move_tile(&self) -> Option<&Tile<W>> {
+        match &self.interactive_move {
+            Some(InteractiveMoveState::Moving(move_)) => Some(&move_.tile),
+            _ => None,
+        }
+    }
+
+    pub fn with_windows(
+        &self,
+        mut f: impl FnMut(&W, Option<&Output>, Option<WorkspaceId>, WindowLayout),
+    ) {
         if let Some(InteractiveMoveState::Moving(move_)) = &self.interactive_move {
-            f(move_.tile.window(), Some(&move_.output), None);
+            f(
+                move_.tile.window(),
+                Some(&move_.output),
+                None,
+                WindowLayout {
+                    tile_pos_in_scrolling_layout: None,
+                    tile_size: move_.tile.tile_size().into(),
+                    window_size: move_.tile.window().size().into(),
+                    tile_pos_in_workspace_view: None,
+                    window_pos_in_workspace_view: None,
+                },
+            );
         }
 
         match &self.monitor_set {
             MonitorSet::Normal { monitors, .. } => {
                 for mon in monitors {
                     for ws in &mon.workspaces {
-                        for win in ws.windows() {
-                            f(win, Some(&mon.output), Some(ws.id()));
+                        // for (tile, cell) in ws.tiles_with_workspace_positions() {
+                        for (tile, window_layout) in ws.tiles_with_window_layouts() {
+                            f(
+                                tile.window(),
+                                Some(&mon.output),
+                                Some(ws.id()),
+                                window_layout,
+                            );
                         }
                     }
                 }
             }
             MonitorSet::NoOutputs { workspaces } => {
                 for ws in workspaces {
-                    for win in ws.windows() {
-                        f(win, None, Some(ws.id()));
+                    // for (tile, cell) in ws.tiles_with_workspace_positions() {
+                    for (tile, window_layout) in ws.tiles_with_window_layouts() {
+                        f(tile.window(), None, Some(ws.id()), window_layout);
                     }
                 }
             }

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2323,6 +2323,19 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         zip(columns, offsets)
     }
 
+    pub fn tiles_with_workspace_positions(
+        &self,
+    ) -> impl Iterator<Item = (&Tile<W>, (usize, usize))> {
+        self.columns
+            .iter()
+            .enumerate()
+            .flat_map(move |(col_i, col)| {
+                col.tiles()
+                    .enumerate()
+                    .map(move |(tile_i, (tile, _))| (tile, (col_i, tile_i)))
+            })
+    }
+
     pub fn tiles_with_render_positions(
         &self,
     ) -> impl Iterator<Item = (&Tile<W>, Point<f64, Logical>, bool)> {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2373,7 +2373,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             .flat_map(move |(col_idx, col)| {
                 col.tiles().enumerate().map(move |(tile_idx, (tile, _))| {
                     let layout = WindowLayout {
-                        pos_in_scrolling_layout: Some((col_idx, tile_idx)),
+                        // Our indices are 1-based, consistent with the actions.
+                        pos_in_scrolling_layout: Some((col_idx + 1, tile_idx + 1)),
                         ..tile.ipc_layout_template()
                     };
                     (tile, layout)

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -2,6 +2,7 @@ use core::f64;
 use std::rc::Rc;
 
 use niri_config::{Color, CornerRadius, GradientInterpolation};
+use niri_ipc::WindowLayout;
 use smithay::backend::renderer::element::{Element, Kind};
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Logical, Point, Rectangle, Scale, Size};
@@ -686,6 +687,19 @@ impl<W: LayoutElement> Tile<W> {
         loc += self.window_loc();
         loc += self.window.buf_loc().to_f64();
         loc
+    }
+
+    /// Returns a partially-filled [`WindowLayout`].
+    ///
+    /// Only the sizing properties that a [`Tile`] can fill are filled.
+    pub fn ipc_layout_template(&self) -> WindowLayout {
+        WindowLayout {
+            pos_in_scrolling_layout: None,
+            tile_size: self.tile_size().into(),
+            window_size: self.window().size().into(),
+            tile_pos_in_workspace_view: None,
+            window_offset_in_tile: self.window_loc().into(),
+        }
     }
 
     fn is_in_input_region(&self, mut point: Point<f64, Logical>) -> bool {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1416,7 +1416,7 @@ impl<W: LayoutElement> Workspace<W> {
                     tile_size: tile.tile_size().into(),
                     window_size: tile.window().size().into(),
                     tile_pos_in_workspace_view: None,
-                    window_pos_in_workspace_view: None,
+                    window_offset_in_tile: tile.window_loc().into(),
                 },
             )
         });
@@ -1430,7 +1430,7 @@ impl<W: LayoutElement> Workspace<W> {
                     tile_size: tile.tile_size().into(),
                     window_size: tile.window().size().into(),
                     tile_pos_in_workspace_view: Some(pos.into()),
-                    window_pos_in_workspace_view: Some((pos + tile.window_loc()).into()),
+                    window_offset_in_tile: tile.window_loc().into(),
                 },
             )
         });

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1412,7 +1412,7 @@ impl<W: LayoutElement> Workspace<W> {
             (
                 tile,
                 WindowLayout {
-                    tile_pos_in_scrolling_layout: Some(pos),
+                    pos_in_scrolling_layout: Some(pos),
                     tile_size: tile.tile_size().into(),
                     window_size: tile.window().size().into(),
                     tile_pos_in_workspace_view: None,
@@ -1426,7 +1426,7 @@ impl<W: LayoutElement> Workspace<W> {
             (
                 tile,
                 WindowLayout {
-                    tile_pos_in_scrolling_layout: None,
+                    pos_in_scrolling_layout: None,
                     tile_size: tile.tile_size().into(),
                     window_size: tile.window().size().into(),
                     tile_pos_in_workspace_view: Some(pos.into()),

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1406,38 +1406,6 @@ impl<W: LayoutElement> Workspace<W> {
         self.windows_mut().find(|win| win.is_wl_surface(wl_surface))
     }
 
-    pub fn tiles_with_window_layouts(&self) -> impl Iterator<Item = (&Tile<W>, WindowLayout)> {
-        let scrolling = self.scrolling.tiles_with_workspace_positions();
-        let scrolling = scrolling.map(move |(tile, pos)| {
-            (
-                tile,
-                WindowLayout {
-                    pos_in_scrolling_layout: Some(pos),
-                    tile_size: tile.tile_size().into(),
-                    window_size: tile.window().size().into(),
-                    tile_pos_in_workspace_view: None,
-                    window_offset_in_tile: tile.window_loc().into(),
-                },
-            )
-        });
-
-        let floating = self.floating.tiles_with_render_positions();
-        let floating = floating.map(move |(tile, pos)| {
-            (
-                tile,
-                WindowLayout {
-                    pos_in_scrolling_layout: None,
-                    tile_size: tile.tile_size().into(),
-                    window_size: tile.window().size().into(),
-                    tile_pos_in_workspace_view: Some(pos.into()),
-                    window_offset_in_tile: tile.window_loc().into(),
-                },
-            )
-        });
-
-        floating.chain(scrolling)
-    }
-
     pub fn tiles_with_render_positions(
         &self,
     ) -> impl Iterator<Item = (&Tile<W>, Point<f64, Logical>, bool)> {
@@ -1456,6 +1424,12 @@ impl<W: LayoutElement> Workspace<W> {
     ) -> impl Iterator<Item = (&mut Tile<W>, Point<f64, Logical>)> {
         let scrolling = self.scrolling.tiles_with_render_positions_mut(round);
         let floating = self.floating.tiles_with_render_positions_mut(round);
+        floating.chain(scrolling)
+    }
+
+    pub fn tiles_with_ipc_layouts(&self) -> impl Iterator<Item = (&Tile<W>, WindowLayout)> {
+        let scrolling = self.scrolling.tiles_with_ipc_layouts();
+        let floating = self.floating.tiles_with_ipc_layouts();
         floating.chain(scrolling)
     }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2208,7 +2208,7 @@ impl State {
             },
         );
 
-        self.niri.layout.with_windows(|mapped, _, _| {
+        self.niri.layout.with_windows(|mapped, _, _, _| {
             let id = mapped.id().get();
             let props = with_toplevel_role(mapped.toplevel(), |role| {
                 gnome_shell_introspect::WindowProperties {
@@ -3998,7 +3998,7 @@ impl Niri {
         let mut seen = HashSet::new();
         let mut output_changed = vec![];
 
-        self.layout.with_windows(|mapped, output, _| {
+        self.layout.with_windows(|mapped, output, _, _| {
             seen.insert(mapped.window.clone());
 
             let Some(output) = output else {

--- a/src/protocols/foreign_toplevel.rs
+++ b/src/protocols/foreign_toplevel.rs
@@ -93,7 +93,7 @@ pub fn refresh(state: &mut State) {
     // Save the focused window for last, this way when the focus changes, we will first deactivate
     // the previous window and only then activate the newly focused window.
     let mut focused = None;
-    state.niri.layout.with_windows(|mapped, output, _| {
+    state.niri.layout.with_windows(|mapped, output, _, _| {
         let toplevel = mapped.toplevel();
         let wl_surface = toplevel.wl_surface();
         with_toplevel_role(toplevel, |role| {


### PR DESCRIPTION
This is a WIP draft to extend the IPC and the behavior of `niri msg -j windows` to support listing where each window is in terms of column/row indices, as well as (client-side) compute the geometry of all windows. This allows for development of much more interactive/useful status bars for niri.

- Add three new fields into `niri-ipc::Window`:
    - `tile_coordinates` -- Location of the window's tile within a workspace in terms of indices.
    - `tile_size` -- Size of the tile.
    - ~`geometry` -- [x,y,width,height] of the tile relative to the workspace's top-left corner, in pixels.~
- Add two new window events into the event stream to maintain the above state:
    - One for when a collection of tiles/windows are resized at once.
    - Another for when a collection of tiles/windows are shifted over by some number of columns.

Current limitations of this draft:
As of yet, this does not expose pos/size for both tile and window, only for the tile.
Additionally, there is no consideration of tabbed windows yet.

Discussion of the `geometry` field:
(edit: agreement has been reached to not include it, don't bother reading this paragraph)
Window state `geometry` is never actually set on the niri server side, it's computed and filled in client-side for `niri msg -j windows`. This is pretty awkward, but it seems better IMO than leaving it to every single user to implement, especially since many uses of this will be in environments such as shell scripts where doing the necessary math would suck. It might be better to make a new `niri msg window-geometries` request or something for this in particular, and remove it from Window state. It's difficult to actually set the window geometry in the server because it would require spamming the event stream a bit (but it's not a completely unreasonable amount, so this would also be feasible). 