### PR TITLE
Overview

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -764,6 +764,8 @@ pub enum Action {
     },
     /// Clear the dynamic cast target, making it show nothing.
     ClearDynamicCastTarget {},
+    /// Toggle the Overview.
+    ToggleOverview {},
 }
 
 /// Change in window or column size.

--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -266,6 +266,7 @@ impl TestCase for Layout {
             .monitor_for_output(&self.output)
             .unwrap()
             .render_elements(renderer, RenderTarget::Output, true)
+            .flat_map(|(_, iter)| iter)
             .map(|elem| Box::new(elem) as _)
             .collect()
     }

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -153,7 +153,7 @@ impl XdgShellHandler for State {
 
         match start_data {
             PointerOrTouchStartData::Pointer(start_data) => {
-                let grab = MoveGrab::new(start_data, window);
+                let grab = MoveGrab::new(start_data, window, false);
                 pointer.set_grab(self, grab, serial, Focus::Clear);
             }
             PointerOrTouchStartData::Touch(start_data) => {
@@ -315,6 +315,9 @@ impl XdgShellHandler for State {
             return;
         } else if let Some(output) = self.niri.layout.active_output() {
             let layers = layer_map_for_output(output);
+
+            // FIXME: somewhere here we probably need to check is_overview_open to match the logic
+            // in update_keyboard_focus().
 
             if layers
                 .layer_for_surface(&root, WindowSurfaceType::TOPLEVEL)

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -1062,6 +1062,19 @@ impl State {
         // The target geometry for the positioner should be relative to its parent's geometry, so
         // we will compute that here.
         let mut target = Rectangle::from_size(output_geo.size);
+
+        // Background and bottom layer popups render below the top and the overlay layer, so let's
+        // put them into the non-exclusive zone.
+        //
+        // FIXME: ideally this should use the "top and overlay layer" non-exclusive zone, but
+        // Smithay only computes the "all layers" non-exclusive zone atm.
+        //
+        // FIXME: related to the above, top layer popups should use the "overlay layer"
+        // non-exclusive zone.
+        if matches!(layer_surface.layer(), Layer::Background | Layer::Bottom) {
+            target = map.non_exclusive_zone();
+        }
+
         target.loc -= layer_geo.loc;
         target.loc -= get_popup_toplevel_coords(popup);
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -37,13 +37,13 @@ use std::mem;
 use std::rc::Rc;
 use std::time::Duration;
 
-use monitor::MonitorAddWindowTarget;
+use monitor::{InsertHint, InsertPosition, MonitorAddWindowTarget};
 use niri_config::{
     CenterFocusedColumn, Config, CornerRadius, FloatOrInt, PresetSize, Struts,
     Workspace as WorkspaceConfig, WorkspaceReference,
 };
 use niri_ipc::{ColumnDisplay, PositionChange, SizeChange};
-use scrolling::{Column, ColumnWidth, InsertHint, InsertPosition};
+use scrolling::{Column, ColumnWidth};
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
 use smithay::output::{self, Output};
@@ -2756,9 +2756,10 @@ impl<W: LayoutElement> Layout<W> {
     fn update_insert_hint(&mut self, output: Option<&Output>) {
         let _span = tracy_client::span!("Layout::update_insert_hint");
 
-        let _span = tracy_client::span!("Layout::update_insert_hint::clear");
-        for ws in self.workspaces_mut() {
-            ws.clear_insert_hint();
+        if let MonitorSet::Normal { monitors, .. } = &mut self.monitor_set {
+            for mon in monitors {
+                mon.insert_hint = None;
+            }
         }
 
         if !matches!(self.interactive_move, Some(InteractiveMoveState::Moving(_))) {
@@ -2789,7 +2790,8 @@ impl<W: LayoutElement> Layout<W> {
                     .find(|ws| ws.id() == ws_id)
                     .unwrap();
 
-                let position = ws.get_insert_position(move_.pointer_pos_within_output - geo.loc);
+                let pos_within_workspace = move_.pointer_pos_within_output - geo.loc;
+                let position = ws.scrolling_insert_position(pos_within_workspace);
 
                 let rules = move_.tile.window().rules();
                 let border_width = move_.tile.effective_border_width().unwrap_or(0.);
@@ -2799,7 +2801,8 @@ impl<W: LayoutElement> Layout<W> {
                         radius.expanded_by(border_width as f32)
                     });
 
-                ws.set_insert_hint(InsertHint {
+                mon.insert_hint = Some(InsertHint {
+                    workspace: ws_id,
                     position,
                     corner_radius,
                 });
@@ -4005,8 +4008,9 @@ impl<W: LayoutElement> Layout<W> {
                     let position = if move_.is_floating {
                         InsertPosition::Floating
                     } else {
+                        let pos_within_workspace = move_.pointer_pos_within_output - ws_geo.loc;
                         let ws = &mut mon.workspaces[ws_idx];
-                        ws.get_insert_position(move_.pointer_pos_within_output - ws_geo.loc)
+                        ws.scrolling_insert_position(pos_within_workspace)
                     };
 
                     (mon, ws_idx, position, ws_geo.loc)
@@ -4018,7 +4022,7 @@ impl<W: LayoutElement> Layout<W> {
                     let position = if move_.is_floating {
                         InsertPosition::Floating
                     } else {
-                        ws.get_insert_position(Point::from((0., 0.)))
+                        ws.scrolling_insert_position(Point::from((0., 0.)))
                     };
 
                     let ws_id = ws.id();

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2601,6 +2601,17 @@ impl<W: LayoutElement> Layout<W> {
                 }
                 saw_view_offset_gesture = has_view_offset_gesture;
             }
+
+            let scale = monitor.output.current_scale().fractional_scale();
+            let iter = monitor.workspaces_with_render_geo();
+            for (_ws, ws_geo) in iter {
+                let pos = ws_geo.loc;
+                let rounded_pos = pos.to_physical_precise_round(scale).to_logical(scale);
+
+                // Workspace positions must be rounded to physical pixels.
+                assert_abs_diff_eq!(pos.x, rounded_pos.x, epsilon = 1e-5);
+                assert_abs_diff_eq!(pos.y, rounded_pos.y, epsilon = 1e-5);
+            }
         }
     }
 
@@ -2623,14 +2634,14 @@ impl<W: LayoutElement> Layout<W> {
         // Scroll the view if needed.
         if let Some((output, pos_within_output)) = dnd_scroll {
             if let Some(mon) = self.monitor_for_output_mut(&output) {
-                if let Some((ws, offset)) = mon.workspace_under(pos_within_output) {
+                if let Some((ws, geo)) = mon.workspace_under(pos_within_output) {
                     let ws_id = ws.id();
                     let ws = mon
                         .workspaces
                         .iter_mut()
                         .find(|ws| ws.id() == ws_id)
                         .unwrap();
-                    ws.dnd_scroll_gesture_scroll(pos_within_output - offset);
+                    ws.dnd_scroll_gesture_scroll(pos_within_output - geo.loc);
                 }
             }
         }
@@ -2770,7 +2781,7 @@ impl<W: LayoutElement> Layout<W> {
         let _span = tracy_client::span!("Layout::update_insert_hint::update");
 
         if let Some(mon) = self.monitor_for_output_mut(&move_.output) {
-            if let Some((ws, offset)) = mon.workspace_under(move_.pointer_pos_within_output) {
+            if let Some((ws, geo)) = mon.workspace_under(move_.pointer_pos_within_output) {
                 let ws_id = ws.id();
                 let ws = mon
                     .workspaces
@@ -2778,7 +2789,7 @@ impl<W: LayoutElement> Layout<W> {
                     .find(|ws| ws.id() == ws_id)
                     .unwrap();
 
-                let position = ws.get_insert_position(move_.pointer_pos_within_output - offset);
+                let position = ws.get_insert_position(move_.pointer_pos_within_output - geo.loc);
 
                 let rules = move_.tile.window().rules();
                 let border_width = move_.tile.effective_border_width().unwrap_or(0.);
@@ -3659,8 +3670,8 @@ impl<W: LayoutElement> Layout<W> {
             return false;
         };
 
-        let Some((mon, (ws, ws_offset))) = monitors.iter().find_map(|mon| {
-            mon.workspaces_with_render_positions()
+        let Some((mon, (ws, ws_geo))) = monitors.iter().find_map(|mon| {
+            mon.workspaces_with_render_geo()
                 .find(|(ws, _)| ws.has_window(&window_id))
                 .map(|rv| (mon, rv))
         }) else {
@@ -3678,7 +3689,7 @@ impl<W: LayoutElement> Layout<W> {
             .unwrap();
         let window_offset = tile.window_loc();
 
-        let tile_pos = ws_offset + tile_offset;
+        let tile_pos = ws_geo.loc + tile_offset;
 
         let pointer_offset_within_window = start_pos_within_output - tile_pos - window_offset;
         let window_size = tile.window_size();
@@ -3774,8 +3785,8 @@ impl<W: LayoutElement> Layout<W> {
                 // potentially animatable.
                 let mut tile_pos = None;
                 if let MonitorSet::Normal { monitors, .. } = &self.monitor_set {
-                    if let Some((mon, (ws, ws_offset))) = monitors.iter().find_map(|mon| {
-                        mon.workspaces_with_render_positions()
+                    if let Some((mon, (ws, ws_geo))) = monitors.iter().find_map(|mon| {
+                        mon.workspaces_with_render_geo()
                             .find(|(ws, _)| ws.has_window(window))
                             .map(|rv| (mon, rv))
                     }) {
@@ -3785,7 +3796,7 @@ impl<W: LayoutElement> Layout<W> {
                                 .find(|(tile, _, _)| tile.window().id() == window)
                                 .unwrap();
 
-                            tile_pos = Some(ws_offset + tile_offset);
+                            tile_pos = Some(ws_geo.loc + tile_offset);
                         }
                     }
                 }
@@ -3977,12 +3988,12 @@ impl<W: LayoutElement> Layout<W> {
                 let (mon, ws_idx, position, offset) = if let Some(mon) =
                     monitors.iter_mut().find(|mon| mon.output == move_.output)
                 {
-                    let (ws, offset) = mon
+                    let (ws, ws_geo) = mon
                         .workspace_under(move_.pointer_pos_within_output)
                         // If the pointer is somehow outside the move output and a workspace switch
                         // is in progress, this won't necessarily do the expected thing, but also
                         // that is not really supposed to happen so eh?
-                        .unwrap_or_else(|| mon.workspaces_with_render_positions().next().unwrap());
+                        .unwrap_or_else(|| mon.workspaces_with_render_geo().next().unwrap());
 
                     let ws_id = ws.id();
                     let ws_idx = mon
@@ -3995,14 +4006,14 @@ impl<W: LayoutElement> Layout<W> {
                         InsertPosition::Floating
                     } else {
                         let ws = &mut mon.workspaces[ws_idx];
-                        ws.get_insert_position(move_.pointer_pos_within_output - offset)
+                        ws.get_insert_position(move_.pointer_pos_within_output - ws_geo.loc)
                     };
 
-                    (mon, ws_idx, position, offset)
+                    (mon, ws_idx, position, ws_geo.loc)
                 } else {
                     let mon = &mut monitors[*active_monitor_idx];
                     // No point in trying to use the pointer position on the wrong output.
-                    let (ws, offset) = mon.workspaces_with_render_positions().next().unwrap();
+                    let (ws, ws_geo) = mon.workspaces_with_render_geo().next().unwrap();
 
                     let position = if move_.is_floating {
                         InsertPosition::Floating
@@ -4016,7 +4027,7 @@ impl<W: LayoutElement> Layout<W> {
                         .iter_mut()
                         .position(|ws| ws.id() == ws_id)
                         .unwrap();
-                    (mon, ws_idx, position, offset)
+                    (mon, ws_idx, position, ws_geo.loc)
                 };
 
                 let win_id = move_.tile.window().id().clone();
@@ -4433,7 +4444,7 @@ impl<W: LayoutElement> Layout<W> {
                 let Some(mon) = self.monitor_for_output_mut(&output) else {
                     return;
                 };
-                let Some((ws, offset)) = mon.workspace_under(pointer_pos_within_output) else {
+                let Some((ws, ws_geo)) = mon.workspace_under(pointer_pos_within_output) else {
                     return;
                 };
                 let ws_id = ws.id();
@@ -4443,7 +4454,7 @@ impl<W: LayoutElement> Layout<W> {
                     .find(|ws| ws.id() == ws_id)
                     .unwrap();
 
-                let tile_pos = tile_pos - offset;
+                let tile_pos = tile_pos - ws_geo.loc;
                 ws.start_close_animation_for_tile(renderer, snapshot, tile_size, tile_pos, blocker);
                 return;
             }

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -3,12 +3,14 @@ use std::iter::zip;
 use std::rc::Rc;
 use std::time::Duration;
 
+use niri_config::CornerRadius;
 use smithay::backend::renderer::element::utils::{
     CropRenderElement, Relocate, RelocateRenderElement,
 };
 use smithay::output::Output;
 use smithay::utils::{Logical, Point, Rectangle, Size};
 
+use super::insert_hint_element::{InsertHintElement, InsertHintRenderElement};
 use super::scrolling::{Column, ColumnWidth};
 use super::tile::Tile;
 use super::workspace::{
@@ -17,6 +19,7 @@ use super::workspace::{
 use super::{ActivateWindow, HitType, LayoutElement, Options};
 use crate::animation::{Animation, Clock};
 use crate::input::swipe_tracker::SwipeTracker;
+use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::RenderTarget;
 use crate::rubber_band::RubberBand;
@@ -45,6 +48,12 @@ pub struct Monitor<W: LayoutElement> {
     pub(super) previous_workspace_id: Option<WorkspaceId>,
     /// In-progress switch between workspaces.
     pub(super) workspace_switch: Option<WorkspaceSwitch>,
+    /// Indication where an interactively-moved window is about to be placed.
+    pub(super) insert_hint: Option<InsertHint>,
+    /// Insert hint element for rendering.
+    insert_hint_element: InsertHintElement,
+    /// Location to render the insert hint element.
+    insert_hint_render_loc: Option<InsertHintRenderLoc>,
     /// Clock for driving animations.
     pub(super) clock: Clock,
     /// Configurable properties of the layout.
@@ -68,6 +77,26 @@ pub struct WorkspaceSwitchGesture {
     is_touchpad: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InsertPosition {
+    NewColumn(usize),
+    InColumn(usize, usize),
+    Floating,
+}
+
+#[derive(Debug)]
+pub(super) struct InsertHint {
+    pub workspace: WorkspaceId,
+    pub position: InsertPosition,
+    pub corner_radius: CornerRadius,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct InsertHintRenderLoc {
+    workspace: WorkspaceId,
+    location: Point<f64, Logical>,
+}
+
 /// Where to put a newly added window.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum MonitorAddWindowTarget<'a, W: LayoutElement> {
@@ -85,8 +114,14 @@ pub enum MonitorAddWindowTarget<'a, W: LayoutElement> {
     NextTo(&'a W::Id),
 }
 
-pub type MonitorRenderElement<R> =
-    RelocateRenderElement<CropRenderElement<WorkspaceRenderElement<R>>>;
+niri_render_elements! {
+    MonitorInnerRenderElement<R> => {
+        Workspace = CropRenderElement<WorkspaceRenderElement<R>>,
+        InsertHint = CropRenderElement<InsertHintRenderElement>,
+    }
+}
+
+pub type MonitorRenderElement<R> = RelocateRenderElement<MonitorInnerRenderElement<R>>;
 
 impl WorkspaceSwitch {
     pub fn current_idx(&self) -> f64 {
@@ -139,6 +174,9 @@ impl<W: LayoutElement> Monitor<W> {
             workspaces,
             active_workspace_idx: 0,
             previous_workspace_id: None,
+            insert_hint: None,
+            insert_hint_element: InsertHintElement::new(options.insert_hint),
+            insert_hint_render_loc: None,
             workspace_switch: None,
             clock,
             options,
@@ -663,8 +701,50 @@ impl<W: LayoutElement> Monitor<W> {
     }
 
     pub fn update_render_elements(&mut self, is_active: bool) {
-        for (ws, _) in self.workspaces_with_render_geo_mut() {
+        let mut insert_hint_ws_geo = None;
+        let insert_hint_ws_id = self.insert_hint.as_ref().map(|hint| hint.workspace);
+
+        for (ws, geo) in self.workspaces_with_render_geo_mut() {
             ws.update_render_elements(is_active);
+
+            if Some(ws.id()) == insert_hint_ws_id {
+                insert_hint_ws_geo = Some(geo);
+            }
+        }
+
+        self.insert_hint_render_loc = None;
+        if let Some(hint) = &self.insert_hint {
+            if let Some(ws) = self.workspaces.iter().find(|ws| ws.id() == hint.workspace) {
+                if let Some(mut area) = ws.insert_hint_area(hint.position) {
+                    let scale = ws.scale().fractional_scale();
+                    let view_size = ws.view_size();
+
+                    // Make sure the hint is at least partially visible.
+                    if matches!(hint.position, InsertPosition::NewColumn(_)) {
+                        let geo = insert_hint_ws_geo.unwrap();
+
+                        area.loc.x = area.loc.x.max(-geo.loc.x - area.size.w / 2.);
+                        area.loc.x = area.loc.x.min(geo.loc.x + geo.size.w - area.size.w / 2.);
+                    }
+
+                    // Round to physical pixels.
+                    area = area.to_physical_precise_round(scale).to_logical(scale);
+
+                    let view_rect = Rectangle::new(area.loc.upscale(-1.), view_size);
+                    self.insert_hint_element.update_render_elements(
+                        area.size,
+                        view_rect,
+                        hint.corner_radius,
+                        scale,
+                    );
+                    self.insert_hint_render_loc = Some(InsertHintRenderLoc {
+                        workspace: hint.workspace,
+                        location: area.loc,
+                    });
+                }
+            } else {
+                error!("insert hint workspace missing from monitor");
+            }
         }
     }
 
@@ -684,6 +764,8 @@ impl<W: LayoutElement> Monitor<W> {
             ws.update_config(options.clone());
         }
 
+        self.insert_hint_element.update_config(options.insert_hint);
+
         self.options = options;
     }
 
@@ -691,6 +773,8 @@ impl<W: LayoutElement> Monitor<W> {
         for ws in &mut self.workspaces {
             ws.update_shaders();
         }
+
+        self.insert_hint_element.update_shaders();
     }
 
     pub fn move_workspace_down(&mut self) {
@@ -932,10 +1016,23 @@ impl<W: LayoutElement> Monitor<W> {
             )
         };
 
+        // Draw the insert hint.
+        let mut insert_hint = None;
+        if !self.options.insert_hint.off {
+            if let Some(render_loc) = self.insert_hint_render_loc {
+                insert_hint = Some((
+                    render_loc.workspace,
+                    self.insert_hint_element
+                        .render(renderer, render_loc.location),
+                ));
+            }
+        }
+
         self.workspaces_with_render_geo()
             .flat_map(move |(ws, geo)| {
                 let map_ws_contents = move |elem: WorkspaceRenderElement<R>| {
                     let elem = CropRenderElement::from_element(elem, scale, crop_bounds)?;
+                    let elem = MonitorInnerRenderElement::Workspace(elem);
                     Some(elem)
                 };
 
@@ -943,7 +1040,21 @@ impl<W: LayoutElement> Monitor<W> {
                 let floating = floating.filter_map(map_ws_contents);
                 let scrolling = scrolling.filter_map(map_ws_contents);
 
-                let iter = floating.chain(scrolling);
+                let hint = if matches!(insert_hint, Some((hint_ws_id, _)) if hint_ws_id == ws.id())
+                {
+                    let iter = insert_hint.take().unwrap().1;
+                    let iter = iter.filter_map(move |elem| {
+                        let elem = CropRenderElement::from_element(elem, scale, crop_bounds)?;
+                        let elem = MonitorInnerRenderElement::InsertHint(elem);
+                        Some(elem)
+                    });
+                    Some(iter)
+                } else {
+                    None
+                };
+                let hint = hint.into_iter().flatten();
+
+                let iter = floating.chain(hint).chain(scrolling);
 
                 iter.map(move |elem| {
                     RelocateRenderElement::from_element(

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use niri_config::CornerRadius;
 use smithay::backend::renderer::element::utils::{
-    CropRenderElement, Relocate, RelocateRenderElement,
+    CropRenderElement, Relocate, RelocateRenderElement, RescaleRenderElement,
 };
 use smithay::output::Output;
 use smithay::utils::{Logical, Point, Rectangle, Size};
@@ -16,15 +16,21 @@ use super::tile::Tile;
 use super::workspace::{
     OutputId, Workspace, WorkspaceAddWindowTarget, WorkspaceId, WorkspaceRenderElement,
 };
-use super::{ActivateWindow, HitType, LayoutElement, Options};
+use super::{
+    compute_workspace_scale, ActivateWindow, HitType, LayoutElement, Options,
+    OVERVIEW_WORKSPACE_SCALE,
+};
 use crate::animation::{Animation, Clock};
 use crate::input::swipe_tracker::SwipeTracker;
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
+use crate::render_helpers::shadow::ShadowRenderElement;
 use crate::render_helpers::RenderTarget;
 use crate::rubber_band::RubberBand;
 use crate::utils::transaction::Transaction;
-use crate::utils::{output_size, ResizeEdge};
+use crate::utils::{
+    output_size, round_logical_in_physical, round_logical_in_physical_max1, ResizeEdge,
+};
 
 /// Amount of touchpad movement to scroll the height of one workspace.
 const WORKSPACE_GESTURE_MOVEMENT: f64 = 300.;
@@ -33,6 +39,11 @@ const WORKSPACE_GESTURE_RUBBER_BAND: RubberBand = RubberBand {
     stiffness: 0.5,
     limit: 0.05,
 };
+
+/// Amount of DnD edge scrolling to scroll the height of one workspace.
+///
+/// This constant is tied to the default dnd-edge-workspace-switch max-speed setting.
+const WORKSPACE_DND_EDGE_SCROLL_MOVEMENT: f64 = 1500.;
 
 #[derive(Debug)]
 pub struct Monitor<W: LayoutElement> {
@@ -54,6 +65,10 @@ pub struct Monitor<W: LayoutElement> {
     insert_hint_element: InsertHintElement,
     /// Location to render the insert hint element.
     insert_hint_render_loc: Option<InsertHintRenderLoc>,
+    /// Whether the overview is open.
+    pub(super) overview_open: bool,
+    /// Progress of the overview zoom animation, 1 is fully in overview.
+    overview_progress: Option<OverviewProgress>,
     /// Clock for driving animations.
     pub(super) clock: Clock,
     /// Configurable properties of the layout.
@@ -75,6 +90,16 @@ pub struct WorkspaceSwitchGesture {
     tracker: SwipeTracker,
     /// Whether the gesture is controlled by the touchpad.
     is_touchpad: bool,
+    /// Whether the gesture is clamped to +-1 workspace around the center.
+    is_clamped: bool,
+
+    // If this gesture is for drag-and-drop scrolling, this is the last event's unadjusted
+    // timestamp.
+    dnd_last_event_time: Option<Duration>,
+    // Time when the drag-and-drop scroll delta became non-zero, used for debouncing.
+    //
+    // If `None` then the scroll delta is currently zero.
+    dnd_nonzero_start_time: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,17 +109,29 @@ pub(super) enum InsertPosition {
     Floating,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InsertWorkspace {
+    Existing(WorkspaceId),
+    NewAt(usize),
+}
+
 #[derive(Debug)]
 pub(super) struct InsertHint {
-    pub workspace: WorkspaceId,
+    pub workspace: InsertWorkspace,
     pub position: InsertPosition,
     pub corner_radius: CornerRadius,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct InsertHintRenderLoc {
-    workspace: WorkspaceId,
+    workspace: InsertWorkspace,
     location: Point<f64, Logical>,
+}
+
+#[derive(Debug)]
+pub(super) enum OverviewProgress {
+    Animation(Animation),
+    Value(f64),
 }
 
 /// Where to put a newly added window.
@@ -118,10 +155,13 @@ niri_render_elements! {
     MonitorInnerRenderElement<R> => {
         Workspace = CropRenderElement<WorkspaceRenderElement<R>>,
         InsertHint = CropRenderElement<InsertHintRenderElement>,
+        UncroppedInsertHint = InsertHintRenderElement,
+        Shadow = ShadowRenderElement,
     }
 }
 
-pub type MonitorRenderElement<R> = RelocateRenderElement<MonitorInnerRenderElement<R>>;
+pub type MonitorRenderElement<R> =
+    RelocateRenderElement<RescaleRenderElement<MonitorInnerRenderElement<R>>>;
 
 impl WorkspaceSwitch {
     pub fn current_idx(&self) -> f64 {
@@ -161,6 +201,40 @@ impl WorkspaceSwitch {
     }
 }
 
+impl InsertWorkspace {
+    fn existing_id(self) -> Option<WorkspaceId> {
+        match self {
+            InsertWorkspace::Existing(id) => Some(id),
+            InsertWorkspace::NewAt(_) => None,
+        }
+    }
+}
+
+impl OverviewProgress {
+    pub fn value(&self) -> f64 {
+        match self {
+            OverviewProgress::Animation(anim) => anim.value(),
+            OverviewProgress::Value(v) => *v,
+        }
+    }
+
+    pub fn clamped_value(&self) -> f64 {
+        match self {
+            OverviewProgress::Animation(anim) => anim.clamped_value(),
+            OverviewProgress::Value(v) => *v,
+        }
+    }
+}
+
+impl From<&super::OverviewProgress> for OverviewProgress {
+    fn from(value: &super::OverviewProgress) -> Self {
+        match value {
+            super::OverviewProgress::Animation(anim) => Self::Animation(anim.clone()),
+            super::OverviewProgress::Gesture(gesture) => Self::Value(gesture.value),
+        }
+    }
+}
+
 impl<W: LayoutElement> Monitor<W> {
     pub fn new(
         output: Output,
@@ -177,6 +251,8 @@ impl<W: LayoutElement> Monitor<W> {
             insert_hint: None,
             insert_hint_element: InsertHintElement::new(options.insert_hint),
             insert_hint_render_loc: None,
+            overview_open: false,
+            overview_progress: None,
             workspace_switch: None,
             clock,
             options,
@@ -254,7 +330,15 @@ impl<W: LayoutElement> Monitor<W> {
         self.add_workspace_at(self.workspaces.len());
     }
 
-    fn activate_workspace(&mut self, idx: usize) {
+    pub fn activate_workspace(&mut self, idx: usize) {
+        self.activate_workspace_with_anim_config(idx, None);
+    }
+
+    pub fn activate_workspace_with_anim_config(
+        &mut self,
+        idx: usize,
+        config: Option<niri_config::Animation>,
+    ) {
         if self.active_workspace_idx == idx {
             return;
         }
@@ -271,7 +355,7 @@ impl<W: LayoutElement> Monitor<W> {
             current_idx,
             idx as f64,
             0.,
-            self.options.animations.workspace_switch.0,
+            config.unwrap_or(self.options.animations.workspace_switch.0),
         )));
     }
 
@@ -677,11 +761,32 @@ impl<W: LayoutElement> Monitor<W> {
     }
 
     pub fn advance_animations(&mut self) {
-        if let Some(WorkspaceSwitch::Animation(anim)) = &mut self.workspace_switch {
-            if anim.is_done() {
-                self.workspace_switch = None;
-                self.clean_up_workspaces();
+        match &mut self.workspace_switch {
+            Some(WorkspaceSwitch::Animation(anim)) => {
+                if anim.is_done() {
+                    self.workspace_switch = None;
+                    self.clean_up_workspaces();
+                }
             }
+            Some(WorkspaceSwitch::Gesture(gesture)) => {
+                // Make sure the last event time doesn't go too much out of date (for
+                // monitors not under cursor), causing sudden jumps.
+                //
+                // This happens after any dnd_scroll_gesture_scroll() calls (in
+                // Layout::advance_animations()), so it doesn't mess up the time delta there.
+                if let Some(last_time) = &mut gesture.dnd_last_event_time {
+                    let now = self.clock.now_unadjusted();
+                    if *last_time != now {
+                        *last_time = now;
+
+                        // If last_time was already == now, then dnd_scroll_gesture_scroll() must've
+                        // updated the gesture already. Therefore, when this code runs, the pointer
+                        // must be outside the DnD scrolling zone.
+                        gesture.dnd_nonzero_start_time = None;
+                    }
+                }
+            }
+            None => (),
         }
 
         for ws in &mut self.workspaces {
@@ -706,7 +811,10 @@ impl<W: LayoutElement> Monitor<W> {
 
     pub fn update_render_elements(&mut self, is_active: bool) {
         let mut insert_hint_ws_geo = None;
-        let insert_hint_ws_id = self.insert_hint.as_ref().map(|hint| hint.workspace);
+        let insert_hint_ws_id = self
+            .insert_hint
+            .as_ref()
+            .and_then(|hint| hint.workspace.existing_id());
 
         for (ws, geo) in self.workspaces_with_render_geo_mut() {
             ws.update_render_elements(is_active);
@@ -718,36 +826,81 @@ impl<W: LayoutElement> Monitor<W> {
 
         self.insert_hint_render_loc = None;
         if let Some(hint) = &self.insert_hint {
-            if let Some(ws) = self.workspaces.iter().find(|ws| ws.id() == hint.workspace) {
-                if let Some(mut area) = ws.insert_hint_area(hint.position) {
-                    let scale = ws.scale().fractional_scale();
-                    let view_size = ws.view_size();
+            match hint.workspace {
+                InsertWorkspace::Existing(ws_id) => {
+                    if let Some(ws) = self.workspaces.iter().find(|ws| ws.id() == ws_id) {
+                        if let Some(mut area) = ws.insert_hint_area(hint.position) {
+                            let scale = ws.scale().fractional_scale();
+                            let view_size = ws.view_size();
 
-                    // Make sure the hint is at least partially visible.
-                    if matches!(hint.position, InsertPosition::NewColumn(_)) {
-                        let geo = insert_hint_ws_geo.unwrap();
+                            // Make sure the hint is at least partially visible.
+                            if matches!(hint.position, InsertPosition::NewColumn(_)) {
+                                let ws_scale = self.workspace_scale();
+                                let geo = insert_hint_ws_geo.unwrap();
+                                let geo = geo.downscale(ws_scale);
 
-                        area.loc.x = area.loc.x.max(-geo.loc.x - area.size.w / 2.);
-                        area.loc.x = area.loc.x.min(geo.loc.x + geo.size.w - area.size.w / 2.);
+                                area.loc.x = area.loc.x.max(-geo.loc.x - area.size.w / 2.);
+                                area.loc.x =
+                                    area.loc.x.min(geo.loc.x + geo.size.w - area.size.w / 2.);
+                            }
+
+                            // Round to physical pixels.
+                            area = area.to_physical_precise_round(scale).to_logical(scale);
+
+                            let view_rect = Rectangle::new(area.loc.upscale(-1.), view_size);
+                            self.insert_hint_element.update_render_elements(
+                                area.size,
+                                view_rect,
+                                hint.corner_radius,
+                                scale,
+                            );
+                            self.insert_hint_render_loc = Some(InsertHintRenderLoc {
+                                workspace: hint.workspace,
+                                location: area.loc,
+                            });
+                        }
+                    } else {
+                        error!("insert hint workspace missing from monitor");
                     }
+                }
+                InsertWorkspace::NewAt(ws_idx) => {
+                    // FIXME extract method
+                    let scale = self.output.current_scale().fractional_scale();
+                    let size = output_size(&self.output);
+                    let ws_scale = self.workspace_scale();
+                    let ws_size = size
+                        .upscale(ws_scale)
+                        .to_physical_precise_ceil(scale)
+                        .to_logical(scale);
+                    let gap = round_logical_in_physical_max1(scale, size.h * 0.1 * ws_scale);
 
-                    // Round to physical pixels.
-                    area = area.to_physical_precise_round(scale).to_logical(scale);
+                    let hint_gap = round_logical_in_physical(scale, gap * 0.1);
+                    let hint_height = gap - hint_gap * 2.;
 
-                    let view_rect = Rectangle::new(area.loc.upscale(-1.), view_size);
+                    let next_ws_geo = self.workspaces_render_geo().nth(ws_idx).unwrap();
+                    let hint_loc_diff = Point::from((0., hint_height + hint_gap));
+                    let hint_loc = next_ws_geo.loc - hint_loc_diff;
+                    let hint_size = Size::from((next_ws_geo.size.w, hint_height));
+
+                    // FIXME: sometimes the hint ends up 1 px wider than necessary and/or 1 px
+                    // narrower than necessary. The values here seem correct. Might have to do with
+                    // how zooming out currently doesn't round to output scale properly.
+
+                    // Compute view rect as if we're above the next workspace (rather than below
+                    // the previous one).
+                    let view_rect = Rectangle::new(hint_loc_diff, ws_size);
+
                     self.insert_hint_element.update_render_elements(
-                        area.size,
+                        hint_size,
                         view_rect,
-                        hint.corner_radius,
+                        CornerRadius::default(),
                         scale,
                     );
                     self.insert_hint_render_loc = Some(InsertHintRenderLoc {
                         workspace: hint.workspace,
-                        location: area.loc,
+                        location: hint_loc,
                     });
                 }
-            } else {
-                error!("insert hint workspace missing from monitor");
             }
         }
     }
@@ -884,6 +1037,10 @@ impl<W: LayoutElement> Monitor<W> {
     ///
     /// During animations, assumes the final view position.
     pub fn active_tile_visual_rectangle(&self) -> Option<Rectangle<f64, Logical>> {
+        if self.overview_open {
+            return None;
+        }
+        // TODO: unify logic
         let mut rect = self.active_workspace_ref().active_tile_visual_rectangle()?;
 
         if let Some(switch) = &self.workspace_switch {
@@ -899,7 +1056,107 @@ impl<W: LayoutElement> Monitor<W> {
         Some(rect)
     }
 
+    pub fn workspace_scale(&self) -> f64 {
+        let progress = self.overview_progress.as_ref().map(|p| p.value());
+        compute_workspace_scale(progress)
+    }
+
+    pub(super) fn set_overview_progress(&mut self, progress: Option<&super::OverviewProgress>) {
+        let prev_render_idx = self.workspace_render_idx();
+        self.overview_progress = progress.map(OverviewProgress::from);
+        let new_render_idx = self.workspace_render_idx();
+
+        // If the view jumped (can happen when going from corrected to uncorrected render_idx, for
+        // example when toggling the overview in the middle of an overview animation), then restart
+        // the workspace switch to avoid jumps.
+        if prev_render_idx != new_render_idx {
+            if let Some(WorkspaceSwitch::Animation(anim)) = &mut self.workspace_switch {
+                // FIXME: maintain velocity.
+                *anim = anim.restarted(prev_render_idx, anim.to(), 0.);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn overview_progress_value(&self) -> Option<f64> {
+        self.overview_progress.as_ref().map(|p| p.value())
+    }
+
     pub fn workspace_render_idx(&self) -> f64 {
+        // If workspace switch and overview progress are matching animations, then compute a
+        // correction term to make the movement appear monotonic.
+        if let (
+            Some(WorkspaceSwitch::Animation(switch_anim)),
+            Some(OverviewProgress::Animation(progress_anim)),
+        ) = (&self.workspace_switch, &self.overview_progress)
+        {
+            if switch_anim.start_time() == progress_anim.start_time()
+                && (switch_anim.duration().as_secs_f64() - progress_anim.duration().as_secs_f64())
+                    .abs()
+                    <= 0.001
+            {
+                let scale = self.output.current_scale().fractional_scale();
+                let size = output_size(&self.output);
+
+                #[rustfmt::skip]
+                // How this was derived:
+                //
+                // - Assume we're animating a zoom + switch. Consider switch "from" and "to".
+                //   These are render_idx values, so first workspace to second would have switch
+                //   from = 0. and to = 1. regardless of the zoom level.
+                //
+                // - At the start, the point at "from" is at Y = 0. We're moving the point at "to"
+                //   to Y = 0. We want this to be a monotonic motion in apparent coordinates (after
+                //   zoom).
+                //
+                // - Height at the start:
+                //   from_height = (size.h + gap) * from_ws_scale.
+                //
+                // - Current height:
+                //   current_height = (size.h + gap) * ws_scale.
+                //
+                // - We're moving the "to" point to Y = 0:
+                //   to_y = 0.
+                //
+                // - The initial position of the point we're moving:
+                //   from_y = (to - from) * from_height.
+                //
+                // - We want this point to travel monotonically in apparent coordinates:
+                //   current_y = from_y + (to_y - from_y) * progress,
+                //   where progress is from 0 to 1, equals to the animation progress (switch and
+                //   zoom are the same since they are synchronized).
+                //
+                // - Derive the Y of the first workspace from this:
+                //   first_y = current_y - to * current_height.
+                //
+                // Now, let's substitute and rearrange the terms.
+                //
+                // - current_y = from_y + (0 - (to - from) * from_height) * progress
+                // - progress = (switch_anim.value() - from) / (to - from)
+                // - current_y = from_y - (to - from) * from_height * (switch_anim.value() - from) / (to - from)
+                // - current_y = from_y - from_height * (switch_anim.value() - from)
+                // - first_y = from_y - from_height * (switch_anim.value() - from) - to * current_height
+                // - first_y = (to - from) * from_height - from_height * (switch_anim.value() - from) - to * current_height
+                // - first_y = to * from_height - switch_anim.value() * from_height - to * current_height
+                // - first_y = -switch_anim.value() * from_height + to * (from_height - current_height)
+                let from = progress_anim.from();
+                let from_ws_scale = (1. - from * (1. - OVERVIEW_WORKSPACE_SCALE)).max(0.);
+                let from_ws_height = round_logical_in_physical_max1(scale, size.h * from_ws_scale);
+                let from_gap = round_logical_in_physical_max1(scale, size.h * from_ws_scale * 0.1);
+                let from_ws_height_gap = from_ws_height + from_gap;
+
+                let ws_scale = self.workspace_scale();
+                let ws_height = round_logical_in_physical_max1(scale, size.h * ws_scale);
+                let gap = round_logical_in_physical_max1(scale, size.h * ws_scale * 0.1);
+                let ws_height_gap = ws_height + gap;
+
+                let first_ws_y = -switch_anim.value() * from_ws_height_gap
+                    + switch_anim.to() * (from_ws_height_gap - ws_height_gap);
+
+                return -first_ws_y / ws_height_gap;
+            }
+        };
+
         if let Some(switch) = &self.workspace_switch {
             switch.current_idx()
         } else {
@@ -910,15 +1167,25 @@ impl<W: LayoutElement> Monitor<W> {
     pub fn workspaces_render_geo(&self) -> impl Iterator<Item = Rectangle<f64, Logical>> {
         let scale = self.output.current_scale().fractional_scale();
         let size = output_size(&self.output);
+        let ws_scale = self.workspace_scale();
 
         // Ceil the workspace size in physical pixels.
-        let ws_size = size.to_physical_precise_ceil(scale).to_logical(scale);
+        let ws_size = size
+            .upscale(ws_scale)
+            .to_physical_precise_ceil(scale)
+            .to_logical(scale);
 
-        let first_ws_y = -self.workspace_render_idx() * ws_size.h;
+        let gap = round_logical_in_physical_max1(scale, size.h * 0.1 * ws_scale);
+        let ws_height_gap = ws_size.h + gap;
 
-        (0..self.workspaces.len()).map(move |idx| {
-            let y = first_ws_y + idx as f64 * ws_size.h;
-            let loc = Point::from((0., y));
+        let static_offset = (size.to_point() - ws_size.to_point()).downscale(2.);
+
+        let first_ws_y = -self.workspace_render_idx() * ws_height_gap;
+
+        // Return position for one-past-last workspace too.
+        (0..=self.workspaces.len()).map(move |idx| {
+            let y = first_ws_y + idx as f64 * ws_height_gap;
+            let loc = Point::from((0., y)) + static_offset;
             let loc = loc.to_physical_precise_round(scale).to_logical(scale);
             Rectangle::new(loc, ws_size)
         })
@@ -932,6 +1199,18 @@ impl<W: LayoutElement> Monitor<W> {
 
         let geo = self.workspaces_render_geo();
         zip(self.workspaces.iter(), geo)
+            // Cull out workspaces outside the output.
+            .filter(move |(_ws, geo)| geo.intersection(output_geo).is_some())
+    }
+
+    pub fn workspaces_with_render_geo_idx(
+        &self,
+    ) -> impl Iterator<Item = ((usize, &Workspace<W>), Rectangle<f64, Logical>)> {
+        let output_size = output_size(&self.output);
+        let output_geo = Rectangle::new(Point::from((0., 0.)), output_size);
+
+        let geo = self.workspaces_render_geo();
+        zip(self.workspaces.iter().enumerate(), geo)
             // Cull out workspaces outside the output.
             .filter(move |(_ws, geo)| geo.intersection(output_geo).is_some())
     }
@@ -964,20 +1243,91 @@ impl<W: LayoutElement> Monitor<W> {
         Some((ws, geo))
     }
 
+    pub fn workspace_under_narrow(
+        &self,
+        pos_within_output: Point<f64, Logical>,
+    ) -> Option<&Workspace<W>> {
+        self.workspaces_with_render_geo()
+            .find_map(|(ws, geo)| geo.contains(pos_within_output).then_some(ws))
+    }
+
     pub fn window_under(&self, pos_within_output: Point<f64, Logical>) -> Option<(&W, HitType)> {
         let (ws, geo) = self.workspace_under(pos_within_output)?;
-        let (win, hit) = ws.window_under(pos_within_output - geo.loc)?;
-        Some((win, hit.offset_win_pos(geo.loc)))
+
+        if self.overview_progress.is_some() {
+            let ws_scale = self.workspace_scale();
+            let pos_within_workspace = (pos_within_output - geo.loc).downscale(ws_scale);
+            let (win, hit) = ws.window_under(pos_within_workspace)?;
+            // During the overview animation, we cannot do input hits because we cannot really
+            // represent scaled windows properly.
+            Some((win, hit.to_activate()))
+        } else {
+            let (win, hit) = ws.window_under(pos_within_output - geo.loc)?;
+            Some((win, hit.offset_win_pos(geo.loc)))
+        }
     }
 
     pub fn resize_edges_under(&self, pos_within_output: Point<f64, Logical>) -> Option<ResizeEdge> {
+        if self.overview_progress.is_some() {
+            return None;
+        }
+
         let (ws, geo) = self.workspace_under(pos_within_output)?;
         ws.resize_edges_under(pos_within_output - geo.loc)
     }
 
+    pub(super) fn insert_position(
+        &self,
+        pos_within_output: Point<f64, Logical>,
+    ) -> (InsertWorkspace, Rectangle<f64, Logical>) {
+        let mut iter = self.workspaces_with_render_geo_idx();
+
+        let dummy = Rectangle::default();
+
+        // Monitors always have at least one workspace.
+        let ((idx, ws), geo) = iter.next().unwrap();
+
+        // Check if above first.
+        if pos_within_output.y < geo.loc.y {
+            return (InsertWorkspace::NewAt(idx), dummy);
+        }
+
+        let contains = move |geo: Rectangle<f64, Logical>| {
+            geo.loc.y <= pos_within_output.y && pos_within_output.y < geo.loc.y + geo.size.h
+        };
+
+        // Check first.
+        if contains(geo) {
+            return (InsertWorkspace::Existing(ws.id()), geo);
+        }
+
+        let mut last_geo = geo;
+        let mut last_idx = idx;
+        for ((idx, ws), geo) in iter {
+            // Check gap above.
+            let gap_loc = Point::from((last_geo.loc.x, last_geo.loc.y + last_geo.size.h));
+            let gap_size = Size::from((geo.size.w, geo.loc.y - gap_loc.y));
+            let gap_geo = Rectangle::new(gap_loc, gap_size);
+            if contains(gap_geo) {
+                return (InsertWorkspace::NewAt(idx), dummy);
+            }
+
+            // Check workspace itself.
+            if contains(geo) {
+                return (InsertWorkspace::Existing(ws.id()), geo);
+            }
+
+            last_geo = geo;
+            last_idx = idx;
+        }
+
+        // Anything below.
+        (InsertWorkspace::NewAt(last_idx + 1), dummy)
+    }
+
     pub fn render_above_top_layer(&self) -> bool {
         // Render above the top layer only if the view is stationary.
-        if self.workspace_switch.is_some() {
+        if self.workspace_switch.is_some() || self.overview_progress.is_some() {
             return false;
         }
 
@@ -985,12 +1335,41 @@ impl<W: LayoutElement> Monitor<W> {
         ws.render_above_top_layer()
     }
 
+    pub fn render_insert_hint_between_workspaces<R: NiriRenderer>(
+        &self,
+        renderer: &mut R,
+    ) -> impl Iterator<Item = MonitorRenderElement<R>> {
+        let mut rv = None;
+
+        if !self.options.insert_hint.off {
+            if let Some(render_loc) = self.insert_hint_render_loc {
+                if let InsertWorkspace::NewAt(_) = render_loc.workspace {
+                    let iter = self
+                        .insert_hint_element
+                        .render(renderer, render_loc.location)
+                        .map(MonitorInnerRenderElement::UncroppedInsertHint);
+                    rv = Some(iter);
+                }
+            }
+        }
+
+        rv.into_iter().flatten().map(|elem| {
+            let elem = RescaleRenderElement::from_element(elem, Point::default(), 1.);
+            RelocateRenderElement::from_element(elem, Point::default(), Relocate::Relative)
+        })
+    }
+
     pub fn render_elements<'a, R: NiriRenderer>(
         &'a self,
         renderer: &'a mut R,
         target: RenderTarget,
         focus_ring: bool,
-    ) -> impl Iterator<Item = MonitorRenderElement<R>> + 'a {
+    ) -> impl Iterator<
+        Item = (
+            Rectangle<f64, Logical>,
+            impl Iterator<Item = MonitorRenderElement<R>> + 'a,
+        ),
+    > + 'a {
         let _span = tracy_client::span!("Monitor::render_elements");
 
         let scale = self.output.current_scale().fractional_scale();
@@ -1008,7 +1387,7 @@ impl<W: LayoutElement> Monitor<W> {
         // rendering for maximized GTK windows.
         //
         // FIXME: use proper bounds after fixing the Crop element.
-        let crop_bounds = if self.workspace_switch.is_some() {
+        let crop_bounds = if self.workspace_switch.is_some() || self.overview_progress.is_some() {
             Rectangle::new(
                 Point::from((-i32::MAX / 2, 0)),
                 Size::from((i32::MAX, height)),
@@ -1020,57 +1399,70 @@ impl<W: LayoutElement> Monitor<W> {
             )
         };
 
+        let ws_scale = self.workspace_scale();
+        let overview_clamped_progress = self.overview_progress.as_ref().map(|p| p.clamped_value());
+
         // Draw the insert hint.
         let mut insert_hint = None;
         if !self.options.insert_hint.off {
             if let Some(render_loc) = self.insert_hint_render_loc {
-                insert_hint = Some((
-                    render_loc.workspace,
-                    self.insert_hint_element
-                        .render(renderer, render_loc.location),
-                ));
+                if let InsertWorkspace::Existing(workspace_id) = render_loc.workspace {
+                    insert_hint = Some((
+                        workspace_id,
+                        self.insert_hint_element
+                            .render(renderer, render_loc.location),
+                    ));
+                }
             }
         }
 
-        self.workspaces_with_render_geo()
-            .flat_map(move |(ws, geo)| {
-                let map_ws_contents = move |elem: WorkspaceRenderElement<R>| {
+        self.workspaces_with_render_geo().map(move |(ws, geo)| {
+            let map_ws_contents = move |elem: WorkspaceRenderElement<R>| {
+                let elem = CropRenderElement::from_element(elem, scale, crop_bounds)?;
+                let elem = MonitorInnerRenderElement::Workspace(elem);
+                Some(elem)
+            };
+
+            let (floating, scrolling) = ws.render_elements(renderer, target, focus_ring);
+            let floating = floating.filter_map(map_ws_contents);
+            let scrolling = scrolling.filter_map(map_ws_contents);
+
+            let shadow = overview_clamped_progress.map(|value| {
+                ws.render_shadow(renderer)
+                    .map(move |elem| elem.with_alpha(value.clamp(0., 1.) as f32))
+                    .map(MonitorInnerRenderElement::Shadow)
+            });
+            let shadow = shadow.into_iter().flatten();
+
+            let hint = if matches!(insert_hint, Some((hint_ws_id, _)) if hint_ws_id == ws.id()) {
+                let iter = insert_hint.take().unwrap().1;
+                let iter = iter.filter_map(move |elem| {
                     let elem = CropRenderElement::from_element(elem, scale, crop_bounds)?;
-                    let elem = MonitorInnerRenderElement::Workspace(elem);
+                    let elem = MonitorInnerRenderElement::InsertHint(elem);
                     Some(elem)
-                };
+                });
+                Some(iter)
+            } else {
+                None
+            };
+            let hint = hint.into_iter().flatten();
 
-                let (floating, scrolling) = ws.render_elements(renderer, target, focus_ring);
-                let floating = floating.filter_map(map_ws_contents);
-                let scrolling = scrolling.filter_map(map_ws_contents);
+            let iter = floating.chain(hint).chain(scrolling).chain(shadow);
 
-                let hint = if matches!(insert_hint, Some((hint_ws_id, _)) if hint_ws_id == ws.id())
-                {
-                    let iter = insert_hint.take().unwrap().1;
-                    let iter = iter.filter_map(move |elem| {
-                        let elem = CropRenderElement::from_element(elem, scale, crop_bounds)?;
-                        let elem = MonitorInnerRenderElement::InsertHint(elem);
-                        Some(elem)
-                    });
-                    Some(iter)
-                } else {
-                    None
-                };
-                let hint = hint.into_iter().flatten();
+            let iter = iter.map(move |elem| {
+                let elem = RescaleRenderElement::from_element(elem, Point::from((0, 0)), ws_scale);
+                RelocateRenderElement::from_element(
+                    elem,
+                    // The offset we get from workspaces_with_render_positions() is already
+                    // rounded to physical pixels, but it's in the logical coordinate
+                    // space, so we need to convert it to physical.
+                    geo.loc.to_physical_precise_round(scale),
+                    Relocate::Relative,
+                )
+            });
 
-                let iter = floating.chain(hint).chain(scrolling);
-
-                iter.map(move |elem| {
-                    RelocateRenderElement::from_element(
-                        elem,
-                        // The offset we get from workspaces_with_render_positions() is already
-                        // rounded to physical pixels, but it's in the logical coordinate
-                        // space, so we need to convert it to physical.
-                        geo.loc.to_physical_precise_round(scale),
-                        Relocate::Relative,
-                    )
-                })
-            })
+            (geo, iter)
+        })
     }
 
     pub fn workspace_switch_gesture_begin(&mut self, is_touchpad: bool) {
@@ -1082,6 +1474,39 @@ impl<W: LayoutElement> Monitor<W> {
             current_idx,
             tracker: SwipeTracker::new(),
             is_touchpad,
+            is_clamped: !self.overview_open,
+            dnd_last_event_time: None,
+            dnd_nonzero_start_time: None,
+        };
+        self.workspace_switch = Some(WorkspaceSwitch::Gesture(gesture));
+    }
+
+    pub fn dnd_scroll_gesture_begin(&mut self) {
+        if let Some(WorkspaceSwitch::Gesture(WorkspaceSwitchGesture {
+            dnd_last_event_time: Some(_),
+            ..
+        })) = &self.workspace_switch
+        {
+            // Already active.
+            return;
+        }
+
+        if !self.overview_open {
+            // This gesture is only for the overview.
+            return;
+        }
+
+        let center_idx = self.active_workspace_idx;
+        let current_idx = self.workspace_render_idx();
+
+        let gesture = WorkspaceSwitchGesture {
+            center_idx,
+            current_idx,
+            tracker: SwipeTracker::new(),
+            is_touchpad: false,
+            is_clamped: false,
+            dnd_last_event_time: Some(self.clock.now_unadjusted()),
+            dnd_nonzero_start_time: None,
         };
         self.workspace_switch = Some(WorkspaceSwitch::Gesture(gesture));
     }
@@ -1092,27 +1517,46 @@ impl<W: LayoutElement> Monitor<W> {
         timestamp: Duration,
         is_touchpad: bool,
     ) -> Option<bool> {
+        let ws_scale = self.workspace_scale();
+
         let Some(WorkspaceSwitch::Gesture(gesture)) = &mut self.workspace_switch else {
             return None;
         };
 
-        if gesture.is_touchpad != is_touchpad {
+        if gesture.is_touchpad != is_touchpad || gesture.dnd_last_event_time.is_some() {
             return None;
         }
+
+        // Reduce the effect of ws_scale on the touchpad somewhat.
+        let delta_scale = if gesture.is_touchpad {
+            (ws_scale - 1.) / 2.5 + 1.
+        } else {
+            ws_scale
+        };
+
+        let delta_y = delta_y / delta_scale;
+        let mut rubber_band = WORKSPACE_GESTURE_RUBBER_BAND;
+        rubber_band.limit /= ws_scale;
 
         gesture.tracker.push(delta_y, timestamp);
 
         let total_height = if gesture.is_touchpad {
             WORKSPACE_GESTURE_MOVEMENT
         } else {
-            self.workspaces[0].view_size().h
+            // Account for the gap.
+            self.workspaces[0].view_size().h * 1.1
         };
         let pos = gesture.tracker.pos() / total_height;
 
-        let min = gesture.center_idx.saturating_sub(1) as f64;
-        let max = (gesture.center_idx + 1).min(self.workspaces.len() - 1) as f64;
+        let (min, max) = if gesture.is_clamped {
+            let min = gesture.center_idx.saturating_sub(1) as f64;
+            let max = (gesture.center_idx + 1).min(self.workspaces.len() - 1) as f64;
+            (min, max)
+        } else {
+            (0., (self.workspaces.len() - 1) as f64)
+        };
         let new_idx = gesture.center_idx as f64 + pos;
-        let new_idx = WORKSPACE_GESTURE_RUBBER_BAND.clamp(min, max, new_idx);
+        let new_idx = rubber_band.clamp(min, max, new_idx);
 
         if gesture.current_idx == new_idx {
             return Some(false);
@@ -1122,11 +1566,102 @@ impl<W: LayoutElement> Monitor<W> {
         Some(true)
     }
 
+    pub fn dnd_scroll_gesture_scroll(&mut self, pos: Point<f64, Logical>, speed: f64) -> bool {
+        let ws_scale = self.workspace_scale();
+
+        let Some(WorkspaceSwitch::Gesture(gesture)) = &mut self.workspace_switch else {
+            return false;
+        };
+
+        let Some(last_time) = gesture.dnd_last_event_time else {
+            // Not a DnD scroll.
+            return false;
+        };
+
+        let config = &self.options.gestures.dnd_edge_workspace_switch;
+        let trigger_height = config.trigger_height.0;
+
+        // This working area intentionally does not include extra struts from Options.
+        // TODO: working area
+        let output_size = output_size(&self.output);
+
+        let width = output_size.w * ws_scale;
+        let x = pos.x - (output_size.w - width) / 2.;
+
+        let y = pos.y;
+        let height = output_size.h;
+
+        let y = y.clamp(0., height);
+        let trigger_height = trigger_height.clamp(0., height / 2.);
+
+        let delta = if x < 0. || width <= x {
+            // Outside the bounds horizontally.
+            0.
+        } else if y < trigger_height {
+            -(trigger_height - y)
+        } else if height - y < trigger_height {
+            trigger_height - (height - y)
+        } else {
+            0.
+        };
+
+        let delta = if trigger_height < 0.01 {
+            // Sanity check for trigger-height 0 or small window sizes.
+            0.
+        } else {
+            // Normalize to [0, 1].
+            delta / trigger_height
+        };
+        let delta = delta * speed;
+
+        let now = self.clock.now_unadjusted();
+        gesture.dnd_last_event_time = Some(now);
+
+        if delta == 0. {
+            // We're outside the scrolling zone.
+            gesture.dnd_nonzero_start_time = None;
+            return false;
+        }
+
+        let nonzero_start = *gesture.dnd_nonzero_start_time.get_or_insert(now);
+
+        // Delay starting the gesture a bit to avoid unwanted movement when dragging across
+        // monitors.
+        let delay = Duration::from_millis(u64::from(config.delay_ms));
+        if now.saturating_sub(nonzero_start) < delay {
+            return true;
+        }
+
+        let time_delta = now.saturating_sub(last_time).as_secs_f64();
+
+        let delta = delta * time_delta * config.max_speed.0;
+
+        gesture.tracker.push(delta, now);
+
+        let total_height = WORKSPACE_DND_EDGE_SCROLL_MOVEMENT;
+        let pos = gesture.tracker.pos() / total_height;
+
+        let (min, max) = if gesture.is_clamped {
+            let min = gesture.center_idx.saturating_sub(1) as f64;
+            let max = (gesture.center_idx + 1).min(self.workspaces.len() - 1) as f64;
+            (min, max)
+        } else {
+            (0., (self.workspaces.len() - 1) as f64)
+        };
+        let new_idx = gesture.center_idx as f64 + pos;
+        let new_idx = new_idx.clamp(min, max);
+
+        gesture.current_idx = new_idx;
+        true
+    }
+
     pub fn workspace_switch_gesture_end(
         &mut self,
         cancelled: bool,
         is_touchpad: Option<bool>,
     ) -> bool {
+        let ws_scale = self.workspace_scale();
+
         let Some(WorkspaceSwitch::Gesture(gesture)) = &mut self.workspace_switch else {
             return false;
         };
@@ -1145,28 +1680,35 @@ impl<W: LayoutElement> Monitor<W> {
         let now = self.clock.now_unadjusted();
         gesture.tracker.push(0., now);
 
+        let mut rubber_band = WORKSPACE_GESTURE_RUBBER_BAND;
+        rubber_band.limit /= ws_scale;
+
         let total_height = if gesture.is_touchpad {
             WORKSPACE_GESTURE_MOVEMENT
+        } else if gesture.dnd_last_event_time.is_some() {
+            WORKSPACE_DND_EDGE_SCROLL_MOVEMENT
         } else {
-            self.workspaces[0].view_size().h
+            // Account for the gap.
+            self.workspaces[0].view_size().h * 1.1
         };
 
         let mut velocity = gesture.tracker.velocity() / total_height;
         let current_pos = gesture.tracker.pos() / total_height;
         let pos = gesture.tracker.projected_end_pos() / total_height;
 
-        let min = gesture.center_idx.saturating_sub(1) as f64;
-        let max = (gesture.center_idx + 1).min(self.workspaces.len() - 1) as f64;
+        let (min, max) = if gesture.is_clamped {
+            let min = gesture.center_idx.saturating_sub(1) as f64;
+            let max = (gesture.center_idx + 1).min(self.workspaces.len() - 1) as f64;
+            (min, max)
+        } else {
+            (0., (self.workspaces.len() - 1) as f64)
+        };
         let new_idx = gesture.center_idx as f64 + pos;
 
-        let new_idx = WORKSPACE_GESTURE_RUBBER_BAND.clamp(min, max, new_idx);
+        let new_idx = new_idx.clamp(min, max);
         let new_idx = new_idx.round() as usize;
 
-        velocity *= WORKSPACE_GESTURE_RUBBER_BAND.clamp_derivative(
-            min,
-            max,
-            gesture.center_idx as f64 + current_pos,
-        );
+        velocity *= rubber_band.clamp_derivative(min, max, gesture.center_idx as f64 + current_pos);
 
         self.previous_workspace_id = Some(self.workspaces[self.active_workspace_idx].id());
 
@@ -1180,5 +1722,20 @@ impl<W: LayoutElement> Monitor<W> {
         )));
 
         true
+    }
+
+    pub fn dnd_scroll_gesture_end(&mut self) {
+        if !matches!(
+            self.workspace_switch,
+            Some(WorkspaceSwitch::Gesture(WorkspaceSwitchGesture {
+                dnd_last_event_time: Some(_),
+                ..
+            }))
+        ) {
+            // Not a DnD scroll.
+            return;
+        };
+
+        self.workspace_switch_gesture_end(false, None);
     }
 }

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -227,27 +227,31 @@ impl<W: LayoutElement> Monitor<W> {
         self.windows().any(|win| win.id() == window)
     }
 
-    pub fn add_workspace_top(&mut self) {
+    pub fn add_workspace_at(&mut self, idx: usize) {
         let ws = Workspace::new(
             self.output.clone(),
             self.clock.clone(),
             self.options.clone(),
         );
-        self.workspaces.insert(0, ws);
-        self.active_workspace_idx += 1;
+
+        self.workspaces.insert(idx, ws);
+        if idx <= self.active_workspace_idx {
+            self.active_workspace_idx += 1;
+        }
 
         if let Some(switch) = &mut self.workspace_switch {
-            switch.offset(1);
+            if idx as f64 <= switch.target_idx() {
+                switch.offset(1);
+            }
         }
     }
 
+    pub fn add_workspace_top(&mut self) {
+        self.add_workspace_at(0);
+    }
+
     pub fn add_workspace_bottom(&mut self) {
-        let ws = Workspace::new(
-            self.output.clone(),
-            self.clock.clone(),
-            self.options.clone(),
-        );
-        self.workspaces.push(ws);
+        self.add_workspace_at(self.workspaces.len());
     }
 
     fn activate_workspace(&mut self, idx: usize) {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -1,4 +1,5 @@
 use std::cmp::min;
+use std::iter::zip;
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -20,7 +21,7 @@ use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::RenderTarget;
 use crate::rubber_band::RubberBand;
 use crate::utils::transaction::Transaction;
-use crate::utils::{output_size, round_logical_in_physical, ResizeEdge};
+use crate::utils::{output_size, ResizeEdge};
 
 /// Amount of touchpad movement to scroll the height of one workspace.
 const WORKSPACE_GESTURE_MOVEMENT: f64 = 300.;
@@ -666,31 +667,8 @@ impl<W: LayoutElement> Monitor<W> {
     }
 
     pub fn update_render_elements(&mut self, is_active: bool) {
-        match &self.workspace_switch {
-            Some(switch) => {
-                let render_idx = switch.current_idx();
-                let before_idx = render_idx.floor();
-                let after_idx = render_idx.ceil();
-
-                if after_idx < 0. || before_idx as usize >= self.workspaces.len() {
-                    return;
-                }
-
-                let after_idx = after_idx as usize;
-                if after_idx < self.workspaces.len() {
-                    self.workspaces[after_idx].update_render_elements(is_active);
-
-                    if before_idx < 0. {
-                        return;
-                    }
-                }
-
-                let before_idx = before_idx as usize;
-                self.workspaces[before_idx].update_render_elements(is_active);
-            }
-            None => {
-                self.workspaces[self.active_workspace_idx].update_render_elements(is_active);
-            }
+        for (ws, _) in self.workspaces_with_render_geo_mut() {
+            ws.update_render_elements(is_active);
         }
     }
 
@@ -837,72 +815,78 @@ impl<W: LayoutElement> Monitor<W> {
         Some(rect)
     }
 
-    pub fn workspaces_with_render_positions(
+    pub fn workspaces_render_geo(&self) -> impl Iterator<Item = Rectangle<f64, Logical>> {
+        let scale = self.output.current_scale().fractional_scale();
+        let size = output_size(&self.output);
+
+        // Ceil the workspace size in physical pixels.
+        let ws_size = size.to_physical_precise_ceil(scale).to_logical(scale);
+
+        let render_idx = if let Some(switch) = &self.workspace_switch {
+            switch.current_idx()
+        } else {
+            self.active_workspace_idx as f64
+        };
+
+        let first_ws_y = -render_idx * ws_size.h;
+
+        (0..self.workspaces.len()).map(move |idx| {
+            let y = first_ws_y + idx as f64 * ws_size.h;
+            let loc = Point::from((0., y));
+            let loc = loc.to_physical_precise_round(scale).to_logical(scale);
+            Rectangle::new(loc, ws_size)
+        })
+    }
+
+    pub fn workspaces_with_render_geo(
         &self,
-    ) -> impl Iterator<Item = (&Workspace<W>, Point<f64, Logical>)> {
-        let mut first = None;
-        let mut second = None;
+    ) -> impl Iterator<Item = (&Workspace<W>, Rectangle<f64, Logical>)> {
+        let output_size = output_size(&self.output);
+        let output_geo = Rectangle::new(Point::from((0., 0.)), output_size);
 
-        match &self.workspace_switch {
-            Some(switch) => {
-                let render_idx = switch.current_idx();
-                let before_idx = render_idx.floor();
-                let after_idx = render_idx.ceil();
+        let geo = self.workspaces_render_geo();
+        zip(self.workspaces.iter(), geo)
+            // Cull out workspaces outside the output.
+            .filter(move |(_ws, geo)| geo.intersection(output_geo).is_some())
+    }
 
-                if after_idx >= 0. && before_idx < self.workspaces.len() as f64 {
-                    let scale = self.output.current_scale().fractional_scale();
-                    let size = output_size(&self.output);
-                    let offset =
-                        round_logical_in_physical(scale, (render_idx - before_idx) * size.h);
+    pub fn workspaces_with_render_geo_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (&mut Workspace<W>, Rectangle<f64, Logical>)> {
+        let output_size = output_size(&self.output);
+        let output_geo = Rectangle::new(Point::from((0., 0.)), output_size);
 
-                    // Ceil the height in physical pixels.
-                    let height = (size.h * scale).ceil() / scale;
-
-                    if before_idx >= 0. {
-                        let before_idx = before_idx as usize;
-                        let before_offset = Point::from((0., -offset));
-                        first = Some((&self.workspaces[before_idx], before_offset));
-                    }
-
-                    let after_idx = after_idx as usize;
-                    if after_idx < self.workspaces.len() {
-                        let after_offset = Point::from((0., -offset + height));
-                        second = Some((&self.workspaces[after_idx], after_offset));
-                    }
-                }
-            }
-            None => {
-                first = Some((
-                    &self.workspaces[self.active_workspace_idx],
-                    Point::from((0., 0.)),
-                ));
-            }
-        }
-
-        first.into_iter().chain(second)
+        let geo = self.workspaces_render_geo();
+        zip(self.workspaces.iter_mut(), geo)
+            // Cull out workspaces outside the output.
+            .filter(move |(_ws, geo)| geo.intersection(output_geo).is_some())
     }
 
     pub fn workspace_under(
         &self,
         pos_within_output: Point<f64, Logical>,
-    ) -> Option<(&Workspace<W>, Point<f64, Logical>)> {
+    ) -> Option<(&Workspace<W>, Rectangle<f64, Logical>)> {
         let size = output_size(&self.output);
-        let (ws, bounds) = self
-            .workspaces_with_render_positions()
-            .map(|(ws, offset)| (ws, Rectangle::new(offset, size)))
-            .find(|(_, bounds)| bounds.contains(pos_within_output))?;
-        Some((ws, bounds.loc))
+        let (ws, geo) = self.workspaces_with_render_geo().find_map(|(ws, geo)| {
+            // Extend width to entire output.
+            let loc = Point::from((0., geo.loc.y));
+            let size = Size::from((size.w, geo.size.h));
+            let bounds = Rectangle::new(loc, size);
+
+            bounds.contains(pos_within_output).then_some((ws, geo))
+        })?;
+        Some((ws, geo))
     }
 
     pub fn window_under(&self, pos_within_output: Point<f64, Logical>) -> Option<(&W, HitType)> {
-        let (ws, offset) = self.workspace_under(pos_within_output)?;
-        let (win, hit) = ws.window_under(pos_within_output - offset)?;
-        Some((win, hit.offset_win_pos(offset)))
+        let (ws, geo) = self.workspace_under(pos_within_output)?;
+        let (win, hit) = ws.window_under(pos_within_output - geo.loc)?;
+        Some((win, hit.offset_win_pos(geo.loc)))
     }
 
     pub fn resize_edges_under(&self, pos_within_output: Point<f64, Logical>) -> Option<ResizeEdge> {
-        let (ws, offset) = self.workspace_under(pos_within_output)?;
-        ws.resize_edges_under(pos_within_output - offset)
+        let (ws, geo) = self.workspace_under(pos_within_output)?;
+        ws.resize_edges_under(pos_within_output - geo.loc)
     }
 
     pub fn render_above_top_layer(&self) -> bool {
@@ -950,8 +934,8 @@ impl<W: LayoutElement> Monitor<W> {
             )
         };
 
-        self.workspaces_with_render_positions()
-            .flat_map(move |(ws, offset)| {
+        self.workspaces_with_render_geo()
+            .flat_map(move |(ws, geo)| {
                 ws.render_elements(renderer, target, focus_ring)
                     .filter_map(move |elem| {
                         CropRenderElement::from_element(elem, scale, crop_bounds)
@@ -962,7 +946,7 @@ impl<W: LayoutElement> Monitor<W> {
                             // The offset we get from workspaces_with_render_positions() is already
                             // rounded to physical pixels, but it's in the logical coordinate
                             // space, so we need to convert it to physical.
-                            offset.to_physical_precise_round(scale),
+                            geo.loc.to_physical_precise_round(scale),
                             Relocate::Relative,
                         )
                     })

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -218,11 +218,7 @@ impl<W: LayoutElement> Monitor<W> {
         }
 
         // FIXME: also compute and use current velocity.
-        let current_idx = self
-            .workspace_switch
-            .as_ref()
-            .map(|s| s.current_idx())
-            .unwrap_or(self.active_workspace_idx as f64);
+        let current_idx = self.workspace_render_idx();
 
         self.previous_workspace_id = Some(self.workspaces[self.active_workspace_idx].id());
 
@@ -815,6 +811,14 @@ impl<W: LayoutElement> Monitor<W> {
         Some(rect)
     }
 
+    pub fn workspace_render_idx(&self) -> f64 {
+        if let Some(switch) = &self.workspace_switch {
+            switch.current_idx()
+        } else {
+            self.active_workspace_idx as f64
+        }
+    }
+
     pub fn workspaces_render_geo(&self) -> impl Iterator<Item = Rectangle<f64, Logical>> {
         let scale = self.output.current_scale().fractional_scale();
         let size = output_size(&self.output);
@@ -822,13 +826,7 @@ impl<W: LayoutElement> Monitor<W> {
         // Ceil the workspace size in physical pixels.
         let ws_size = size.to_physical_precise_ceil(scale).to_logical(scale);
 
-        let render_idx = if let Some(switch) = &self.workspace_switch {
-            switch.current_idx()
-        } else {
-            self.active_workspace_idx as f64
-        };
-
-        let first_ws_y = -render_idx * ws_size.h;
+        let first_ws_y = -self.workspace_render_idx() * ws_size.h;
 
         (0..self.workspaces.len()).map(move |idx| {
             let y = first_ws_y + idx as f64 * ws_size.h;
@@ -955,11 +953,7 @@ impl<W: LayoutElement> Monitor<W> {
 
     pub fn workspace_switch_gesture_begin(&mut self, is_touchpad: bool) {
         let center_idx = self.active_workspace_idx;
-        let current_idx = self
-            .workspace_switch
-            .as_ref()
-            .map(|s| s.current_idx())
-            .unwrap_or(center_idx as f64);
+        let current_idx = self.workspace_render_idx();
 
         let gesture = WorkspaceSwitchGesture {
             center_idx,

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -934,20 +934,27 @@ impl<W: LayoutElement> Monitor<W> {
 
         self.workspaces_with_render_geo()
             .flat_map(move |(ws, geo)| {
-                ws.render_elements(renderer, target, focus_ring)
-                    .filter_map(move |elem| {
-                        CropRenderElement::from_element(elem, scale, crop_bounds)
-                    })
-                    .map(move |elem| {
-                        RelocateRenderElement::from_element(
-                            elem,
-                            // The offset we get from workspaces_with_render_positions() is already
-                            // rounded to physical pixels, but it's in the logical coordinate
-                            // space, so we need to convert it to physical.
-                            geo.loc.to_physical_precise_round(scale),
-                            Relocate::Relative,
-                        )
-                    })
+                let map_ws_contents = move |elem: WorkspaceRenderElement<R>| {
+                    let elem = CropRenderElement::from_element(elem, scale, crop_bounds)?;
+                    Some(elem)
+                };
+
+                let (floating, scrolling) = ws.render_elements(renderer, target, focus_ring);
+                let floating = floating.filter_map(map_ws_contents);
+                let scrolling = scrolling.filter_map(map_ws_contents);
+
+                let iter = floating.chain(scrolling);
+
+                iter.map(move |elem| {
+                    RelocateRenderElement::from_element(
+                        elem,
+                        // The offset we get from workspaces_with_render_positions() is already
+                        // rounded to physical pixels, but it's in the logical coordinate
+                        // space, so we need to convert it to physical.
+                        geo.loc.to_physical_precise_round(scale),
+                        Relocate::Relative,
+                    )
+                })
             })
     }
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2846,14 +2846,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         Some(true)
     }
 
-    pub fn dnd_scroll_gesture_scroll(&mut self, delta: f64) {
+    pub fn dnd_scroll_gesture_scroll(&mut self, delta: f64) -> bool {
         let ViewOffset::Gesture(gesture) = &mut self.view_offset else {
-            return;
+            return false;
         };
 
         let Some(last_time) = gesture.dnd_last_event_time else {
             // Not a DnD scroll.
-            return;
+            return false;
         };
 
         let config = &self.options.gestures.dnd_edge_view_scroll;
@@ -2864,7 +2864,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         if delta == 0. {
             // We're outside the scrolling zone.
             gesture.dnd_nonzero_start_time = None;
-            return;
+            return false;
         }
 
         let nonzero_start = *gesture.dnd_nonzero_start_time.get_or_insert(now);
@@ -2873,7 +2873,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         // monitors.
         let delay = Duration::from_millis(u64::from(config.delay_ms));
         if now.saturating_sub(nonzero_start) < delay {
-            return;
+            return true;
         }
 
         let time_delta = now.saturating_sub(last_time).as_secs_f64();
@@ -2917,6 +2917,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         gesture.delta_from_tracker += clamped_offset - view_offset;
         gesture.current_view_offset = clamped_offset;
+        true
     }
 
     pub fn view_offset_gesture_end(&mut self, _cancelled: bool, is_touchpad: Option<bool>) -> bool {

--- a/src/layout/tab_indicator.rs
+++ b/src/layout/tab_indicator.rs
@@ -10,7 +10,9 @@ use crate::animation::{Animation, Clock};
 use crate::niri_render_elements;
 use crate::render_helpers::border::BorderRenderElement;
 use crate::render_helpers::renderer::NiriRenderer;
-use crate::utils::{floor_logical_in_physical_max1, round_logical_in_physical};
+use crate::utils::{
+    floor_logical_in_physical_max1, round_logical_in_physical, round_logical_in_physical_max1,
+};
 
 #[derive(Debug)]
 pub struct TabIndicator {
@@ -77,12 +79,13 @@ impl TabIndicator {
         scale: f64,
     ) -> impl Iterator<Item = Rectangle<f64, Logical>> {
         let round = |logical: f64| round_logical_in_physical(scale, logical);
+        let round_max1 = |logical: f64| round_logical_in_physical_max1(scale, logical);
 
         let progress = self.open_anim.as_ref().map_or(1., |a| a.value().max(0.));
 
-        let width = round(self.config.width.0);
-        let gap = round(self.config.gap.0);
-        let gaps_between = round(self.config.gaps_between_tabs.0);
+        let width = round_max1(self.config.width.0);
+        let gap = round_max1(self.config.gap.0);
+        let gaps_between = round_max1(self.config.gaps_between_tabs.0);
 
         let position = self.config.position;
         let side = match position {

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -576,6 +576,8 @@ enum Op {
     ViewOffsetGestureBegin {
         #[proptest(strategy = "1..=5usize")]
         output_idx: usize,
+        #[proptest(strategy = "proptest::option::of(0..=4usize)")]
+        workspace_idx: Option<usize>,
         is_touchpad: bool,
     },
     ViewOffsetGestureUpdate {
@@ -602,6 +604,13 @@ enum Op {
         cancelled: bool,
         is_touchpad: Option<bool>,
     },
+    OverviewGestureBegin,
+    OverviewGestureUpdate {
+        #[proptest(strategy = "-400f64..400f64")]
+        delta: f64,
+        timestamp: Duration,
+    },
+    OverviewGestureEnd,
     InteractiveMoveBegin {
         #[proptest(strategy = "1..=5usize")]
         window: usize,
@@ -657,6 +666,7 @@ enum Op {
         #[proptest(strategy = "1..=5usize")]
         window: usize,
     },
+    ToggleOverview,
 }
 
 impl Op {
@@ -1345,6 +1355,7 @@ impl Op {
             }
             Op::ViewOffsetGestureBegin {
                 output_idx: id,
+                workspace_idx,
                 is_touchpad: normalize,
             } => {
                 let name = format!("output{id}");
@@ -1352,7 +1363,7 @@ impl Op {
                     return;
                 };
 
-                layout.view_offset_gesture_begin(&output, normalize);
+                layout.view_offset_gesture_begin(&output, workspace_idx, normalize);
             }
             Op::ViewOffsetGestureUpdate {
                 delta,
@@ -1388,6 +1399,15 @@ impl Op {
                 is_touchpad,
             } => {
                 layout.workspace_switch_gesture_end(cancelled, is_touchpad);
+            }
+            Op::OverviewGestureBegin => {
+                layout.overview_gesture_begin();
+            }
+            Op::OverviewGestureUpdate { delta, timestamp } => {
+                layout.overview_gesture_update(delta, timestamp);
+            }
+            Op::OverviewGestureEnd => {
+                layout.overview_gesture_end();
             }
             Op::InteractiveMoveBegin {
                 window,
@@ -1441,6 +1461,9 @@ impl Op {
             }
             Op::InteractiveResizeEnd { window } => {
                 layout.interactive_resize_end(&window);
+            }
+            Op::ToggleOverview => {
+                layout.toggle_overview();
             }
         }
     }
@@ -2265,6 +2288,7 @@ fn unfullscreen_view_offset_not_reset_on_gesture() {
         Op::FullscreenWindow(1),
         Op::ViewOffsetGestureBegin {
             output_idx: 1,
+            workspace_idx: None,
             is_touchpad: true,
         },
         Op::ViewOffsetGestureEnd {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1409,7 +1409,10 @@ impl<W: LayoutElement> Workspace<W> {
         renderer: &mut R,
         target: RenderTarget,
         focus_ring: bool,
-    ) -> impl Iterator<Item = WorkspaceRenderElement<R>> {
+    ) -> (
+        impl Iterator<Item = WorkspaceRenderElement<R>>,
+        impl Iterator<Item = WorkspaceRenderElement<R>>,
+    ) {
         let scrolling_focus_ring = focus_ring && !self.floating_is_active();
         let scrolling = self
             .scrolling
@@ -1424,8 +1427,9 @@ impl<W: LayoutElement> Workspace<W> {
                     .render_elements(renderer, view_rect, target, floating_focus_ring);
             floating.into_iter().map(WorkspaceRenderElement::from)
         });
+        let floating = floating.into_iter().flatten();
 
-        floating.into_iter().flatten().chain(scrolling)
+        (floating, scrolling)
     }
 
     pub fn render_above_top_layer(&self) -> bool {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -15,12 +15,12 @@ use smithay::wayland::shell::xdg::SurfaceCachedState;
 
 use super::floating::{FloatingSpace, FloatingSpaceRenderElement};
 use super::scrolling::{
-    Column, ColumnWidth, InsertHint, InsertPosition, ScrollDirection, ScrollingSpace,
-    ScrollingSpaceRenderElement,
+    Column, ColumnWidth, ScrollDirection, ScrollingSpace, ScrollingSpaceRenderElement,
 };
 use super::tile::{Tile, TileRenderSnapshot};
 use super::{
-    ActivateWindow, HitType, InteractiveResizeData, LayoutElement, Options, RemovedTile, SizeFrac,
+    ActivateWindow, HitType, InsertPosition, InteractiveResizeData, LayoutElement, Options,
+    RemovedTile, SizeFrac,
 };
 use crate::animation::Clock;
 use crate::niri_render_elements;
@@ -1597,16 +1597,15 @@ impl<W: LayoutElement> Workspace<W> {
         }
     }
 
-    pub fn set_insert_hint(&mut self, insert_hint: InsertHint) {
-        self.scrolling.set_insert_hint(insert_hint);
+    pub(super) fn scrolling_insert_position(&self, pos: Point<f64, Logical>) -> InsertPosition {
+        self.scrolling.insert_position(pos)
     }
 
-    pub fn clear_insert_hint(&mut self) {
-        self.scrolling.clear_insert_hint();
-    }
-
-    pub fn get_insert_position(&self, pos: Point<f64, Logical>) -> InsertPosition {
-        self.scrolling.get_insert_position(pos)
+    pub(super) fn insert_hint_area(
+        &self,
+        position: InsertPosition,
+    ) -> Option<Rectangle<f64, Logical>> {
+        self.scrolling.insert_hint_area(position)
     }
 
     pub fn view_offset_gesture_begin(&mut self, is_touchpad: bool) {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, ensure, Context};
 use calloop::futures::Scheduler;
 use niri_config::{
     Config, FloatOrInt, Key, Modifiers, OutputName, PreviewRender, TrackLayout,
-    WarpMouseToFocusMode, WorkspaceReference, DEFAULT_BACKGROUND_COLOR,
+    WarpMouseToFocusMode, WorkspaceReference, DEFAULT_BACKDROP_COLOR, DEFAULT_BACKGROUND_COLOR,
 };
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::input::Keycode;
@@ -26,7 +26,8 @@ use smithay::backend::renderer::element::surface::{
     render_elements_from_surface_tree, WaylandSurfaceRenderElement,
 };
 use smithay::backend::renderer::element::utils::{
-    select_dmabuf_feedback, Relocate, RelocateRenderElement,
+    select_dmabuf_feedback, CropRenderElement, Relocate, RelocateRenderElement,
+    RescaleRenderElement,
 };
 use smithay::backend::renderer::element::{
     default_primary_scanout_output_compare, Id, Kind, PrimaryScanoutOutput, RenderElementStates,
@@ -131,7 +132,7 @@ use crate::ipc::server::IpcServer;
 use crate::layer::mapped::LayerSurfaceRenderElement;
 use crate::layer::MappedLayer;
 use crate::layout::tile::TileRenderElement;
-use crate::layout::workspace::WorkspaceId;
+use crate::layout::workspace::{Workspace, WorkspaceId};
 use crate::layout::{HitType, Layout, LayoutElement as _, MonitorRenderElement};
 use crate::niri_render_elements;
 use crate::protocols::foreign_toplevel::{self, ForeignToplevelManagerState};
@@ -344,6 +345,7 @@ pub struct Niri {
     /// Used for limiting the notify to once per iteration, so that it's not spammed with high
     /// resolution mice.
     pub notified_activity_this_iteration: bool,
+    pub pointer_inside_hot_corner: bool,
     pub tablet_cursor_location: Option<Point<f64, Logical>>,
     pub gesture_swipe_3f_cumulative: Option<(f64, f64)>,
     pub vertical_wheel_tracker: ScrollTracker,
@@ -428,6 +430,7 @@ pub struct OutputState {
     /// Solid color buffer for the background that we use instead of clearing to avoid damage
     /// tracking issues and make screenshots easier.
     pub background_buffer: SolidColorBuffer,
+    pub backdrop_buffer: SolidColorBuffer,
     pub lock_render_state: LockRenderState,
     pub lock_surface: Option<LockSurface>,
     pub lock_color_buffer: SolidColorBuffer,
@@ -467,6 +470,7 @@ pub enum KeyboardFocus {
     LayerShell { surface: WlSurface },
     LockScreen { surface: Option<WlSurface> },
     ScreenshotUi,
+    Overview,
 }
 
 #[derive(Default, Clone, PartialEq)]
@@ -563,6 +567,7 @@ impl KeyboardFocus {
             KeyboardFocus::LayerShell { surface } => Some(surface),
             KeyboardFocus::LockScreen { surface } => surface.as_ref(),
             KeyboardFocus::ScreenshotUi => None,
+            KeyboardFocus::Overview => None,
         }
     }
 
@@ -572,11 +577,16 @@ impl KeyboardFocus {
             KeyboardFocus::LayerShell { surface } => Some(surface),
             KeyboardFocus::LockScreen { surface } => surface,
             KeyboardFocus::ScreenshotUi => None,
+            KeyboardFocus::Overview => None,
         }
     }
 
     pub fn is_layout(&self) -> bool {
         matches!(self, KeyboardFocus::Layout { .. })
+    }
+
+    pub fn is_overview(&self) -> bool {
+        matches!(self, KeyboardFocus::Overview)
     }
 }
 
@@ -1040,6 +1050,11 @@ impl State {
                 surface = surface.or_else(|| focus_on_layer(Layer::Background));
             } else {
                 surface = surface.or_else(|| focus_on_layer(Layer::Top));
+
+                if self.niri.layout.is_overview_open() {
+                    surface = Some(surface.unwrap_or(KeyboardFocus::Overview));
+                }
+
                 surface = surface.or_else(|| on_d_focus_on_layer(Layer::Bottom));
                 surface = surface.or_else(|| on_d_focus_on_layer(Layer::Background));
                 surface = surface.or_else(layout_focus);
@@ -2392,6 +2407,7 @@ impl Niri {
             pointer_inactivity_timer: None,
             pointer_inactivity_timer_got_reset: false,
             notified_activity_this_iteration: false,
+            pointer_inside_hot_corner: false,
             tablet_cursor_location: None,
             gesture_swipe_3f_cumulative: None,
             vertical_wheel_tracker: ScrollTracker::new(120),
@@ -2640,6 +2656,9 @@ impl Niri {
             .to_array_unpremul();
         background_color[3] = 1.;
 
+        let mut backdrop_color = DEFAULT_BACKDROP_COLOR.to_array_unpremul();
+        backdrop_color[3] = 1.;
+
         // FIXME: fix winit damage on other transforms.
         if name.connector == "winit" {
             transform = Transform::Flipped180;
@@ -2673,6 +2692,7 @@ impl Niri {
             last_drm_sequence: None,
             frame_callback_sequence: 0,
             background_buffer: SolidColorBuffer::new(size, background_color),
+            backdrop_buffer: SolidColorBuffer::new(size, backdrop_color),
             lock_render_state,
             lock_surface: None,
             lock_color_buffer: SolidColorBuffer::new(size, CLEAR_COLOR_LOCKED),
@@ -2777,6 +2797,7 @@ impl Niri {
 
         if let Some(state) = self.output_state.get_mut(output) {
             state.background_buffer.resize(output_size);
+            state.backdrop_buffer.resize(output_size);
 
             state.lock_color_buffer.resize(output_size);
             if let Some(lock_surface) = &state.lock_surface {
@@ -2876,15 +2897,56 @@ impl Niri {
             return false;
         }
 
-        if layer_popup_under(Layer::Top)
-            || layer_toplevel_under(Layer::Top)
-            || layer_popup_under(Layer::Bottom)
-            || layer_popup_under(Layer::Background)
-        {
+        let hot_corner = Rectangle::from_size(Size::from((1., 1.)));
+        if hot_corner.contains(pos_within_output) {
+            return true;
+        }
+
+        if layer_popup_under(Layer::Top) || layer_toplevel_under(Layer::Top) {
+            return true;
+        }
+
+        if self.layout.is_overview_open() {
+            return false;
+        }
+
+        if layer_popup_under(Layer::Bottom) || layer_popup_under(Layer::Background) {
             return true;
         }
 
         false
+    }
+
+    /// Returns the workspace under the position to be activated.
+    ///
+    /// The return value is an output and a workspace index on it.
+    pub fn workspace_under(
+        &self,
+        extended_bounds: bool,
+        pos: Point<f64, Logical>,
+    ) -> Option<(Output, &Workspace<Mapped>)> {
+        if self.is_locked() || self.screenshot_ui.is_open() {
+            return None;
+        }
+
+        let (output, pos_within_output) = self.output_under(pos)?;
+
+        if self.is_layout_obscured_under(output, pos_within_output) {
+            return None;
+        }
+
+        let ws = self
+            .layout
+            .workspace_under(extended_bounds, output, pos_within_output)?;
+        Some((output.clone(), ws))
+    }
+
+    pub fn workspace_under_cursor(
+        &self,
+        extended_bounds: bool,
+    ) -> Option<(Output, &Workspace<Mapped>)> {
+        let pos = self.seat.get_pointer().unwrap().current_location();
+        self.workspace_under(extended_bounds, pos)
     }
 
     /// Returns the window under the position to be activated.
@@ -3017,6 +3079,8 @@ impl Niri {
         let mut under =
             layer_popup_under(Layer::Overlay).or_else(|| layer_toplevel_under(Layer::Overlay));
 
+        let is_overview_open = self.layout.is_overview_open();
+
         // When rendering above the top layer, we put the regular monitor elements first.
         // Otherwise, we will render all layer-shell pop-ups and the top layer on top.
         if mon.render_above_top_layer() {
@@ -3029,14 +3093,28 @@ impl Niri {
                 .or_else(|| layer_toplevel_under(Layer::Bottom))
                 .or_else(|| layer_toplevel_under(Layer::Background));
         } else {
+            let hot_corner = Rectangle::from_size(Size::from((1., 1.)));
+            if hot_corner.contains(pos_within_output) {
+                return rv;
+            }
+
             under = under
                 .or_else(|| layer_popup_under(Layer::Top))
-                .or_else(|| layer_toplevel_under(Layer::Top))
-                .or_else(|| layer_popup_under(Layer::Bottom))
-                .or_else(|| layer_popup_under(Layer::Background))
-                .or_else(window_under)
-                .or_else(|| layer_toplevel_under(Layer::Bottom))
-                .or_else(|| layer_toplevel_under(Layer::Background));
+                .or_else(|| layer_toplevel_under(Layer::Top));
+
+            if !is_overview_open {
+                under = under
+                    .or_else(|| layer_popup_under(Layer::Bottom))
+                    .or_else(|| layer_popup_under(Layer::Background));
+            }
+
+            under = under.or_else(window_under);
+
+            if !is_overview_open {
+                under = under
+                    .or_else(|| layer_toplevel_under(Layer::Bottom))
+                    .or_else(|| layer_toplevel_under(Layer::Background));
+            }
         }
 
         let Some((mut surface_and_pos, (window, layer))) = under else {
@@ -3495,6 +3573,7 @@ impl Niri {
             // layer-shell, the layout will briefly draw as active, despite never having focus.
             KeyboardFocus::LockScreen { .. } => true,
             KeyboardFocus::ScreenshotUi => true,
+            KeyboardFocus::Overview => true,
         };
 
         self.layout.refresh(layout_is_active);
@@ -3748,10 +3827,18 @@ impl Niri {
             return elements;
         }
 
-        // Prepare the background element.
+        // Prepare the background elements.
         let state = self.output_state.get(output).unwrap();
+        let background_buffer = state.background_buffer.clone();
         let background = SolidColorRenderElement::from_buffer(
-            &state.background_buffer,
+            &background_buffer,
+            (0, 0),
+            output_scale,
+            1.,
+            Kind::Unspecified,
+        );
+        let backdrop = SolidColorRenderElement::from_buffer(
+            &state.backdrop_buffer,
             (0, 0),
             output_scale,
             1.,
@@ -3768,8 +3855,8 @@ impl Niri {
                     .map(OutputRenderElements::from),
             );
 
-            // Add the background for outputs that were connected while the screenshot UI was open.
-            elements.push(background);
+            // Add the backdrop for outputs that were connected while the screenshot UI was open.
+            elements.push(backdrop);
 
             if self.debug_draw_opaque_regions {
                 draw_opaque_regions(&mut elements, output_scale);
@@ -3788,7 +3875,12 @@ impl Niri {
 
         // Get monitor elements.
         let mon = self.layout.monitor_for_output(output).unwrap();
-        let monitor_elements: Vec<_> = mon.render_elements(renderer, target, focus_ring).collect();
+        let ws_scale = mon.workspace_scale();
+        let monitor_elements = Vec::from_iter(
+            mon.render_elements(renderer, target, focus_ring)
+                .map(|(geo, iter)| (geo, Vec::from_iter(iter))),
+        );
+        let insert_hint_elements = mon.render_insert_hint_between_workspaces(renderer);
         let int_move_elements: Vec<_> = self
             .layout
             .render_interactive_move_for_output(renderer, output, target)
@@ -3824,27 +3916,82 @@ impl Niri {
                     .into_iter()
                     .map(OutputRenderElements::from),
             );
-            elements.extend(monitor_elements.into_iter().map(OutputRenderElements::from));
+            elements.extend(
+                insert_hint_elements
+                    .into_iter()
+                    .map(OutputRenderElements::from),
+            );
+            elements.extend(
+                monitor_elements
+                    .into_iter()
+                    .flat_map(|(_, iter)| iter)
+                    .map(OutputRenderElements::from),
+            );
 
             elements.extend(top_layer.into_iter().map(OutputRenderElements::from));
             elements.extend(layer_elems.popups.drain(..).map(OutputRenderElements::from));
             elements.extend(layer_elems.normal.drain(..).map(OutputRenderElements::from));
+
+            // TODO background
         } else {
             elements.extend(top_layer.into_iter().map(OutputRenderElements::from));
-            elements.extend(layer_elems.popups.drain(..).map(OutputRenderElements::from));
 
+            // TODO: adjust input to put interactive move above popups.
             elements.extend(
                 int_move_elements
                     .into_iter()
                     .map(OutputRenderElements::from),
             );
-            elements.extend(monitor_elements.into_iter().map(OutputRenderElements::from));
 
-            elements.extend(layer_elems.normal.drain(..).map(OutputRenderElements::from));
+            elements.extend(
+                insert_hint_elements
+                    .into_iter()
+                    .map(OutputRenderElements::from),
+            );
+
+            for (ws_geo, ws_elements) in monitor_elements {
+                // Collect all other layer-shell elements.
+                let mut layer_elems = SplitElements::default();
+                extend_from_layer(&mut layer_elems, Layer::Bottom);
+                extend_from_layer(&mut layer_elems, Layer::Background);
+
+                let ws_geo = ws_geo.to_physical_precise_round(output_scale);
+                for elem in layer_elems.popups {
+                    let elem =
+                        RescaleRenderElement::from_element(elem, Point::from((0, 0)), ws_scale);
+                    let elem =
+                        RelocateRenderElement::from_element(elem, ws_geo.loc, Relocate::Relative);
+                    if let Some(elem) = CropRenderElement::from_element(elem, output_scale, ws_geo)
+                    {
+                        elements.push(OutputRenderElements::from(elem));
+                    }
+                }
+
+                elements.extend(ws_elements.into_iter().map(OutputRenderElements::from));
+
+                for elem in layer_elems.normal {
+                    let elem =
+                        RescaleRenderElement::from_element(elem, Point::from((0, 0)), ws_scale);
+                    let elem =
+                        RelocateRenderElement::from_element(elem, ws_geo.loc, Relocate::Relative);
+                    if let Some(elem) = CropRenderElement::from_element(elem, output_scale, ws_geo)
+                    {
+                        elements.push(OutputRenderElements::from(elem));
+                    }
+                }
+
+                let elem = background.clone();
+                let elem = RescaleRenderElement::from_element(elem, Point::from((0, 0)), ws_scale);
+                let elem =
+                    RelocateRenderElement::from_element(elem, ws_geo.loc, Relocate::Relative);
+                if let Some(elem) = CropRenderElement::from_element(elem, output_scale, ws_geo) {
+                    elements.push(OutputRenderElements::from(elem));
+                }
+            }
         }
 
-        // Then the background.
-        elements.push(background);
+        // Then the backdrop.
+        elements.push(backdrop);
 
         if self.debug_draw_opaque_regions {
             draw_opaque_regions(&mut elements, output_scale);
@@ -5433,7 +5580,7 @@ impl Niri {
         }
 
         if let Some(window) = &new_focus.window {
-            if current_focus.window.as_ref() != Some(window) {
+            if !self.layout.is_overview_open() && current_focus.window.as_ref() != Some(window) {
                 let (window, hit) = window;
 
                 // Don't trigger focus-follows-mouse over the tab indicator.
@@ -5671,10 +5818,17 @@ niri_render_elements! {
     OutputRenderElements<R> => {
         Monitor = MonitorRenderElement<R>,
         Tile = TileRenderElement<R>,
+        RescaledTile = RescaleRenderElement<TileRenderElement<R>>,
         LayerSurface = LayerSurfaceRenderElement<R>,
+        RelocatedLayerSurface = CropRenderElement<RelocateRenderElement<RescaleRenderElement<
+            LayerSurfaceRenderElement<R>
+        >>>,
         Wayland = WaylandSurfaceRenderElement<R>,
         NamedPointer = MemoryRenderBufferRenderElement<R>,
         SolidColor = SolidColorRenderElement,
+        RelocatedSolidColor = CropRenderElement<RelocateRenderElement<RescaleRenderElement<
+            SolidColorRenderElement
+        >>>,
         ScreenshotUi = ScreenshotUiRenderElement,
         Texture = PrimaryGpuTextureRenderElement,
         // Used for the CPU-rendered panels.

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2872,11 +2872,14 @@ impl Niri {
         }
 
         let mon = self.layout.monitor_for_output(output).unwrap();
-        if !mon.render_above_top_layer()
-            && (layer_popup_under(Layer::Top)
-                || layer_toplevel_under(Layer::Top)
-                || layer_popup_under(Layer::Bottom)
-                || layer_popup_under(Layer::Background))
+        if mon.render_above_top_layer() {
+            return false;
+        }
+
+        if layer_popup_under(Layer::Top)
+            || layer_toplevel_under(Layer::Top)
+            || layer_popup_under(Layer::Bottom)
+            || layer_popup_under(Layer::Background)
         {
             return true;
         }

--- a/src/render_helpers/shader_element.rs
+++ b/src/render_helpers/shader_element.rs
@@ -245,6 +245,11 @@ impl ShaderRenderElement {
         self.area.loc = location;
         self
     }
+
+    pub fn with_alpha(mut self, alpha: f32) -> Self {
+        self.alpha = alpha;
+        self
+    }
 }
 
 impl Element for ShaderRenderElement {

--- a/src/render_helpers/shadow.rs
+++ b/src/render_helpers/shadow.rs
@@ -175,6 +175,11 @@ impl ShadowRenderElement {
         self
     }
 
+    pub fn with_alpha(mut self, alpha: f32) -> Self {
+        self.inner = self.inner.with_alpha(alpha);
+        self
+    }
+
     pub fn has_shader(renderer: &mut impl NiriRenderer) -> bool {
         Shaders::get(renderer)
             .program(ProgramType::Shadow)

--- a/src/tests/client.rs
+++ b/src/tests/client.rs
@@ -231,6 +231,14 @@ impl Window {
         self.surface.attach(Some(&buffer), 0, 0);
     }
 
+    pub fn set_min_size(&self, w: u16, h: u16) {
+        self.xdg_toplevel.set_min_size(i32::from(w), i32::from(h));
+    }
+
+    pub fn set_max_size(&self, w: u16, h: u16) {
+        self.xdg_toplevel.set_max_size(i32::from(w), i32::from(h));
+    }
+
     pub fn set_size(&self, w: u16, h: u16) {
         self.viewport.set_destination(i32::from(w), i32::from(h));
     }

--- a/src/tests/window_opening.rs
+++ b/src/tests/window_opening.rs
@@ -95,6 +95,52 @@ fn dont_ack_initial_configure() {
     );
 }
 
+#[test]
+fn commit_before_initial_configure() {
+    let mut f = Fixture::new();
+
+    let id = f.add_client();
+    let window = f.client(id).create_window();
+    let surface = window.surface.clone();
+    window.commit();
+
+    // Attach and commit before niri's loop has a chance to run.
+    window.attach_new_buffer();
+    window.commit();
+
+    f.double_roundtrip(id);
+
+    let window = f.client(id).window(&surface);
+    assert_snapshot!(
+        window.format_recent_configures(),
+        @"size: 1 × 688, bounds: 1248 × 688, states: []"
+    );
+}
+
+// FIXME: this test currently panics. Uncomment and rename after it's checked in Smithay.
+//
+// https://github.com/Smithay/smithay/issues/1717
+#[test]
+fn commit_before_initial_configure_floating_fixme() {
+    let mut f = Fixture::new();
+
+    let id = f.add_client();
+    let window = f.client(id).create_window();
+
+    // Set fixed size to force floating.
+    window.set_min_size(1, 1);
+    window.set_max_size(1, 1);
+
+    window.commit();
+
+    // Attach and commit before niri's loop has a chance to run.
+    window.attach_new_buffer();
+    window.commit();
+
+    // FIXME: uncomment this.
+    // f.double_roundtrip(id);
+}
+
 #[derive(Clone, Copy)]
 enum WantFullscreen {
     No,


### PR DESCRIPTION
Implements #850. Related: #849.

This is an overview. It zooms out your workspaces and lets you move your windows around.

https://github.com/user-attachments/assets/c3a3fd5d-0a2c-490b-a47f-3fff7826e347

Open it with a new `toggle-overview` bind, or via the top-left hot corner, or via a touchpad four-finger swipe up. While in the overview, all keyboard navigation keeps working, while pointing devices get easier:
- Mouse: left click for interactive-move, right click to scroll a workspace left/right (no Mod required).
- Touchpad: two-finger gestures TBD, for now use the normal three-finger gestures.
- Touchscreen: TBD.

The overview hot corner has some differences from a layer-shell impl like waycorner:
- It is automatically disabled when a fullscreen window is on the monitor.
- It does not prevent direct scanout because it does not render anything.
- It works during interactive move and drag-and-drop.

Drag-and-drop will also scroll the workspaces up/down in the overview, and will activate the workspace in the overview if you hold it above for a moment. Combined with the hot corner, this lets you do a mouse-only DnD across workspaces.

https://github.com/user-attachments/assets/5f09c5b7-ff40-462b-8b9c-f1b8073a2cbb

You can also drag-and-drop to a new workspace above, below, or in-between existing workspaces.

https://github.com/user-attachments/assets/b76d5349-aa20-4889-ab90-0a51554c789d

New options:
- `overview-open-close` in `animations {}`
- `dnd-edge-workspace-switch` in `gestures {}`

I'm looking for testing and feedback:
- bugs and crashes
- wrong behavior with good justification on why it is wrong
- features with good justification; if it's small enough I may consider it for this PR, otherwise maybe for later
- config options **only** with good justification why they are needed and example how they should look in the config, which should be consistent with the rest of the config

Some issues that I know about:
- [ ] Mouse scroll to switch workspaces during interactive move in the overview doesn't work properly.
- [ ] Mouse scroll in the overview affects focused output instead of output under cursor.
- [ ] Drag-and-drop hold over a window outside the viewport doesn't scroll to that window after focusing the workspace.
- [ ] There's some animation jank when interactively moving a window to a new workspace above first.
- [ ] Zoom in + scroll window into view animation is not linear; I'm not yet sure if it's fixable or not for this PR, will have to look into it.

Some TBD things for this PR:
- [ ] Touchpad two-finger scrolling in the overview that will match three-finger scrolling.
- [ ] Touchscreen gestures within the overview.

Some things definitely out of scope for this PR:
- Window icons. This requires searching and keeping track of .desktop files to match Wayland app-id to icons, which is a whole endeavor all by itself.
- 1 pixel jank with thin borders, gaps, and in general in the overview. This requires a big refactor of the niri rendering. I gave it a honest attempt, and it is way too big and error prone to do for this PR.
- Scaling down windows, preserving gap sizes, other overview window layout ideas. This requires the same refactor as above, plus the design still needs experimentation.
- Animations for workspace movement, removal, addition: a lot of work.
- DnD entire workspaces: a lot of work, though would be cool, and is a natural overview feature.
- Put blurred background on the backdrop or w/e: we don't have blur yet, also we can't just take the bottom layer-shell layer because if you have desktop icons there then it will look weird. So idk this might be blocked on adding desktop backgrounds support to niri itself. Also unclear how it should work with per-workspace bg that will be a thing when that happens.