### PR TITLE
refactor(main): eliminate a `mut` from config load code in main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -161,12 +161,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let mut config_errored = false;
-    let mut config = Config::load(&path)
-        .map_err(|err| {
-            warn!("{err:?}");
-            config_errored = true;
-        })
+    let config_load_result = Config::load(&path);
+    let config_errored = config_load_result.is_err();
+    let mut config = config_load_result
+        .map_err(|err| warn!("{err:?}"))
         .unwrap_or_default();
 
     let spawn_at_startup = mem::take(&mut config.spawn_at_startup);


### PR DESCRIPTION
I think this makes for marginally better readability, since you don't have to wonder whether config_errored is set anywhere else. It's also slightly terser.

Not fussed at all if you want to reject this since it's such a bikeshed/matter of opinion.