### PR TITLE
Add `focus_target_workspace` arg to `MoveColumnToWorkspace` actions (#457)

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1734,9 +1734,12 @@ pub enum Action {
         reference: WorkspaceReference,
         focus: bool,
     },
-    MoveColumnToWorkspaceDown,
-    MoveColumnToWorkspaceUp,
-    MoveColumnToWorkspace(#[knuffel(argument)] WorkspaceReference),
+    MoveColumnToWorkspaceDown(#[knuffel(property(name = "focus"), default = true)] bool),
+    MoveColumnToWorkspaceUp(#[knuffel(property(name = "focus"), default = true)] bool),
+    MoveColumnToWorkspace(
+        #[knuffel(argument)] WorkspaceReference,
+        #[knuffel(property(name = "focus"), default = true)] bool,
+    ),
     MoveWorkspaceDown,
     MoveWorkspaceUp,
     MoveWorkspaceToIndex(#[knuffel(argument)] usize),
@@ -1970,10 +1973,14 @@ impl From<niri_ipc::Action> for Action {
                 reference: WorkspaceReference::from(reference),
                 focus,
             },
-            niri_ipc::Action::MoveColumnToWorkspaceDown {} => Self::MoveColumnToWorkspaceDown,
-            niri_ipc::Action::MoveColumnToWorkspaceUp {} => Self::MoveColumnToWorkspaceUp,
-            niri_ipc::Action::MoveColumnToWorkspace { reference } => {
-                Self::MoveColumnToWorkspace(WorkspaceReference::from(reference))
+            niri_ipc::Action::MoveColumnToWorkspaceDown { focus } => {
+                Self::MoveColumnToWorkspaceDown(focus)
+            }
+            niri_ipc::Action::MoveColumnToWorkspaceUp { focus } => {
+                Self::MoveColumnToWorkspaceUp(focus)
+            }
+            niri_ipc::Action::MoveColumnToWorkspace { reference, focus } => {
+                Self::MoveColumnToWorkspace(WorkspaceReference::from(reference), focus)
             }
             niri_ipc::Action::MoveWorkspaceDown {} => Self::MoveWorkspaceDown,
             niri_ipc::Action::MoveWorkspaceUp {} => Self::MoveWorkspaceUp,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -438,14 +438,35 @@ pub enum Action {
         focus: bool,
     },
     /// Move the focused column to the workspace below.
-    MoveColumnToWorkspaceDown {},
+    MoveColumnToWorkspaceDown {
+        /// Whether the focus should follow the target workspace.
+        ///
+        /// If `true` (the default), the focus will follow the column to the new workspace. If
+        /// `false`, the focus will remain on the original workspace.
+        #[cfg_attr(feature = "clap", arg(long, action = clap::ArgAction::Set, default_value_t = true))]
+        focus: bool,
+    },
     /// Move the focused column to the workspace above.
-    MoveColumnToWorkspaceUp {},
+    MoveColumnToWorkspaceUp {
+        /// Whether the focus should follow the target workspace.
+        ///
+        /// If `true` (the default), the focus will follow the column to the new workspace. If
+        /// `false`, the focus will remain on the original workspace.
+        #[cfg_attr(feature = "clap", arg(long, action = clap::ArgAction::Set, default_value_t = true))]
+        focus: bool,
+    },
     /// Move the focused column to a workspace by reference (index or name).
     MoveColumnToWorkspace {
         /// Reference (index or name) of the workspace to move the column to.
         #[cfg_attr(feature = "clap", arg())]
         reference: WorkspaceReferenceArg,
+
+        /// Whether the focus should follow the target workspace.
+        ///
+        /// If `true` (the default), the focus will follow the column to the new workspace. If
+        /// `false`, the focus will remain on the original workspace.
+        #[cfg_attr(feature = "clap", arg(long, action = clap::ArgAction::Set, default_value_t = true))]
+        focus: bool,
     },
     /// Move the focused workspace down.
     MoveWorkspaceDown {},

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1230,19 +1230,19 @@ impl State {
                     }
                 }
             }
-            Action::MoveColumnToWorkspaceDown => {
-                self.niri.layout.move_column_to_workspace_down();
+            Action::MoveColumnToWorkspaceDown(focus) => {
+                self.niri.layout.move_column_to_workspace_down(focus);
                 self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
-            Action::MoveColumnToWorkspaceUp => {
-                self.niri.layout.move_column_to_workspace_up();
+            Action::MoveColumnToWorkspaceUp(focus) => {
+                self.niri.layout.move_column_to_workspace_up(focus);
                 self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
-            Action::MoveColumnToWorkspace(reference) => {
+            Action::MoveColumnToWorkspace(reference, focus) => {
                 if let Some((mut output, index)) =
                     self.niri.find_output_and_workspace_index(reference)
                 {
@@ -1255,13 +1255,15 @@ impl State {
                     if let Some(output) = output {
                         self.niri
                             .layout
-                            .move_column_to_workspace_on_output(&output, index);
-                        if !self.maybe_warp_cursor_to_focus_centered() {
+                            .move_column_to_output(&output, Some(index), focus);
+                        if focus && !self.maybe_warp_cursor_to_focus_centered() {
                             self.move_cursor_to_output(&output);
                         }
                     } else {
-                        self.niri.layout.move_column_to_workspace(index);
-                        self.maybe_warp_cursor_to_focus();
+                        self.niri.layout.move_column_to_workspace(index, focus);
+                        if focus {
+                            self.maybe_warp_cursor_to_focus();
+                        }
                     }
 
                     // FIXME: granular
@@ -1639,7 +1641,7 @@ impl State {
             }
             Action::MoveColumnToMonitorLeft => {
                 if let Some(output) = self.niri.output_left() {
-                    self.niri.layout.move_column_to_output(&output);
+                    self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
                         self.move_cursor_to_output(&output);
@@ -1648,7 +1650,7 @@ impl State {
             }
             Action::MoveColumnToMonitorRight => {
                 if let Some(output) = self.niri.output_right() {
-                    self.niri.layout.move_column_to_output(&output);
+                    self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
                         self.move_cursor_to_output(&output);
@@ -1657,7 +1659,7 @@ impl State {
             }
             Action::MoveColumnToMonitorDown => {
                 if let Some(output) = self.niri.output_down() {
-                    self.niri.layout.move_column_to_output(&output);
+                    self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
                         self.move_cursor_to_output(&output);
@@ -1666,7 +1668,7 @@ impl State {
             }
             Action::MoveColumnToMonitorUp => {
                 if let Some(output) = self.niri.output_up() {
-                    self.niri.layout.move_column_to_output(&output);
+                    self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
                         self.move_cursor_to_output(&output);
@@ -1675,7 +1677,7 @@ impl State {
             }
             Action::MoveColumnToMonitorPrevious => {
                 if let Some(output) = self.niri.output_previous() {
-                    self.niri.layout.move_column_to_output(&output);
+                    self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
                         self.move_cursor_to_output(&output);
@@ -1684,7 +1686,7 @@ impl State {
             }
             Action::MoveColumnToMonitorNext => {
                 if let Some(output) = self.niri.output_next() {
-                    self.niri.layout.move_column_to_output(&output);
+                    self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
                         self.move_cursor_to_output(&output);
@@ -1693,7 +1695,7 @@ impl State {
             }
             Action::MoveColumnToMonitor(output) => {
                 if let Some(output) = self.niri.output_by_name_match(&output).cloned() {
-                    self.niri.layout.move_column_to_output(&output);
+                    self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
                         self.move_cursor_to_output(&output);

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1888,7 +1888,7 @@ impl<W: LayoutElement> Layout<W> {
             }
         }
 
-        self.move_column_to_output(output);
+        self.move_column_to_output(output, None, true);
         true
     }
 
@@ -1899,7 +1899,7 @@ impl<W: LayoutElement> Layout<W> {
             }
         }
 
-        self.move_column_to_output(output);
+        self.move_column_to_output(output, None, true);
         true
     }
 
@@ -2213,31 +2213,25 @@ impl<W: LayoutElement> Layout<W> {
         monitor.move_to_workspace(window, idx, activate);
     }
 
-    pub fn move_column_to_workspace_up(&mut self) {
+    pub fn move_column_to_workspace_up(&mut self, activate: bool) {
         let Some(monitor) = self.active_monitor() else {
             return;
         };
-        monitor.move_column_to_workspace_up();
+        monitor.move_column_to_workspace_up(activate);
     }
 
-    pub fn move_column_to_workspace_down(&mut self) {
+    pub fn move_column_to_workspace_down(&mut self, activate: bool) {
         let Some(monitor) = self.active_monitor() else {
             return;
         };
-        monitor.move_column_to_workspace_down();
+        monitor.move_column_to_workspace_down(activate);
     }
 
-    pub fn move_column_to_workspace(&mut self, idx: usize) {
+    pub fn move_column_to_workspace(&mut self, idx: usize, activate: bool) {
         let Some(monitor) = self.active_monitor() else {
             return;
         };
-        monitor.move_column_to_workspace(idx);
-    }
-
-    pub fn move_column_to_workspace_on_output(&mut self, output: &Output, idx: usize) {
-        self.move_column_to_output(output);
-        self.focus_output(output);
-        self.move_column_to_workspace(idx);
+        monitor.move_column_to_workspace(idx, activate);
     }
 
     pub fn switch_workspace_up(&mut self) {
@@ -3559,7 +3553,12 @@ impl<W: LayoutElement> Layout<W> {
         }
     }
 
-    pub fn move_column_to_output(&mut self, output: &Output) {
+    pub fn move_column_to_output(
+        &mut self,
+        output: &Output,
+        target_ws_idx: Option<usize>,
+        activate: bool,
+    ) {
         if let MonitorSet::Normal {
             monitors,
             active_monitor_idx,
@@ -3583,8 +3582,10 @@ impl<W: LayoutElement> Layout<W> {
                 return;
             };
 
-            let workspace_idx = monitors[new_idx].active_workspace_idx;
-            self.add_column_by_idx(new_idx, workspace_idx, column, true);
+            let workspace_idx = target_ws_idx
+                .unwrap_or(monitors[new_idx].active_workspace_idx)
+                .min(monitors[new_idx].workspaces.len() - 1);
+            self.add_column_by_idx(new_idx, workspace_idx, column, activate);
         }
     }
 

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -738,7 +738,7 @@ impl<W: LayoutElement> Monitor<W> {
         }
     }
 
-    pub fn move_column_to_workspace_up(&mut self) {
+    pub fn move_column_to_workspace_up(&mut self, activate: bool) {
         let source_workspace_idx = self.active_workspace_idx;
 
         let new_idx = source_workspace_idx.saturating_sub(1);
@@ -756,10 +756,10 @@ impl<W: LayoutElement> Monitor<W> {
             return;
         };
 
-        self.add_column(new_idx, column, true);
+        self.add_column(new_idx, column, activate);
     }
 
-    pub fn move_column_to_workspace_down(&mut self) {
+    pub fn move_column_to_workspace_down(&mut self, activate: bool) {
         let source_workspace_idx = self.active_workspace_idx;
 
         let new_idx = min(source_workspace_idx + 1, self.workspaces.len() - 1);
@@ -777,10 +777,10 @@ impl<W: LayoutElement> Monitor<W> {
             return;
         };
 
-        self.add_column(new_idx, column, true);
+        self.add_column(new_idx, column, activate);
     }
 
-    pub fn move_column_to_workspace(&mut self, idx: usize) {
+    pub fn move_column_to_workspace(&mut self, idx: usize, activate: bool) {
         let source_workspace_idx = self.active_workspace_idx;
 
         let new_idx = min(idx, self.workspaces.len() - 1);
@@ -798,7 +798,7 @@ impl<W: LayoutElement> Monitor<W> {
             return;
         };
 
-        self.add_column(new_idx, column, true);
+        self.add_column(new_idx, column, activate);
     }
 
     pub fn switch_workspace_up(&mut self) {

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -211,33 +211,33 @@ fn render(
     ]);
 
     // Prefer move-column-to-workspace-down, but fall back to move-window-to-workspace-down.
-    if binds
+    if let Some(bind) = binds
         .iter()
-        .any(|bind| bind.action == Action::MoveColumnToWorkspaceDown)
+        .find(|bind| matches!(bind.action, Action::MoveColumnToWorkspaceDown(_)))
     {
-        actions.push(&Action::MoveColumnToWorkspaceDown);
+        actions.push(&bind.action);
     } else if binds
         .iter()
-        .any(|bind| bind.action == Action::MoveWindowToWorkspaceDown)
+        .any(|bind| matches!(bind.action, Action::MoveWindowToWorkspaceDown))
     {
         actions.push(&Action::MoveWindowToWorkspaceDown);
     } else {
-        actions.push(&Action::MoveColumnToWorkspaceDown);
+        actions.push(&Action::MoveColumnToWorkspaceDown(true));
     }
 
     // Same for -up.
-    if binds
+    if let Some(bind) = binds
         .iter()
-        .any(|bind| bind.action == Action::MoveColumnToWorkspaceUp)
+        .find(|bind| matches!(bind.action, Action::MoveColumnToWorkspaceUp(_)))
     {
-        actions.push(&Action::MoveColumnToWorkspaceUp);
+        actions.push(&bind.action);
     } else if binds
         .iter()
-        .any(|bind| bind.action == Action::MoveWindowToWorkspaceUp)
+        .any(|bind| matches!(bind.action, Action::MoveWindowToWorkspaceUp))
     {
         actions.push(&Action::MoveWindowToWorkspaceUp);
     } else {
-        actions.push(&Action::MoveColumnToWorkspaceUp);
+        actions.push(&Action::MoveColumnToWorkspaceUp(true));
     }
 
     actions.extend(&[
@@ -424,8 +424,8 @@ fn action_name(action: &Action) -> String {
         Action::MoveColumnRight => String::from("Move Column Right"),
         Action::FocusWorkspaceDown => String::from("Switch Workspace Down"),
         Action::FocusWorkspaceUp => String::from("Switch Workspace Up"),
-        Action::MoveColumnToWorkspaceDown => String::from("Move Column to Workspace Down"),
-        Action::MoveColumnToWorkspaceUp => String::from("Move Column to Workspace Up"),
+        Action::MoveColumnToWorkspaceDown(_) => String::from("Move Column to Workspace Down"),
+        Action::MoveColumnToWorkspaceUp(_) => String::from("Move Column to Workspace Up"),
         Action::MoveWindowToWorkspaceDown => String::from("Move Window to Workspace Down"),
         Action::MoveWindowToWorkspaceUp => String::from("Move Window to Workspace Up"),
         Action::SwitchPresetColumnWidth => String::from("Switch Preset Column Widths"),


### PR DESCRIPTION
## Description:

This PR introduces a new `focus-target-workspace` argument for `move-column-to-workspace*` actions to address the use case described in #457, while maintaining backward compatibility with existing configurations.

## Changes:

- Added a **new optional argument** `focus-target-workspace` (default: `true`) to control workspace focus behavior
  - When set to `true` (default): Maintains original behavior - moves column and switches focus to target workspace
  - When set to `false`: Moves column without changing focus
- Example configurations:
  ``` 
  # New behavior: Move column without switching workspace
  Mod+Ctrl+1 { move-column-to-workspace 1 focus-target-workspace=false; }
  
  # Equivalent to original behavior (explicit)
  Mod+Ctrl+2 { move-column-to-workspace 2 focus-target-workspace=true; }
  
  # Equivalent to original behaviour (implicit default)
  Mod+Ctrl+3 { move-column-to-workspace 3; }
  ```
- Benefits of this implementation:
  - Enables batch column organization across workspaces without disruptive context switching
  - Allows temporary workspace decluttering while maintaining current focus
  - Preserves compatibility with all existing keybindings through default argument
  - Reduces code duplication by extending existing actions
- Original workflow remains unchanged for users who prefer immediate workspace switching
