### PR TITLE
Implement IPC for the overview state

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -97,6 +97,8 @@ pub enum Request {
     EventStream,
     /// Respond with an error (for testing error handling).
     ReturnError,
+    /// Request information about the overview.
+    Overview,
 }
 
 /// Reply from niri to client.
@@ -139,6 +141,16 @@ pub enum Response {
     PickedColor(Option<PickedColor>),
     /// Output configuration change result.
     OutputConfigChanged(OutputConfigChanged),
+    /// Information about the overview.
+    Overview(Overview),
+}
+
+/// Overview information.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct Overview {
+    /// Overview opened state
+    pub opened: bool,
 }
 
 /// Color picked from the screen.
@@ -1268,6 +1280,11 @@ pub enum Event {
     KeyboardLayoutSwitched {
         /// Index of the newly active layout.
         idx: u8,
+    },
+    /// The overview opened.
+    OverviewToggled {
+        /// Opened state of the overview
+        opened: bool,
     },
 }
 

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -149,7 +149,7 @@ pub enum Response {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Overview {
-    /// Overview opened state
+    /// Whether the overview is currently open.
     pub is_open: bool,
 }
 

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -150,7 +150,7 @@ pub enum Response {
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Overview {
     /// Overview opened state
-    pub opened: bool,
+    pub is_open: bool,
 }
 
 /// Color picked from the screen.
@@ -1281,10 +1281,10 @@ pub enum Event {
         /// Index of the newly active layout.
         idx: u8,
     },
-    /// The overview opened.
-    OverviewToggled {
-        /// Opened state of the overview
-        opened: bool,
+    /// The overview was opened or closed.
+    OverviewOpenedOrClosed {
+        /// The new state of the overview.
+        is_open: bool,
     },
 }
 

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -98,7 +98,7 @@ pub enum Request {
     /// Respond with an error (for testing error handling).
     ReturnError,
     /// Request information about the overview.
-    Overview,
+    OverviewState,
 }
 
 /// Reply from niri to client.
@@ -142,7 +142,7 @@ pub enum Response {
     /// Output configuration change result.
     OutputConfigChanged(OutputConfigChanged),
     /// Information about the overview.
-    Overview(Overview),
+    OverviewState(Overview),
 }
 
 /// Overview information.

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -40,6 +40,9 @@ pub struct EventStreamState {
 
     /// State of the keyboard layouts.
     pub keyboard_layouts: KeyboardLayoutsState,
+
+    /// State of the overview.
+    pub overview: OverviewState,
 }
 
 /// The workspaces state communicated over the event stream.
@@ -61,6 +64,13 @@ pub struct WindowsState {
 pub struct KeyboardLayoutsState {
     /// Configured keyboard layouts.
     pub keyboard_layouts: Option<KeyboardLayouts>,
+}
+
+/// The overview state communicated over the event stream.
+#[derive(Debug, Default)]
+pub struct OverviewState {
+    /// State of the overview
+    pub opened: bool,
 }
 
 impl EventStreamStatePart for EventStreamState {
@@ -186,6 +196,22 @@ impl EventStreamStatePart for KeyboardLayoutsState {
                 let kb = self.keyboard_layouts.as_mut();
                 let kb = kb.expect("keyboard layouts must be set before a layout can be switched");
                 kb.current_idx = idx;
+            }
+            event => return Some(event),
+        }
+        None
+    }
+}
+
+impl EventStreamStatePart for OverviewState {
+    fn replicate(&self) -> Vec<Event> {
+        vec![Event::OverviewToggled { opened: self.opened }]
+    }
+
+    fn apply(&mut self, event: Event) -> Option<Event> {
+        match event {
+            Event::OverviewToggled { opened } => {
+                self.opened = opened;
             }
             event => return Some(event),
         }

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -207,7 +207,9 @@ impl EventStreamStatePart for KeyboardLayoutsState {
 
 impl EventStreamStatePart for OverviewState {
     fn replicate(&self) -> Vec<Event> {
-        vec![Event::OverviewOpenedOrClosed { is_open: self.is_open }]
+        vec![Event::OverviewOpenedOrClosed {
+            is_open: self.is_open,
+        }]
     }
 
     fn apply(&mut self, event: Event) -> Option<Event> {

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -70,7 +70,7 @@ pub struct KeyboardLayoutsState {
 #[derive(Debug, Default)]
 pub struct OverviewState {
     /// State of the overview
-    pub opened: bool,
+    pub is_open: bool,
 }
 
 impl EventStreamStatePart for EventStreamState {
@@ -205,13 +205,13 @@ impl EventStreamStatePart for KeyboardLayoutsState {
 
 impl EventStreamStatePart for OverviewState {
     fn replicate(&self) -> Vec<Event> {
-        vec![Event::OverviewToggled { opened: self.opened }]
+        vec![Event::OverviewOpenedOrClosed { is_open: self.is_open }]
     }
 
     fn apply(&mut self, event: Event) -> Option<Event> {
         match event {
-            Event::OverviewToggled { opened } => {
-                self.opened = opened;
+            Event::OverviewOpenedOrClosed { is_open: opened } => {
+                self.is_open = opened;
             }
             event => return Some(event),
         }

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -69,7 +69,7 @@ pub struct KeyboardLayoutsState {
 /// The overview state communicated over the event stream.
 #[derive(Debug, Default)]
 pub struct OverviewState {
-    /// State of the overview
+    /// Whether the overview is currently open.
     pub is_open: bool,
 }
 

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -210,8 +210,8 @@ impl EventStreamStatePart for OverviewState {
 
     fn apply(&mut self, event: Event) -> Option<Event> {
         match event {
-            Event::OverviewOpenedOrClosed { is_open: opened } => {
-                self.is_open = opened;
+            Event::OverviewOpenedOrClosed { is_open } => {
+                self.is_open = is_open;
             }
             event => return Some(event),
         }

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -79,6 +79,7 @@ impl EventStreamStatePart for EventStreamState {
         events.extend(self.workspaces.replicate());
         events.extend(self.windows.replicate());
         events.extend(self.keyboard_layouts.replicate());
+        events.extend(self.overview.replicate());
         events
     }
 
@@ -86,6 +87,7 @@ impl EventStreamStatePart for EventStreamState {
         let event = self.workspaces.apply(event)?;
         let event = self.windows.apply(event)?;
         let event = self.keyboard_layouts.apply(event)?;
+        let event = self.overview.apply(event)?;
         Some(event)
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,5 +106,5 @@ pub enum Msg {
     /// Request an error from the running niri instance.
     RequestError,
     /// Print the overview state.
-    Overview,
+    OverviewState,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,4 +105,6 @@ pub enum Msg {
     Version,
     /// Request an error from the running niri instance.
     RequestError,
+    /// Print the overview state.
+    Overview,
 }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -5,8 +5,8 @@ use anyhow::{anyhow, bail, Context};
 use niri_config::OutputName;
 use niri_ipc::socket::Socket;
 use niri_ipc::{
-    Event, KeyboardLayouts, LogicalOutput, Mode, Output, OutputConfigChanged, Request, Response,
-    Transform, Window, Overview,
+    Event, KeyboardLayouts, LogicalOutput, Mode, Output, OutputConfigChanged, Overview, Request,
+    Response, Transform, Window,
 };
 use serde_json::json;
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -454,7 +454,7 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                 return Ok(());
             }
 
-            let Overview { is_open: opened } = response;
+            let Overview { is_open } = response;
             if is_open {
                 println!("Overview is open");
             } else {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -456,7 +456,7 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
 
             let Overview { is_open } = response;
             if is_open {
-                println!("Overview is open");
+                println!("Overview is open.");
             } else {
                 println!("Overview is closed");
             }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -32,7 +32,7 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
         Msg::KeyboardLayouts => Request::KeyboardLayouts,
         Msg::EventStream => Request::EventStream,
         Msg::RequestError => Request::ReturnError,
-        Msg::Overview => Request::Overview,
+        Msg::OverviewState => Request::OverviewState,
     };
 
     let socket = Socket::connect().context("error connecting to the niri socket")?;
@@ -442,8 +442,8 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                 }
             }
         }
-        Msg::Overview => {
-            let Response::Overview(response) = response else {
+        Msg::OverviewState => {
+            let Response::OverviewState(response) = response else {
                 bail!("unexpected response: expected Overview, got {response:?}");
             };
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -436,7 +436,7 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                     Event::KeyboardLayoutSwitched { idx } => {
                         println!("Keyboard layout switched: {idx}");
                     }
-                    Event::OverviewToggled { opened } => {
+                    Event::OverviewOpenedOrClosed { is_open: opened } => {
                         println!("Overview toggled: {opened}");
                     }
                 }
@@ -454,8 +454,12 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                 return Ok(());
             }
 
-            let Overview { opened } = response;
-            println!("Overview: {opened}");
+            let Overview { is_open: opened } = response;
+            if is_open {
+                println!("Overview is open");
+            } else {
+                println!("Overview is closed");
+            }
         }
     }
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -458,7 +458,7 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
             if is_open {
                 println!("Overview is open.");
             } else {
-                println!("Overview is closed");
+                println!("Overview is closed.");
             }
         }
     }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -430,10 +430,10 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             Response::FocusedOutput(output)
         }
         Request::EventStream => Response::Handled,
-        Request::Overview => {
+        Request::OverviewState => {
             let state = ctx.event_stream_state.borrow();
             let is_open = state.overview.is_open;
-            Response::Overview(Overview { is_open })
+            Response::OverviewState(Overview { is_open })
         }
     };
 

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -704,13 +704,13 @@ impl State {
 
         let mut state = server.event_stream_state.borrow_mut();
         let state = &mut state.overview;
-        let opened = self.niri.layout.is_overview_open();
+        let is_open = self.niri.layout.is_overview_open();
 
-        if state.is_open == opened {
+        if state.is_open == is_open {
             return;
         }
 
-        let event = Event::OverviewOpenedOrClosed { is_open: opened };
+        let event = Event::OverviewOpenedOrClosed { is_open };
         state.apply(event.clone());
         server.send_event(event);
     }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -16,7 +16,9 @@ use futures_util::io::{AsyncReadExt, BufReader};
 use futures_util::{select_biased, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, FutureExt as _};
 use niri_config::OutputName;
 use niri_ipc::state::{EventStreamState, EventStreamStatePart as _};
-use niri_ipc::{Event, KeyboardLayouts, OutputConfigChanged, Overview, Reply, Request, Response, Workspace};
+use niri_ipc::{
+    Event, KeyboardLayouts, OutputConfigChanged, Overview, Reply, Request, Response, Workspace,
+};
 use smithay::desktop::layer_map_for_output;
 use smithay::input::pointer::{
     CursorIcon, CursorImageStatus, Focus, GrabStartData as PointerGrabStartData,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -663,7 +663,7 @@ impl State {
         state.ipc_keyboard_layouts_changed();
         // Focus the default monitor if set by the user.
         state.focus_default_monitor();
-
+        
         Ok(state)
     }
 
@@ -728,6 +728,7 @@ impl State {
         self.refresh_ipc_outputs();
         self.ipc_refresh_layout();
         self.ipc_refresh_keyboard_layout_index();
+        self.ipc_overview_toggled();
     }
 
     fn notify_blocker_cleared(&mut self) {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -663,7 +663,7 @@ impl State {
         state.ipc_keyboard_layouts_changed();
         // Focus the default monitor if set by the user.
         state.focus_default_monitor();
-        
+
         Ok(state)
     }
 
@@ -728,7 +728,6 @@ impl State {
         self.refresh_ipc_outputs();
         self.ipc_refresh_layout();
         self.ipc_refresh_keyboard_layout_index();
-        self.ipc_overview_toggled();
     }
 
     fn notify_blocker_cleared(&mut self) {


### PR DESCRIPTION
This adds the ability to query the overview's visible state and adds an event tracking the overview state. This seems to work fine, but I haven't tested it for long.