### PR TITLE
Implement windowed/fake/detached fullscreen

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1476,6 +1476,9 @@ pub enum Action {
     FullscreenWindow,
     #[knuffel(skip)]
     FullscreenWindowById(u64),
+    ToggleWindowedFullscreen,
+    #[knuffel(skip)]
+    ToggleWindowedFullscreenById(u64),
     #[knuffel(skip)]
     FocusWindow(u64),
     FocusWindowInColumn(#[knuffel(argument)] u8),
@@ -1680,6 +1683,12 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::CloseWindow { id: Some(id) } => Self::CloseWindowById(id),
             niri_ipc::Action::FullscreenWindow { id: None } => Self::FullscreenWindow,
             niri_ipc::Action::FullscreenWindow { id: Some(id) } => Self::FullscreenWindowById(id),
+            niri_ipc::Action::ToggleWindowedFullscreen { id: None } => {
+                Self::ToggleWindowedFullscreen
+            }
+            niri_ipc::Action::ToggleWindowedFullscreen { id: Some(id) } => {
+                Self::ToggleWindowedFullscreenById(id)
+            }
             niri_ipc::Action::FocusWindow { id } => Self::FocusWindow(id),
             niri_ipc::Action::FocusWindowInColumn { index } => Self::FocusWindowInColumn(index),
             niri_ipc::Action::FocusWindowPrevious {} => Self::FocusWindowPrevious,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -221,6 +221,18 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(long))]
         id: Option<u64>,
     },
