### PR TITLE
ci/wiki: check that (local) links are well formed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,6 @@ jobs:
         continue-on-error: true
   check-links:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,6 @@ jobs:
         continue-on-error: true
 
   check-links:
-    needs: build
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -241,7 +240,9 @@ jobs:
 
   publish-wiki:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: check-links
+    needs:
+      - build
+      - check-links
     permissions:
       contents: write
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,8 @@ jobs:
 
       - run: nix flake check
         continue-on-error: true
+
   check-links:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: lycheeverse/lychee-action@v2.0.2 # don't bump until this is fixed: https://github.com/lycheeverse/lychee/issues/1574
+      - uses: lycheeverse/lychee-action@v2.0.2 # later versions break fragment checks. don't bump until this is fixed: https://github.com/lycheeverse/lychee/issues/1574
         with:
           args: --offline --include-fragments 'wiki/*.md'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,7 @@ jobs:
         continue-on-error: true
   check-links:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,10 +227,21 @@ jobs:
 
       - run: nix flake check
         continue-on-error: true
+  check-links:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@f87f0a62993c2647717456af92593666acb3a500 # lychee v0.16.1 seems to work well for our case at the moment
+        with:
+          args: --offline --include-fragments 'wiki/*.md'
 
   publish-wiki:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
+    needs: check-links
     permissions:
       contents: write
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,9 +232,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@f87f0a62993c2647717456af92593666acb3a500 # lychee v0.16.1 seems to work well for our case at the moment
+        with:
+          show-progress: false
+      - uses: lycheeverse/lychee-action@v2.0.2 # don't bump until this is fixed: https://github.com/lycheeverse/lychee/issues/1574
         with:
           args: --offline --include-fragments 'wiki/*.md'
 

--- a/wiki/Application-Issues.md
+++ b/wiki/Application-Issues.md
@@ -9,7 +9,7 @@ Apparently, VSCode currently unconditionally queries the X server for a keymap.
 > [!NOTE]
 > Both of these issues seem to be fixed in the nightly build of WezTerm.
 
-There's [a bug](https://github.com/wez/wezterm/issues/4708) in WezTerm that it waits for a zero-sized Wayland configure event, so its window never shows up in niri. To work around it, put this window rule in the niri config (included in the default config):
+There's [a bug](https://github.com/wezterm/wezterm/issues/4708) in WezTerm that it waits for a zero-sized Wayland configure event, so its window never shows up in niri. To work around it, put this window rule in the niri config (included in the default config):
 
 ```kdl
 window-rule {
@@ -20,7 +20,7 @@ window-rule {
 
 This empty default column width lets WezTerm pick its own initial width which makes it show up properly.
 
-There's [another bug](https://github.com/wez/wezterm/issues/6472) in WezTerm that causes it to choose a wrong size when it's in a tiled state, and prevent resizing it.
+There's [another bug](https://github.com/wezterm/wezterm/issues/6472) in WezTerm that causes it to choose a wrong size when it's in a tiled state, and prevent resizing it.
 Niri puts windows in the tiled state with [`prefer-no-csd`](./Configuration:-Miscellaneous.md#prefer-no-csd).
 So if you hit this problem, comment out `prefer-no-csd` in the niri config and restart WezTerm.
 

--- a/wiki/Configuration:-Key-Bindings.md
+++ b/wiki/Configuration:-Key-Bindings.md
@@ -313,7 +313,7 @@ Actions for taking screenshots.
 - `screenshot`: opens the built-in interactive screenshot UI.
 - `screenshot-screen`, `screenshow-window`: takes a screenshot of the focused screen or window respectively.
 
-The screenshot is both stored to the clipboard and saved to disk, according to the [`screenshot-path` option](./Configuration:-Miscellaneous.md#screenshot-path-no-worky).
+The screenshot is both stored to the clipboard and saved to disk, according to the [`screenshot-path` option](./Configuration:-Miscellaneous.md#screenshot-path).
 
 <sup>Since: 25.02</sup> You can disable saving to disk for a specific bind with the `write-to-disk=false` property:
 

--- a/wiki/Configuration:-Key-Bindings.md
+++ b/wiki/Configuration:-Key-Bindings.md
@@ -313,7 +313,7 @@ Actions for taking screenshots.
 - `screenshot`: opens the built-in interactive screenshot UI.
 - `screenshot-screen`, `screenshow-window`: takes a screenshot of the focused screen or window respectively.
 
-The screenshot is both stored to the clipboard and saved to disk, according to the [`screenshot-path` option](./Configuration:-Miscellaneous#screenshot-path).
+The screenshot is both stored to the clipboard and saved to disk, according to the [`screenshot-path` option](./Configuration:-Miscellaneous.md#screenshot-path-no-worky).
 
 <sup>Since: 25.02</sup> You can disable saving to disk for a specific bind with the `write-to-disk=false` property:
 

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -657,7 +657,7 @@ window-rule {
 
 Set a scroll factor for all scroll events sent to a window.
 
-This will be multiplied with the scroll factor set for your input device in the [input section](/wiki/Configuration:-Input.md#pointing-devices).
+This will be multiplied with the scroll factor set for your input device in the [input section](./Configuration:-Input.md#pointing-devices).
 
 ```kdl
 // Make scrolling in Firefox a bit slower.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -5,7 +5,7 @@
 * [Floating Windows](./Floating-Windows.md)
 * [Tabs](./Tabs.md)
 * [Screencasting](./Screencasting.md)
-* [Layer‐Shell Components](./Layer‐Shell-Components.md)
+* [Layer‐Shell Components](./Layer%E2%80%90Shell-Components.md)
 * [IPC, `niri msg`](./IPC.md)
 * [Application-Specific Issues](./Application-Issues.md)
 * [Xwayland](./Xwayland.md)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -5,7 +5,7 @@
 * [Floating Windows](./Floating-Windows.md)
 * [Tabs](./Tabs.md)
 * [Screencasting](./Screencasting.md)
-* [Layer‐Shell Components](./Layer%E2%80%90Shell-Components.md)
+* [Layer‐Shell Components](./Layer‐Shell-Components.md)
 * [IPC, `niri msg`](./IPC.md)
 * [Application-Specific Issues](./Application-Issues.md)
 * [Xwayland](./Xwayland.md)


### PR DESCRIPTION
this change introduces a job that `publish-wiki` also depends upon (besides `build`), using [lychee](https://lychee.cli.rs/) v0.16.1 (specifically before the introduction of https://github.com/lycheeverse/lychee/issues/1574) to check that the links in our wiki are well formed and lead to places that exist.

this `check-links` step has thus far helped me find a few more trouble spots, which are also included in this PR.
the args provided to lychee ensures that only local/relative links are checked, as well as fragments/anchors.

one could consider removing `--offline`, but i ended up running into timeouts (though `--timeout n` (with a default of 20) is a valid flag that could be used to maybe mitigate some of those).

---

i've done some rudimentary tests in my fork,

- links to non-existing pages = failure
- links to non-existing anchors = failure