### PR TITLE
Fix pointer hiding so that it is no longer annoying

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -211,7 +211,7 @@ impl PointerConstraintsHandler for State {
         pointer.set_location(target);
 
         // Redraw to update the cursor position if it's visible.
-        if !self.niri.pointer_hidden {
+        if self.niri.pointer_visibility.is_visible() {
             // FIXME: redraw only outputs overlapping the cursor.
             self.niri.queue_redraw_all();
         }
@@ -369,7 +369,7 @@ impl ClientDndGrabHandler for State {
             // parameters from Smithay I guess.
             //
             // Assume that hidden pointer means touch DnD.
-            if !self.niri.pointer_hidden {
+            if self.niri.pointer_visibility.is_visible() {
                 // We can't even get the current pointer location because it's locked (we're deep
                 // in the grab call stack here). So use the last known one.
                 if let Some(output) = &self.niri.pointer_contents.output {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -477,8 +477,8 @@ impl State {
         }
 
         // niri keeps this set only while actively using a tablet, which means the cursor position
-        // is likely to change almost immediately, causing pointer_hidden to just flicker back and
-        // forth.
+        // is likely to change almost immediately, causing pointer_visibility to just flicker back
+        // and forth.
         if self.niri.tablet_cursor_location.is_some() {
             return;
         }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -42,7 +42,7 @@ use self::resize_grab::ResizeGrab;
 use self::spatial_movement_grab::SpatialMovementGrab;
 use crate::layout::scrolling::ScrollDirection;
 use crate::layout::{ActivateWindow, LayoutElement as _};
-use crate::niri::{CastTarget, State};
+use crate::niri::{CastTarget, PointerVisibility, State};
 use crate::ui::screenshot_ui::ScreenshotUi;
 use crate::utils::spawning::spawn;
 use crate::utils::{center, get_monotonic_time, ResizeEdge};
@@ -483,7 +483,7 @@ impl State {
             return;
         }
 
-        self.niri.pointer_hidden = true;
+        self.niri.pointer_visibility = PointerVisibility::Hidden;
         self.niri.queue_redraw_all();
     }
 
@@ -2014,7 +2014,7 @@ impl State {
         let mut new_pos = pos + event.delta();
 
         // We received an event for the regular pointer, so show it now.
-        self.niri.pointer_hidden = false;
+        self.niri.pointer_visibility = PointerVisibility::Visible;
         self.niri.tablet_cursor_location = None;
 
         // Check if we have an active pointer constraint.
@@ -2283,7 +2283,7 @@ impl State {
         self.niri.maybe_activate_pointer_constraint();
 
         // We moved the pointer, show it.
-        self.niri.pointer_hidden = false;
+        self.niri.pointer_visibility = PointerVisibility::Visible;
 
         // We moved the regular pointer, so show it now.
         self.niri.tablet_cursor_location = None;
@@ -2348,7 +2348,7 @@ impl State {
             }
 
             // We received an event for the regular pointer, so show it now.
-            self.niri.pointer_hidden = false;
+            self.niri.pointer_visibility = PointerVisibility::Visible;
             self.niri.tablet_cursor_location = None;
 
             let is_overview_open = self.niri.layout.is_overview_open();
@@ -2608,7 +2608,7 @@ impl State {
         // We received an event for the regular pointer, so show it now. This is also needed for
         // update_pointer_contents() below to return the real contents, necessary for the pointer
         // axis event to reach the window.
-        self.niri.pointer_hidden = false;
+        self.niri.pointer_visibility = PointerVisibility::Visible;
         self.niri.tablet_cursor_location = None;
 
         let timestamp = Duration::from_micros(event.time());
@@ -3053,7 +3053,7 @@ impl State {
                 event.time_msec(),
             );
 
-            self.niri.pointer_hidden = false;
+            self.niri.pointer_visibility = PointerVisibility::Visible;
             self.niri.tablet_cursor_location = Some(pos);
         }
 
@@ -3145,7 +3145,7 @@ impl State {
                             event.time_msec(),
                         );
                     }
-                    self.niri.pointer_hidden = false;
+                    self.niri.pointer_visibility = PointerVisibility::Visible;
                     self.niri.tablet_cursor_location = Some(pos);
                 }
                 ProximityState::Out => {
@@ -3159,7 +3159,7 @@ impl State {
                         self.move_cursor(pos);
                     }
 
-                    self.niri.pointer_hidden = false;
+                    self.niri.pointer_visibility = PointerVisibility::Visible;
                     self.niri.tablet_cursor_location = None;
                 }
             }
@@ -3591,7 +3591,7 @@ impl State {
         );
 
         // We're using touch, hide the pointer.
-        self.niri.pointer_hidden = true;
+        self.niri.pointer_visibility = PointerVisibility::Disabled;
     }
     fn on_touch_up<I: InputBackend>(&mut self, evt: I::TouchUpEvent) {
         let Some(handle) = self.niri.seat.get_touch() else {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -938,6 +938,11 @@ impl State {
             return false;
         }
 
+        // Disable the hidden pointer if content underneath has changed
+        if !self.niri.pointer_visibility.is_visible() {
+            self.niri.pointer_visibility = PointerVisibility::Disabled;
+        }
+
         self.niri.pointer_contents.clone_from(&under);
 
         pointer.motion(


### PR DESCRIPTION
This PR fixes #816

`hide-after-inactive-pause` and `hide-when-typing` now only prevent pointer from being drawn on the screen, it no longer loses focus.

Pointer still can hide and lose focus at the same time if a touch has occurred.

Why was it annoying? For example, before this change tooltips could disappear after hiding the pointer (as shown in gif below).

**Before:**

![niri-before](https://github.com/user-attachments/assets/07fd5cc6-9253-4152-b313-d7224bdc11a1)

**After:**

![niri-after](https://github.com/user-attachments/assets/da99ba4c-e8f2-445d-8b2e-20291108a040)

*EDIT: sorry, i accidently pressed Ctrl+Enter...*