### PR TITLE
wiki: Mention file chooser dependency and settings for portals

### DIFF
--- a/wiki/Important-Software.md
+++ b/wiki/Important-Software.md
@@ -22,6 +22,8 @@ Since we're using `xdg-desktop-portal-gnome`, Flatpak apps will read the GNOME U
 dconf write /org/gnome/desktop/interface/color-scheme '"prefer-dark"'
 ```
 
+Note that if you're using the provided `resources/niri-portals.conf`, you also need to install the `nautilus` file manager in order for file chooser dialogues to work properly. If you do not want to install `natuilus` (say you use `nemo` instead), you need to set `org.freedesktop.impl.portal.FileChooser=gtk;` in `niri-portals.conf` to use the GTK portal for file chooser dialogues.
+
 ### Authentication Agent
 
 Required when apps need to ask for root permissions. Something like `plasma-polkit-agent` works fine. Start it [with systemd](./Example-systemd-Setup.md) or with [`spawn-at-startup`](./Configuration:-Miscellaneous.md#spawn-at-startup).


### PR DESCRIPTION
Added to hopefully prevent confusion as seen in #1206 and #1284.