### PR TITLE
`center-focused-column "enclosed"`

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -174,6 +174,7 @@ pub enum CenterFocusedColumn {
     /// Focusing a column will center it if it doesn't fit on the screen together with the
     /// previously focused column.
     OnOverflow,
+    Enclosed,
 }
 
 #[derive(knuffel::DecodeScalar, Debug, Default, PartialEq, Eq)]

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -621,6 +621,13 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     self.compute_new_view_offset_for_column_centered(target_x, idx)
                 }
             }
+	    CenterFocusedColumn::Enclosed => {
+		if idx > 0 && idx < self.columns.len()-1 {
+		    self.compute_new_view_offset_for_column_centered(target_x, idx)
+		} else {
+		    self.compute_new_view_offset_for_column_fit(target_x, idx)
+		}
+	    }
             CenterFocusedColumn::Never => {
                 self.compute_new_view_offset_for_column_fit(target_x, idx)
             }

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -3458,6 +3458,7 @@ fn arbitrary_center_focused_column() -> impl Strategy<Value = CenterFocusedColum
         Just(CenterFocusedColumn::Never),
         Just(CenterFocusedColumn::OnOverflow),
         Just(CenterFocusedColumn::Always),
+	Just(CenterFocusedColumn::Enclosed),
     ]
 }
 


### PR DESCRIPTION
`center-focused-column "enclosed"`
Focused column will be centered if it is not the outermost column