### PR TITLE
Add debug option to skip cursor-only updates while VRR is active

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2329,6 +2329,8 @@ pub struct DebugConfig {
     pub strict_new_window_focus_policy: bool,
     #[knuffel(child)]
     pub honor_xdg_activation_with_invalid_serial: bool,
+    #[knuffel(child)]
+    pub skip_cursor_only_updates_while_vrr: bool,
 }
 
 #[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq)]
@@ -5286,6 +5288,7 @@ mod tests {
                 disable_monitor_names: false,
                 strict_new_window_focus_policy: false,
                 honor_xdg_activation_with_invalid_serial: false,
+                skip_cursor_only_updates_while_vrr: false,
             },
             workspaces: [
                 Workspace {

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -1422,6 +1422,12 @@ impl Tty {
             if debug.disable_cursor_plane {
                 flags.remove(FrameFlags::ALLOW_CURSOR_PLANE_SCANOUT);
             }
+            if debug.skip_cursor_only_updates_while_vrr {
+                let output_state = niri.output_state.get_mut(output).unwrap();
+                if output_state.frame_clock.vrr() {
+                    flags.insert(FrameFlags::SKIP_CURSOR_ONLY_UPDATES);
+                }
+            }
 
             flags
         };

--- a/wiki/Configuration:-Debug-Options.md
+++ b/wiki/Configuration:-Debug-Options.md
@@ -29,6 +29,7 @@ debug {
     disable-monitor-names
     strict-new-window-focus-policy
     honor-xdg-activation-with-invalid-serial 
+    skip-cursor-only-updates-while-vrr
 }
 
 binds {
@@ -272,6 +273,20 @@ Maybe in the future these apps/toolkits (Electron, Qt) are fixed, making this de
 ```kdl
 debug {
     honor-xdg-activation-with-invalid-serial
+}
+```
+
+### `skip-cursor-only-updates-while-vrr`
+
+<sup>Since: next release</sup>
+
+Forces the screen not to redraw at all from cursor input while vrr is active.
+
+Useful for games where the cursor isn't drawn internally to prevent erratic vrr shifts in response to cursor movement.
+
+```kdl
+debug {
+    skip-cursor-only-updates-while-vrr
 }
 ```
 


### PR DESCRIPTION
This PR adds a debug option that allows disabling cursor-only screen redraws when VRR is active.

This is a toggleable implementation of the patch supplied by @YaLTeR in https://github.com/YaLTeR/niri/issues/1214.

I've been using this for a few weeks myself and see no issues at all when used along side VRR on-demand in games. This change makes such a huge difference in certain games that I feel like it should be included as a debug option for now until a proper bug-free implementation is ready.