### PR TITLE
fix: don't try to create a default config at path that exists

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -355,7 +355,7 @@ fn config_path(cli_path: Option<PathBuf>) -> (PathBuf, PathBuf, bool) {
     let system_path = system_config_path();
     if let Some(path) = default_config_path() {
         if path.exists() {
-            return (path.clone(), path, true);
+            return (path.clone(), path, false);
         }
 
         if system_path.exists() {


### PR DESCRIPTION
Currently this bug has no actual consequences, we just continue silently on AlreadyExists in main()
(this line: https://github.com/YaLTeR/niri/blob/e9c6f08906143c3fec1ad1301d538bef4cbc1978/src/main.rs#L151).

This commit just eliminates the redundant attempt.