### PR TITLE
feat: close fuzzel if keybind is triggered again

### DIFF
--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -342,7 +342,7 @@ binds {
 
     // Suggested binds for running programs: terminal, app launcher, screen locker.
     Mod+T hotkey-overlay-title="Open a Terminal: alacritty" { spawn "alacritty"; }
-    Mod+D hotkey-overlay-title="Run an Application: fuzzel" { spawn "fuzzel"; }
+    Mod+D hotkey-overlay-title="Run an Application: fuzzel" { spawn "bash" "-c" "pkill fuzzel || fuzzel"; }
     Super+Alt+L hotkey-overlay-title="Lock the Screen: swaylock" { spawn "swaylock"; }
 
     // You can also use a shell. Do this if you need pipes, multiple commands, etc.


### PR DESCRIPTION
This PR allows the user to close Fuzzel by simply triggering `Mod+D` again, without reaching for other key like Esc.