### PR TITLE
Support nested environment variable interpolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2243,6 +2243,7 @@ dependencies = [
  "log",
  "niri-config",
  "niri-ipc",
+ "once_cell",
  "ordered-float",
  "pango",
  "pangocairo",
@@ -2253,6 +2254,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
+ "regex",
  "sd-notify",
  "serde",
  "serde_json",
@@ -2580,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "option-ext"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ libdisplay-info = "0.2.2"
 log = { version = "0.4.26", features = ["max_level_trace", "release_max_level_debug"] }
 niri-config = { version = "25.2.0", path = "niri-config" }
 niri-ipc = { version = "25.2.0", path = "niri-ipc", features = ["clap"] }
+once_cell = "1.21.1"
 ordered-float = "5.0.0"
 pango = { version = "0.20.9", features = ["v1_44"] }
 pangocairo = "0.20.7"
@@ -80,6 +81,7 @@ pipewire = { git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs.git", op
 png = "0.17.16"
 portable-atomic = { version = "1.11.0", default-features = false, features = ["float"] }
 profiling = "1.0.16"
+regex = "1.11.1"
 sd-notify = "0.4.5"
 serde.workspace = true
 serde_json.workspace = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ use niri::dbus;
 use niri::ipc::client::handle_msg;
 use niri::niri::State;
 use niri::utils::spawning::{
-    spawn, store_and_increase_nofile_rlimit, CHILD_ENV, REMOVE_ENV_RUST_BACKTRACE,
-    REMOVE_ENV_RUST_LIB_BACKTRACE,
+    spawn, store_and_increase_nofile_rlimit, resolve_environment,
+    REMOVE_ENV_RUST_BACKTRACE, REMOVE_ENV_RUST_LIB_BACKTRACE,
 };
 use niri::utils::watcher::Watcher;
 use niri::utils::{cause_panic, version, IS_SYSTEMD_SERVICE};
@@ -169,7 +169,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_default();
 
     let spawn_at_startup = mem::take(&mut config.spawn_at_startup);
-    *CHILD_ENV.write().unwrap() = mem::take(&mut config.environment);
+    resolve_environment(mem::take(&mut config.environment));
 
     store_and_increase_nofile_rlimit();
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -153,7 +153,7 @@ use crate::ui::hotkey_overlay::HotkeyOverlay;
 use crate::ui::screen_transition::{self, ScreenTransition};
 use crate::ui::screenshot_ui::{OutputScreenshot, ScreenshotUi, ScreenshotUiRenderElement};
 use crate::utils::scale::{closest_representable_scale, guess_monitor_scale};
-use crate::utils::spawning::CHILD_ENV;
+use crate::utils::spawning::resolve_environment;
 use crate::utils::{
     center, center_f64, expand_home, get_monotonic_time, ipc_transform_to_smithay, is_mapped,
     logical_output, make_screenshot_path, output_matches_name, output_size, send_scale_transform,
@@ -1181,7 +1181,7 @@ impl State {
             .clock
             .set_complete_instantly(config.animations.off);
 
-        *CHILD_ENV.write().unwrap() = mem::take(&mut config.environment);
+        resolve_environment(mem::take(&mut config.environment));
 
         let mut reload_xkb = None;
         let mut libinput_config_changed = false;

--- a/wiki/Configuration:-Miscellaneous.md
+++ b/wiki/Configuration:-Miscellaneous.md
@@ -96,10 +96,13 @@ Override environment variables for processes spawned by niri.
 ```kdl
 environment {
     // Set a variable like this:
-    // QT_QPA_PLATFORM "wayland"
+    QT_QPA_PLATFORM "wayland"
 
     // Remove a variable by using null as the value:
-    // DISPLAY null
+    DISPLAY null
+
+    // Nested variables are expanded
+    XDG_CONFIG_HOME "$HOME/.config"
 }
 ```
 


### PR DESCRIPTION
Currently, the configured `environment` doesn't expand variables that are nested inside of the values of other variables. For example, the following configuration:

```kdl
environment {
    XDG_CONFIG_HOME "$HOME/.config"
    NIRI_CONFIG "$XDG_CONFIG_HOME/niri"
    PATH "$HOME/bin:$PATH"
}
```

would assign the strings as is to the variables, leaving any nested variables intact.

This PR adds support for variable interpolation, resolving previously defined variables to their values (and undefined variables to the empty string), similar to how a shell would do it.