### PR TITLE
layer-shell: properly handle re-map

### DIFF
--- a/src/handlers/layer_shell.rs
+++ b/src/handlers/layer_shell.rs
@@ -176,6 +176,20 @@ impl State {
                 } else {
                     self.niri.mapped_layer_surfaces.remove(layer);
                     self.niri.unmapped_layer_surfaces.insert(surface.clone());
+
+                    // After layer surface unmaps it has to perform the initial commit-configure
+                    // sequence again. This is a workaround until Smithay properly resets
+                    // initial_configure_sent upon the surface unmapping itself as it does for
+                    // toplevels.
+                    with_states(surface, |states| {
+                        let mut data = states
+                            .data_map
+                            .get::<LayerSurfaceData>()
+                            .unwrap()
+                            .lock()
+                            .unwrap();
+                        data.initial_configure_sent = false;
+                    });
                 }
             } else {
                 let scale = output.current_scale();


### PR DESCRIPTION
According to the zwlr_layer_surface_v1 documentation: Unmapping a layer_surface means that the surface cannot be shown by the compositor until it is explicitly mapped again. The layer_surface returns to the state it had right after layer_shell.get_layer_surface. The client can re-map the surface by performing a commit without any buffer attached, waiting for a configure event and handling it as usual.

Before this commit, no configure event was sent when a client performed a commit without any buffer attached.