+    /// Toggle windowed (fake) fullscreen on a window.
+    #[cfg_attr(
+        feature = "clap",
+        clap(about = "Toggle windowed (fake) fullscreen on the focused window")
+    )]
+    ToggleWindowedFullscreen {
+        /// Id of the window to toggle windowed fullscreen of.
+        ///
+        /// If `None`, uses the focused window.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: Option<u64>,
+    },
     /// Focus a window by id.
     FocusWindow {
         /// Id of the window to focus.

--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -163,6 +163,7 @@ impl Layout {
         window.request_size(
             ws.new_window_size(width, None, false, window.rules(), (min_size, max_size)),
             false,
+            false,
             None,
         );
         window.communicate();
@@ -190,6 +191,7 @@ impl Layout {
         let max_size = window.max_size();
         window.request_size(
             ws.new_window_size(width, None, false, window.rules(), (min_size, max_size)),
+            false,
             false,
             None,
         );

--- a/niri-visual-tests/src/cases/window.rs
+++ b/niri-visual-tests/src/cases/window.rs
@@ -14,14 +14,14 @@ pub struct Window {
 impl Window {
     pub fn freeform(args: Args) -> Self {
         let mut window = TestWindow::freeform(0);
-        window.request_size(args.size, false, None);
+        window.request_size(args.size, false, false, None);
         window.communicate();
         Self { window }
     }
 
     pub fn fixed_size(args: Args) -> Self {
         let mut window = TestWindow::fixed_size(0);
-        window.request_size(args.size, false, None);
+        window.request_size(args.size, false, false, None);
         window.communicate();
         Self { window }
     }
@@ -29,7 +29,7 @@ impl Window {
     pub fn fixed_size_with_csd_shadow(args: Args) -> Self {
         let mut window = TestWindow::fixed_size(0);
         window.set_csd_shadow_width(64);
-        window.request_size(args.size, false, None);
+        window.request_size(args.size, false, false, None);
         window.communicate();
         Self { window }
     }
@@ -38,7 +38,7 @@ impl Window {
 impl TestCase for Window {
     fn resize(&mut self, width: i32, height: i32) {
         self.window
-            .request_size(Size::from((width, height)), false, None);
+            .request_size(Size::from((width, height)), false, false, None);
         self.window.communicate();
     }
 

--- a/niri-visual-tests/src/test_window.rs
+++ b/niri-visual-tests/src/test_window.rs
@@ -182,15 +182,12 @@ impl LayoutElement for TestWindow {
     fn request_size(
         &mut self,
         size: Size<i32, Logical>,
+        is_fullscreen: bool,
         _animate: bool,
         _transaction: Option<Transaction>,
     ) {
         self.inner.borrow_mut().requested_size = Some(size);
-        self.inner.borrow_mut().pending_fullscreen = false;
-    }
-
-    fn request_fullscreen(&mut self, _size: Size<i32, Logical>) {
-        self.inner.borrow_mut().pending_fullscreen = true;
+        self.inner.borrow_mut().pending_fullscreen = is_fullscreen;
     }
 
     fn min_size(&self) -> Size<i32, Logical> {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -690,6 +690,23 @@ impl State {
                     self.niri.queue_redraw_all();
                 }
             }
+            Action::ToggleWindowedFullscreen => {
+                let focus = self.niri.layout.focus().map(|m| m.window.clone());
+                if let Some(window) = focus {
+                    self.niri.layout.toggle_windowed_fullscreen(&window);
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
+            Action::ToggleWindowedFullscreenById(id) => {
+                let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
+                let window = window.map(|(_, m)| m.window.clone());
+                if let Some(window) = window {
+                    self.niri.layout.toggle_windowed_fullscreen(&window);
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
             Action::FocusWindow(id) => {
                 let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
                 let window = window.map(|(_, m)| m.window.clone());

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -3457,31 +3457,31 @@ impl<W: LayoutElement> Layout<W> {
         res
     }
 
-    pub fn set_fullscreen(&mut self, window: &W::Id, is_fullscreen: bool) {
+    pub fn set_fullscreen(&mut self, id: &W::Id, is_fullscreen: bool) {
         if let Some(InteractiveMoveState::Moving(move_)) = &self.interactive_move {
-            if move_.tile.window().id() == window {
+            if move_.tile.window().id() == id {
                 return;
             }
         }
 
         for ws in self.workspaces_mut() {
-            if ws.has_window(window) {
-                ws.set_fullscreen(window, is_fullscreen);
+            if ws.has_window(id) {
+                ws.set_fullscreen(id, is_fullscreen);
                 return;
             }
         }
     }
 
-    pub fn toggle_fullscreen(&mut self, window: &W::Id) {
+    pub fn toggle_fullscreen(&mut self, id: &W::Id) {
         if let Some(InteractiveMoveState::Moving(move_)) = &self.interactive_move {
-            if move_.tile.window().id() == window {
+            if move_.tile.window().id() == id {
                 return;
             }
         }
 
         for ws in self.workspaces_mut() {
-            if ws.has_window(window) {
-                ws.toggle_fullscreen(window);
+            if ws.has_window(id) {
+                ws.toggle_fullscreen(id);
                 return;
             }
         }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2337,6 +2337,8 @@ impl<W: LayoutElement> Layout<W> {
                     assert_eq!(self.clock, move_.tile.clock);
                     assert!(!move_.tile.window().is_pending_fullscreen());
 
+                    move_.tile.verify_invariants();
+
                     let scale = move_.output.current_scale().fractional_scale();
                     let options = Options::clone(&self.options).adjusted_for_scale(scale);
                     assert_eq!(

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -3457,24 +3457,10 @@ impl<W: LayoutElement> Layout<W> {
             }
         }
 
-        match &mut self.monitor_set {
-            MonitorSet::Normal { monitors, .. } => {
-                for mon in monitors {
-                    for ws in &mut mon.workspaces {
-                        if ws.has_window(window) {
-                            ws.set_fullscreen(window, is_fullscreen);
-                            return;
-                        }
-                    }
-                }
-            }
-            MonitorSet::NoOutputs { workspaces, .. } => {
-                for ws in workspaces {
-                    if ws.has_window(window) {
-                        ws.set_fullscreen(window, is_fullscreen);
-                        return;
-                    }
-                }
+        for ws in self.workspaces_mut() {
+            if ws.has_window(window) {
+                ws.set_fullscreen(window, is_fullscreen);
+                return;
             }
         }
     }
@@ -3486,24 +3472,10 @@ impl<W: LayoutElement> Layout<W> {
             }
         }
 
-        match &mut self.monitor_set {
-            MonitorSet::Normal { monitors, .. } => {
-                for mon in monitors {
-                    for ws in &mut mon.workspaces {
-                        if ws.has_window(window) {
-                            ws.toggle_fullscreen(window);
-                            return;
-                        }
-                    }
-                }
-            }
-            MonitorSet::NoOutputs { workspaces, .. } => {
-                for ws in workspaces {
-                    if ws.has_window(window) {
-                        ws.toggle_fullscreen(window);
-                        return;
-                    }
-                }
+        for ws in self.workspaces_mut() {
+            if ws.has_window(window) {
+                ws.toggle_fullscreen(window);
+                return;
             }
         }
     }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1189,6 +1189,11 @@ impl<W: LayoutElement> Layout<W> {
     pub fn update_window(&mut self, window: &W::Id, serial: Option<Serial>) {
         if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
             if move_.tile.window().id() == window {
+                // Do this before calling update_window() so it can get up-to-date info.
+                if let Some(serial) = serial {
+                    move_.tile.window_mut().on_commit(serial);
+                }
+
                 move_.tile.update_window();
                 return;
             }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -176,16 +176,15 @@ pub trait LayoutElement {
     fn request_size(
         &mut self,
         size: Size<i32, Logical>,
+        is_fullscreen: bool,
         animate: bool,
         transaction: Option<Transaction>,
     );
 
     /// Requests the element to change size once, clearing the request afterwards.
     fn request_size_once(&mut self, size: Size<i32, Logical>, animate: bool) {
-        self.request_size(size, animate, None);
+        self.request_size(size, false, animate, None);
     }
-
-    fn request_fullscreen(&mut self, size: Size<i32, Logical>);
 
     fn min_size(&self) -> Size<i32, Logical>;
     fn max_size(&self) -> Size<i32, Logical>;
@@ -206,12 +205,12 @@ pub trait LayoutElement {
 
     /// Whether the element is currently fullscreen.
     ///
-    /// This will *not* switch immediately after a [`LayoutElement::request_fullscreen()`] call.
+    /// This will *not* switch immediately after a [`LayoutElement::request_size()`] call.
     fn is_fullscreen(&self) -> bool;
 
     /// Whether we're requesting the element to be fullscreen.
     ///
-    /// This *will* switch immediately after a [`LayoutElement::request_fullscreen()`] call.
+    /// This *will* switch immediately after a [`LayoutElement::request_size()`] call.
     fn is_pending_fullscreen(&self) -> bool;
 
     /// Size previously requested through [`LayoutElement::request_size()`].

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2335,6 +2335,7 @@ impl<W: LayoutElement> Layout<W> {
                 }
                 InteractiveMoveState::Moving(move_) => {
                     assert_eq!(self.clock, move_.tile.clock);
+                    assert!(!move_.tile.window().is_pending_fullscreen());
 
                     let scale = move_.output.current_scale().fractional_scale();
                     let options = Options::clone(&self.options).adjusted_for_scale(scale);

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4018,14 +4018,18 @@ impl<W: LayoutElement> Column<W> {
         let min_size: Vec<_> = self
             .tiles
             .iter()
-            .map(Tile::min_size)
+            .map(Tile::min_size_nonfullscreen)
             .map(|mut size| {
                 size.w = size.w.max(1.);
                 size.h = size.h.max(1.);
                 size
             })
             .collect();
-        let max_size: Vec<_> = self.tiles.iter().map(Tile::max_size).collect();
+        let max_size: Vec<_> = self
+            .tiles
+            .iter()
+            .map(Tile::max_size_nonfullscreen)
+            .collect();
 
         // Compute the column width.
         let min_width = min_size
@@ -4517,7 +4521,7 @@ impl<W: LayoutElement> Column<W> {
                 .iter()
                 .enumerate()
                 .filter(|(idx, _)| *idx != tile_idx)
-                .map(|(_, tile)| f64::max(1., tile.min_size().h) + gaps)
+                .map(|(_, tile)| f64::max(1., tile.min_size_nonfullscreen().h) + gaps)
                 .sum::<f64>()
         };
         let height_left = working_size - extra_size - gaps - min_height_taken - gaps;
@@ -4947,7 +4951,7 @@ impl<W: LayoutElement> Column<W> {
             let requested_size = tile.window().requested_size().unwrap();
             let requested_tile_height =
                 tile.tile_height_for_window_height(f64::from(requested_size.h));
-            let min_tile_height = f64::max(1., tile.min_size().h);
+            let min_tile_height = f64::max(1., tile.min_size_nonfullscreen().h);
 
             if !self.is_fullscreen
                 && self.scale.round() == self.scale

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -3999,8 +3999,16 @@ impl<W: LayoutElement> Column<W> {
 
     fn update_tile_sizes_with_transaction(&mut self, animate: bool, transaction: Transaction) {
         if self.is_fullscreen {
-            for tile in &mut self.tiles {
-                tile.request_fullscreen();
+            for (tile_idx, tile) in self.tiles.iter_mut().enumerate() {
+                // In tabbed mode, only the visible window participates in the transaction.
+                let is_active = tile_idx == self.active_tile_idx;
+                let transaction = if self.display_mode == ColumnDisplay::Tabbed && !is_active {
+                    None
+                } else {
+                    Some(transaction.clone())
+                };
+
+                tile.request_fullscreen(animate, transaction);
             }
             return;
         }

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -129,15 +129,12 @@ impl LayoutElement for TestWindow {
     fn request_size(
         &mut self,
         size: Size<i32, Logical>,
+        is_fullscreen: bool,
         _animate: bool,
         _transaction: Option<Transaction>,
     ) {
         self.0.requested_size.set(Some(size));
-        self.0.pending_fullscreen.set(false);
-    }
-
-    fn request_fullscreen(&mut self, _size: Size<i32, Logical>) {
-        self.0.pending_fullscreen.set(true);
+        self.0.pending_fullscreen.set(is_fullscreen);
     }
 
     fn min_size(&self) -> Size<i32, Logical> {

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -758,10 +758,13 @@ impl<W: LayoutElement> Tile<W> {
             .request_size(self.view_size.to_i32_round(), true, animate, transaction);
     }
 
-    pub fn min_size(&self) -> Size<f64, Logical> {
+    pub fn min_size_nonfullscreen(&self) -> Size<f64, Logical> {
         let mut size = self.window.min_size().to_f64();
 
-        if let Some(width) = self.effective_border_width() {
+        // Can't go through effective_border_width() because we might be fullscreen.
+        if !self.border.is_off() {
+            let width = self.border.width();
+
             size.w = f64::max(1., size.w);
             size.h = f64::max(1., size.h);
 
@@ -772,10 +775,13 @@ impl<W: LayoutElement> Tile<W> {
         size
     }
 
-    pub fn max_size(&self) -> Size<f64, Logical> {
+    pub fn max_size_nonfullscreen(&self) -> Size<f64, Logical> {
         let mut size = self.window.max_size().to_f64();
 
-        if let Some(width) = self.effective_border_width() {
+        // Can't go through effective_border_width() because we might be fullscreen.
+        if !self.border.is_off() {
+            let width = self.border.width();
+
             if size.w > 0. {
                 size.w += width * 2.;
             }

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -718,7 +718,7 @@ impl<W: LayoutElement> Tile<W> {
         // round to avoid situations where proportionally-sized columns don't fit on the screen
         // exactly.
         self.window
-            .request_size(size.to_i32_floor(), animate, transaction);
+            .request_size(size.to_i32_floor(), false, animate, transaction);
     }
 
     pub fn tile_width_for_window_width(&self, size: f64) -> f64 {
@@ -753,9 +753,9 @@ impl<W: LayoutElement> Tile<W> {
         }
     }
 
-    pub fn request_fullscreen(&mut self) {
+    pub fn request_fullscreen(&mut self, animate: bool, transaction: Option<Transaction>) {
         self.window
-            .request_fullscreen(self.view_size.to_i32_round());
+            .request_size(self.view_size.to_i32_round(), true, animate, transaction);
     }
 
     pub fn min_size(&self) -> Size<f64, Logical> {

--- a/src/tests/fullscreen.rs
+++ b/src/tests/fullscreen.rs
@@ -1,0 +1,155 @@
+use client::ClientId;
+use insta::assert_snapshot;
+use wayland_client::protocol::wl_surface::WlSurface;
+
+use super::*;
+use crate::layout::LayoutElement as _;
+
+// Sets up a fixture with two outputs and 100×100 window.
+fn set_up() -> (Fixture, ClientId, WlSurface) {
+    let mut f = Fixture::new();
+    f.add_output(1, (1920, 1080));
+    f.add_output(2, (1280, 720));
+
+    let id = f.add_client();
+    let window = f.client(id).create_window();
+    let surface = window.surface.clone();
+    window.commit();
+    f.roundtrip(id);
+
+    let window = f.client(id).window(&surface);
+    window.attach_new_buffer();
+    window.set_size(100, 100);
+    window.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    (f, id, surface)
+}
+
+#[test]
+fn windowed_fullscreen() {
+    let (mut f, id, surface) = set_up();
+
+    let _ = f.client(id).window(&surface).recent_configures();
+
+    let niri = f.niri();
+    let mapped = niri.layout.windows().next().unwrap().1;
+    let window_id = mapped.window.clone();
+
+    // Enable windowed fullscreen.
+    niri.layout.toggle_windowed_fullscreen(&window_id);
+    f.double_roundtrip(id);
+
+    // Should request fullscreen state with the tiled size.
+    let window = f.client(id).window(&surface);
+    assert_snapshot!(
+        window.format_recent_configures(),
+        @"size: 936 × 1048, bounds: 1888 × 1048, states: [Activated, Fullscreen]"
+    );
+
+    let mapped = f.niri().layout.windows().next().unwrap().1;
+    // Not committed yet.
+    assert!(!mapped.is_windowed_fullscreen());
+
+    // Commit in response.
+    let window = f.client(id).window(&surface);
+    window.ack_last_and_commit();
+    f.roundtrip(id);
+
+    let mapped = f.niri().layout.windows().next().unwrap().1;
+    // Now it is committed.
+    assert!(mapped.is_windowed_fullscreen());
+
+    // Disable windowed fullscreen.
+    f.niri().layout.toggle_windowed_fullscreen(&window_id);
+    f.double_roundtrip(id);
+
+    // Should request without fullscreen state with the tiled size.
+    let window = f.client(id).window(&surface);
+    assert_snapshot!(
+        window.format_recent_configures(),
+        @"size: 936 × 1048, bounds: 1888 × 1048, states: [Activated]"
+    );
+
+    let mapped = f.niri().layout.windows().next().unwrap().1;
+    // Not commited yet.
+    assert!(mapped.is_windowed_fullscreen());
+
+    // Commit in response.
+    let window = f.client(id).window(&surface);
+    window.ack_last_and_commit();
+    f.roundtrip(id);
+
+    let mapped = f.niri().layout.windows().next().unwrap().1;
+    // Now it is committed.
+    assert!(!mapped.is_windowed_fullscreen());
+}
+
+#[test]
+fn windowed_fullscreen_chain() {
+    let (mut f, id, surface) = set_up();
+
+    let _ = f.client(id).window(&surface).recent_configures();
+
+    let mapped = f.niri().layout.windows().next().unwrap().1;
+    let window_id = mapped.window.clone();
+
+    f.niri().layout.toggle_windowed_fullscreen(&window_id);
+    f.roundtrip(id);
+    f.niri().layout.toggle_windowed_fullscreen(&window_id);
+    f.roundtrip(id);
+    f.niri().layout.toggle_windowed_fullscreen(&window_id);
+    f.roundtrip(id);
+    f.niri().layout.toggle_windowed_fullscreen(&window_id);
+    f.double_roundtrip(id);
+
+    // Should be four configures matching the four requests.
+    let window = f.client(id).window(&surface);
+    assert_snapshot!(
+        window.format_recent_configures(),
+        @r"
+    size: 936 × 1048, bounds: 1888 × 1048, states: [Activated, Fullscreen]
+    size: 936 × 1048, bounds: 1888 × 1048, states: [Activated]
+    size: 936 × 1048, bounds: 1888 × 1048, states: [Activated, Fullscreen]
+    size: 936 × 1048, bounds: 1888 × 1048, states: [Activated]
+    "
+    );
+
+    let window = f.client(id).window(&surface);
+    let serials = Vec::from_iter(
+        window.configures_received[window.configures_received.len() - 4..]
+            .iter()
+            .map(|(s, _c)| *s),
+    );
+
+    let get_state = |f: &mut Fixture| {
+        let mapped = f.niri().layout.windows().next().unwrap().1;
+        format!(
+            "fs {}, wfs {}",
+            mapped.is_fullscreen(),
+            mapped.is_windowed_fullscreen()
+        )
+    };
+
+    let mut states = vec![get_state(&mut f)];
+    for serial in serials {
+        let window = f.client(id).window(&surface);
+        window.xdg_surface.ack_configure(serial);
+        window.commit();
+        f.roundtrip(id);
+        states.push(get_state(&mut f));
+    }
+
+    // We expect fs to always be false (because each Fullscreen state request corresponded to a
+    // windowed fullscreen), and wfs to toggle on and off.
+    assert_snapshot!(
+        states.join("\n"),
+        @r"
+    fs false, wfs false
+    fs false, wfs true
+    fs false, wfs false
+    fs false, wfs true
+    fs false, wfs false
+    "
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,4 +5,5 @@ mod fixture;
 mod server;
 
 mod floating;
+mod fullscreen;
 mod window_opening;

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -604,13 +604,18 @@ impl LayoutElement for Mapped {
     fn request_size(
         &mut self,
         size: Size<i32, Logical>,
+        is_fullscreen: bool,
         animate: bool,
         transaction: Option<Transaction>,
     ) {
         let changed = self.toplevel().with_pending_state(|state| {
             let changed = state.size != Some(size);
             state.size = Some(size);
-            state.states.unset(xdg_toplevel::State::Fullscreen);
+            if is_fullscreen {
+                state.states.set(xdg_toplevel::State::Fullscreen);
+            } else {
+                state.states.unset(xdg_toplevel::State::Fullscreen);
+            }
             changed
         });
 
@@ -691,15 +696,6 @@ impl LayoutElement for Mapped {
         }
 
         self.request_size_once = Some(RequestSizeOnce::WaitingForConfigure);
-    }
-
-    fn request_fullscreen(&mut self, size: Size<i32, Logical>) {
-        self.toplevel().with_pending_state(|state| {
-            state.size = Some(size);
-            state.states.set(xdg_toplevel::State::Fullscreen);
-        });
-
-        self.request_size_once = None;
     }
 
     fn min_size(&self) -> Size<i32, Logical> {

--- a/wiki/Screencasting.md
+++ b/wiki/Screencasting.md
@@ -111,4 +111,26 @@ Example:
 
 ![Screencasted window indicated with a red border and shadow.](https://github.com/user-attachments/assets/375b381e-3a87-4e94-8676-44404971d893)
 
+### Windowed (fake/detached) fullscreen
+
+<sup>Since: next release</sup>
+
+When screencasting browser-based presentations like Google Slides, you usually want to hide the browser UI, which requires making the browser fullscreen.
+This is not always convenient, for example if you have an ultrawide monitor, or just want to leave the browser as a smaller window, without taking up an entire monitor.
+
+The `toggle-windowed-fullscreen` bind helps with this.
+It tells the app that it went fullscreen, while in reality leaving it as a normal window that you can resize and put wherever you want.
+
+```kdl
+binds {
+    Mod+Ctrl+Shift+F { toggle-windowed-fullscreen; }
+}
+```
+
+Keep in mind that not all apps react to fullscreening, so it may sometimes look as if the bind did nothing.
+
+Here's an example showing a windowed-fullscreen Google Slides presentation, along with the presenter view and a meeting app:
+
+![Windowed Google Slides presentation, another window showing the presenter view, and another window showing Zoom UI casting the presentation.](https://github.com/user-attachments/assets/b2b49eea-f5a0-4c0a-b537-51fd1949a59d)
+
 [OBS]: https://obsproject.com/


### PR DESCRIPTION
New action: `toggle-windowed-fullscreen`. Should do what you'd expect.

Useful for screencasting various google docs and slides to hide the browser UI, while still keeping it a window.

Wow this was harder than it would seem. The main problem is that all existing layout code assumes that `mapped.is_fullscreen()` cannot change immediately, and with windowed fullscreen it sometimes can. After trying different workarounds, I had to do it close to the "right way", which also seems to be the ultimately correct way.

~~There's still one minor issue left: sometimes the window will flicker if it redraws just as you toggle off windowed fullscreen. I'll fix it before merging.~~ Now fixed.