### PR TITLE
add option to hide unbound actions in hotkey overlay

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1032,7 +1032,7 @@ pub struct HotkeyOverlay {
     #[knuffel(child)]
     pub skip_at_startup: bool,
     #[knuffel(child)]
-    pub hide_unbound: bool,
+    pub hide_not_bound: bool,
 }
 
 #[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -4610,7 +4610,7 @@ mod tests {
             },
             hotkey_overlay: HotkeyOverlay {
                 skip_at_startup: true,
-                hide_unbound: false,
+                hide_not_bound: false,
             },
             animations: Animations {
                 off: false,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -4610,6 +4610,7 @@ mod tests {
             },
             hotkey_overlay: HotkeyOverlay {
                 skip_at_startup: true,
+                hide_unbound: false,
             },
             animations: Animations {
                 off: false,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1031,6 +1031,8 @@ pub struct Struts {
 pub struct HotkeyOverlay {
     #[knuffel(child)]
     pub skip_at_startup: bool,
+    #[knuffel(child)]
+    pub hide_unbound: bool,
 }
 
 #[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -290,13 +290,7 @@ fn render(
         // filter out actions that aren't present in the binds
         actions = actions
             .into_iter()
-            .filter(|action| {
-                binds
-                    .iter()
-                    .map(|bind| bind.action.clone())
-                    .collect::<Vec<Action>>()
-                    .contains(action)
-            })
+            .filter(|action| binds.iter().any(|bind| bind.action == **action))
             .collect();
     }
 

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -286,12 +286,8 @@ fn render(
     }
 
     if config.hotkey_overlay.hide_not_bound {
-        // If hiding unbound hotkeys is desired
-        // filter out actions that aren't present in the binds
-        actions = actions
-            .into_iter()
-            .filter(|action| binds.iter().any(|bind| bind.action == **action))
-            .collect();
+        // Only keep actions that have been bound
+        actions.retain(|&action| binds.iter().any(|bind| bind.action == *action))
     }
 
     let strings = actions

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -129,7 +129,7 @@ fn format_bind(
     binds: &[Bind],
     mod_key: ModKey,
     action: &Action,
-    hide_unbound: bool,
+    hide_not_bound: bool,
 ) -> Option<(String, String)> {
     let mut bind_with_non_null = None;
     let mut bind_with_custom_title = None;
@@ -159,7 +159,7 @@ fn format_bind(
 
     let possible_bind = bind_with_custom_title.or(bind_with_non_null);
 
-    if possible_bind.is_none() && hide_unbound {
+    if possible_bind.is_none() && hide_not_bound {
         return None;
     }
 
@@ -299,7 +299,7 @@ fn render(
     let strings = actions
         .into_iter()
         .filter_map(|action| {
-            format_bind(binds, mod_key, action, config.hotkey_overlay.hide_unbound)
+            format_bind(binds, mod_key, action, config.hotkey_overlay.hide_not_bound)
         })
         .collect::<Vec<_>>();
 
@@ -564,10 +564,10 @@ mod tests {
     use super::*;
 
     #[track_caller]
-    fn check(config: &str, action: Action, hide_unbound: bool) -> String {
+    fn check(config: &str, action: Action, hide_not_bound: bool) -> String {
         let config = Config::parse("test.kdl", config).unwrap();
         if let Some((key, title)) =
-            format_bind(&config.binds.0, ModKey::Super, &action, hide_unbound)
+            format_bind(&config.binds.0, ModKey::Super, &action, hide_not_bound)
         {
             format!("{key}: {title}")
         } else {

--- a/wiki/Configuration:-Miscellaneous.md
+++ b/wiki/Configuration:-Miscellaneous.md
@@ -238,7 +238,8 @@ hotkey-overlay {
 #### `hide-unbound`
 
 Set the `hide-unbound` flag if you don't want to see actions that haven't been bound.
-```
+
+```kdl
 hotkey-overlay {
     hide-unbound
 }

--- a/wiki/Configuration:-Miscellaneous.md
+++ b/wiki/Configuration:-Miscellaneous.md
@@ -235,14 +235,14 @@ hotkey-overlay {
 }
 ```
 
-#### `hide-unbound`
+#### `hide-not-bound`
 
 By default, niri will show the most important actions even if they aren't bound to any key, to prevent confusion.
-Set the `hide-unbound` flag if you want to hide all actions not bound to any key.
+Set the `hide-not-bound` flag if you want to hide all actions not bound to any key.
 
 ```kdl
 hotkey-overlay {
-    hide-unbound
+    hide-not-bound
 }
 ```
 

--- a/wiki/Configuration:-Miscellaneous.md
+++ b/wiki/Configuration:-Miscellaneous.md
@@ -225,11 +225,22 @@ clipboard {
 
 Settings for the "Important Hotkeys" overlay.
 
+#### `skip-at-startup`
+
 Set the `skip-at-startup` flag if you don't want to see the hotkey help at niri startup.
 
 ```kdl
 hotkey-overlay {
     skip-at-startup
+}
+```
+
+#### `hide-unbound`
+
+Set the `hide-unbound` flag if you don't want to see actions that haven't been bound.
+```
+hotkey-overlay {
+    hide-unbound
 }
 ```
 

--- a/wiki/Configuration:-Miscellaneous.md
+++ b/wiki/Configuration:-Miscellaneous.md
@@ -237,7 +237,8 @@ hotkey-overlay {
 
 #### `hide-unbound`
 
-Set the `hide-unbound` flag if you don't want to see actions that haven't been bound.
+By default, niri will show the most important actions even if they aren't bound to any key, to prevent confusion.
+Set the `hide-unbound` flag if you want to hide all actions not bound to any key.
 
 ```kdl
 hotkey-overlay {


### PR DESCRIPTION
while it is possible to hide actions with [custom hotkey overlay titles](https://github.com/YaLTeR/niri/wiki/Configuration:-Key-Bindings#custom-hotkey-overlay-titles), it would be nice to be able to hide actions without needing to bind them. this PR introduces a configuration flag, `hotkey-overlay { hide-unbound }`.

in my particular case, i prefer to always use 1 window per column layouts, so i have `consume-or-expel-window-(left|right)` unbound (plus a plethora of other actions). in order to remove them from the hotkey overlay, i currently need to assign a bogus hotkey and set a none custom title.

<details><summary>Without `hide-unbound`</summary>
<p>

![image](https://github.com/user-attachments/assets/316ed104-3e22-4533-848b-d9b594a376e0)

</p>
</details> 

<details><summary>With `hide-unbound`</summary>
<p>

![image](https://github.com/user-attachments/assets/dfa2b105-7068-49a3-9e33-65511f943c20)

</p>
</details> 

since `hide-unbound` is an opt-in flag, it should not break/change hotkey overlays for anyone after an update.

also, i'm not sure if i've selected a good/descriptive name for this option, so i'm open for better name suggestions :)