### PR TITLE
feat: implement support to enable numlock at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,7 +2721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2965,8 +2965,8 @@ dependencies = [
  "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -3022,8 +3022,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3033,7 +3043,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3046,12 +3066,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3401,7 +3430,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smithay"
 version = "0.6.0"
-source = "git+https://github.com/Smithay/smithay.git#f85d06a4629795f5008b573f6b48606db9ff6d71"
+source = "git+https://github.com/Smithay/smithay.git#c1f13a6b9605c9f7009122a7b2b34f210255dac3"
 dependencies = [
  "aliasable",
  "appendlist",
@@ -3426,11 +3455,11 @@ dependencies = [
  "pixman",
  "pkg-config",
  "profiling",
- "rand",
+ "rand 0.9.1",
  "rustix 0.38.44",
  "smallvec",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
  "udev",
  "wayland-backend",
@@ -3474,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#f85d06a4629795f5008b573f6b48606db9ff6d71"
+source = "git+https://github.com/Smithay/smithay.git#c1f13a6b9605c9f7009122a7b2b34f210255dac3"
 dependencies = [
  "drm",
  "libdisplay-info",

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -120,6 +120,8 @@ pub struct Keyboard {
     pub repeat_rate: u8,
     #[knuffel(child, unwrap(argument), default)]
     pub track_layout: TrackLayout,
+    #[knuffel(child)]
+    pub numlock: bool,
 }
 
 impl Default for Keyboard {
@@ -129,6 +131,7 @@ impl Default for Keyboard {
             repeat_delay: 600,
             repeat_rate: 25,
             track_layout: Default::default(),
+            numlock: Default::default(),
         }
     }
 }
@@ -4059,6 +4062,7 @@ mod tests {
                     repeat_delay: 600,
                     repeat_rate: 25,
                     track_layout: Window,
+                    numlock: false,
                 },
                 touchpad: Touchpad {
                     off: false,

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -16,6 +16,9 @@ input {
             // layout "us,ru"
             // options "grp:win_space_toggle,compose:ralt,ctrl:nocaps"
         }
+
+        // Enable numlock on startup, omitting this setting disables it.
+        numlock
     }
 
     // Next sections include libinput settings.

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -23,6 +23,7 @@ input {
         // repeat-delay 600
         // repeat-rate 25
         // track-layout "global"
+        numlock
     }
 
     touchpad {
@@ -162,6 +163,20 @@ input {
     keyboard {
         repeat-delay 600
         repeat-rate 25
+    }
+}
+```
+
+#### Num Lock
+
+Set the `numlock` flag to turn on Num Lock automatically at startup.
+
+You might want to disable (comment out) `numlock` if you're using a laptop with a keyboard that overlays Num Lock keys on top of regular keys.
+
+```kdl
+input {
+    keyboard {
+        numlock
     }
 }
 ```


### PR DESCRIPTION
This PR implements a config setting to enable numlock at startup as requested in https://github.com/YaLTeR/niri/issues/291.

The code works on my machine (aside from the bug mentioned by @YaLTeR in https://github.com/YaLTeR/niri/pull/127#issuecomment-1913650587 where the numlock led stays off until the first input event is received.)

I still have to find out what the idiomatic way to coming up with the new serialized modifier_state is.

Questions I have:
- [x] Do the expected values change between different keymappings?
  - Answer: possibly - implemented a lookup inside set_modifier_state in smithay
- [x] should the serialization step happen here in niri or inside the set_modifier_state method in smithay?
    - Answer: implemented ad hoc serialization inside set_modifier_state in smithay
- [x] Does this implementation enable numlock whenever a new keyboard is added? Is this a bug?
- [x] should I add some tests?

Depends on: https://github.com/Smithay/smithay/pull/1721.