### PR TITLE
Allow a user to disable all Input

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1716,6 +1716,8 @@ pub enum Action {
     SetDynamicCastWindowById(u64),
     SetDynamicCastMonitor(#[knuffel(argument)] Option<String>),
     ClearDynamicCastTarget,
+    #[knuffel(skip)]
+    InhibitInput(bool),
 }
 
 impl From<niri_ipc::Action> for Action {
@@ -1980,6 +1982,7 @@ impl From<niri_ipc::Action> for Action {
                 Self::SetDynamicCastMonitor(output)
             }
             niri_ipc::Action::ClearDynamicCastTarget {} => Self::ClearDynamicCastTarget,
+            niri_ipc::Action::InhibitInput { inhibited } => Self::InhibitInput(inhibited),
         }
     }
 }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -214,6 +214,12 @@ pub enum Action {
     },
     /// Enable or disable the keyboard shortcuts inhibitor (if any) for the focused surface.
     ToggleKeyboardShortcutsInhibit {},
+    /// Enable or disable input processing.
+    InhibitInput {
+        /// Whether input should be inhibited.
+        #[cfg_attr(feature = "clap", arg(long))]
+        inhibited: bool,
+    },
     /// Close a window.
     #[cfg_attr(feature = "clap", clap(about = "Close the focused window"))]
     CloseWindow {

--- a/src/idle/mod.rs
+++ b/src/idle/mod.rs
@@ -1,0 +1,11 @@
+fn lock(&mut self) {
+    // Prevent locking if input is currently inhibited.
+    if self.niri.input_inhibited {
+        debug!("Screen lock prevented because input is inhibited");
+        return;
+    }
+
+    if self.niri.is_locked() {
+        return;
+    }
+} 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -388,6 +388,9 @@ pub struct Niri {
     /// Window ID for the "dynamic cast" special window for the xdp-gnome picker.
     #[cfg(feature = "xdp-gnome-screencast")]
     pub dynamic_cast_id_for_portal: MappedId,
+
+    /// Whether Niri should ignore input events.
+    pub input_inhibited: bool,
 }
 
 #[derive(Debug)]
@@ -2435,6 +2438,9 @@ impl Niri {
 
             #[cfg(feature = "xdp-gnome-screencast")]
             dynamic_cast_id_for_portal: MappedId::next(),
+
+            // Whether Niri should ignore input events.
+            input_inhibited: false,
         };
 
         niri.reset_pointer_inactivity_timer();


### PR DESCRIPTION
This is not expected to get merged or used, Just wanted to share something I found useful.  I'm building a niri2vnc client  to work like my old x2vnc and I needed to disable all Input via the IPC. I'm no Rust Dev,  It's all vibe coded. Works perfectly for me.