### PR TITLE
Reverse `switch-preset-column-width`

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1673,6 +1673,8 @@ pub enum Action {
     #[knuffel(skip)]
     ResetWindowHeightById(u64),
     SwitchPresetColumnWidth,
+    SwitchPresetColumnWidthNext,
+    SwitchPresetColumnWidthPrev,
     SwitchPresetWindowWidth,
     #[knuffel(skip)]
     SwitchPresetWindowWidthById(u64),
@@ -1897,6 +1899,8 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::ResetWindowHeight { id: None } => Self::ResetWindowHeight,
             niri_ipc::Action::ResetWindowHeight { id: Some(id) } => Self::ResetWindowHeightById(id),
             niri_ipc::Action::SwitchPresetColumnWidth {} => Self::SwitchPresetColumnWidth,
+            niri_ipc::Action::SwitchPresetColumnWidthNext {} => Self::SwitchPresetColumnWidthNext,
+            niri_ipc::Action::SwitchPresetColumnWidthPrev {} => Self::SwitchPresetColumnWidthPrev,
             niri_ipc::Action::SwitchPresetWindowWidth { id: None } => Self::SwitchPresetWindowWidth,
             niri_ipc::Action::SwitchPresetWindowWidth { id: Some(id) } => {
                 Self::SwitchPresetWindowWidthById(id)

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -603,6 +603,10 @@ pub enum Action {
     },
     /// Switch between preset column widths.
     SwitchPresetColumnWidth {},
+    /// Switch between preset column widths.
+    SwitchPresetColumnWidthNext {},
+    /// Switch between preset column widths.
+    SwitchPresetColumnWidthPrev {},
     /// Switch between preset window widths.
     SwitchPresetWindowWidth {
         /// Id of the window whose width to switch.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1362,6 +1362,12 @@ impl State {
             Action::SwitchPresetColumnWidth => {
                 self.niri.layout.toggle_width();
             }
+            Action::SwitchPresetColumnWidthNext => {
+                self.niri.layout.increment_width();
+            }
+            Action::SwitchPresetColumnWidthPrev => {
+                self.niri.layout.decrement_width();
+            }
             Action::SwitchPresetWindowWidth => {
                 self.niri.layout.toggle_window_width(None);
             }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2888,6 +2888,20 @@ impl<W: LayoutElement> Layout<W> {
         self.options = options;
     }
 
+    pub fn increment_width(&mut self) {
+        let Some(workspace) = self.active_workspace_mut() else {
+            return;
+        };
+        workspace.increment_width();
+    }
+
+    pub fn decrement_width(&mut self) {
+        let Some(workspace) = self.active_workspace_mut() else {
+            return;
+        };
+        workspace.decrement_width();
+    }
+
     pub fn toggle_width(&mut self) {
         let Some(workspace) = self.active_workspace_mut() else {
             return;

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4386,7 +4386,7 @@ impl<W: LayoutElement> Column<W> {
         self.preset_width_idx = Some(preset_idx);
     }
 
-    fn toggle_width(&mut self, tile_idx: Option<usize>) {
+    fn cycle_width(&mut self, steps: i32, tile_idx: Option<usize>, wraparound: bool) {
         let tile_idx = tile_idx.unwrap_or(self.active_tile_idx);
 
         let preset_idx = if self.is_full_width {
@@ -4396,7 +4396,19 @@ impl<W: LayoutElement> Column<W> {
         };
 
         let preset_idx = if let Some(idx) = preset_idx {
-            (idx + 1) % self.options.preset_column_widths.len()
+            let signed_idx = if !wraparound
+                && ((idx == 0 && steps < 0)
+                    || (idx == self.options.preset_column_widths.len() - 1 && steps > 0))
+            {
+                idx as i32
+            } else {
+                idx as i32 + steps % self.options.preset_column_widths.len() as i32
+            };
+            if signed_idx < 0 {
+                (signed_idx + self.options.preset_column_widths.len() as i32) as usize
+            } else {
+                signed_idx as usize % self.options.preset_column_widths.len()
+            }
         } else {
             let tile = &self.tiles[tile_idx];
             let current_window = tile.window_expected_or_current_size().w;
@@ -4416,6 +4428,10 @@ impl<W: LayoutElement> Column<W> {
         };
 
         self.select_width(preset_idx, Some(tile_idx));
+    }
+
+    fn toggle_width(&mut self, tile_idx: Option<usize>) {
+        self.cycle_width(1, tile_idx, true);
     }
 
     fn toggle_full_width(&mut self) {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4379,6 +4379,13 @@ impl<W: LayoutElement> Column<W> {
         true
     }
 
+    fn select_width(&mut self, preset_idx: usize, tile_idx: Option<usize>) {
+        let tile_idx = tile_idx.unwrap_or(self.active_tile_idx);
+        let preset = self.options.preset_column_widths[preset_idx];
+        self.set_column_width(SizeChange::from(preset), Some(tile_idx), true);
+        self.preset_width_idx = Some(preset_idx);
+    }
+
     fn toggle_width(&mut self, tile_idx: Option<usize>) {
         let tile_idx = tile_idx.unwrap_or(self.active_tile_idx);
 
@@ -4408,10 +4415,7 @@ impl<W: LayoutElement> Column<W> {
                 .unwrap_or(0)
         };
 
-        let preset = self.options.preset_column_widths[preset_idx];
-        self.set_column_width(SizeChange::from(preset), Some(tile_idx), true);
-
-        self.preset_width_idx = Some(preset_idx);
+        self.select_width(preset_idx, Some(tile_idx));
     }
 
     fn toggle_full_width(&mut self) {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2420,6 +2420,28 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         cancel_resize_for_column(&mut self.interactive_resize, col);
     }
 
+    pub fn increment_width(&mut self) {
+        if self.columns.is_empty() {
+            return;
+        }
+
+        let col = &mut self.columns[self.active_column_idx];
+        col.cycle_width(1, None, false);
+
+        cancel_resize_for_column(&mut self.interactive_resize, col);
+    }
+
+    pub fn decrement_width(&mut self) {
+        if self.columns.is_empty() {
+            return;
+        }
+
+        let col = &mut self.columns[self.active_column_idx];
+        col.cycle_width(-1, None, false);
+
+        cancel_resize_for_column(&mut self.interactive_resize, col);
+    }
+
     pub fn toggle_full_width(&mut self) {
         if self.columns.is_empty() {
             return;

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1068,6 +1068,22 @@ impl<W: LayoutElement> Workspace<W> {
         }
     }
 
+    pub fn increment_width(&mut self) {
+        if self.floating_is_active.get() {
+            self.floating.toggle_window_width(None);
+        } else {
+            self.scrolling.increment_width();
+        }
+    }
+
+    pub fn decrement_width(&mut self) {
+        if self.floating_is_active.get() {
+            self.floating.toggle_window_width(None);
+        } else {
+            self.scrolling.decrement_width();
+        }
+    }
+
     pub fn toggle_width(&mut self) {
         if self.floating_is_active.get() {
             self.floating.toggle_window_width(None);

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -428,6 +428,12 @@ fn action_name(action: &Action) -> String {
         Action::MoveWindowToWorkspaceDown => String::from("Move Window to Workspace Down"),
         Action::MoveWindowToWorkspaceUp => String::from("Move Window to Workspace Up"),
         Action::SwitchPresetColumnWidth => String::from("Switch Preset Column Widths"),
+        Action::SwitchPresetColumnWidthNext => {
+            String::from("Switch to Next Preset Column Width if possible")
+        }
+        Action::SwitchPresetColumnWidthPrev => {
+            String::from("Switch to Previous Preset Column Width if possible")
+        }
         Action::MaximizeColumn => String::from("Maximize Column"),
         Action::ConsumeOrExpelWindowLeft => String::from("Consume or Expel Window Left"),
         Action::ConsumeOrExpelWindowRight => String::from("Consume or Expel Window Right"),


### PR DESCRIPTION
Support `switch-preset-column-width` in reverse order as well as switching presets without wraparound. Implements #1000