### PR TITLE
layer-shell: only reset 'initial_configure_sent' for mapped surfaces

### DIFF
--- a/src/handlers/layer_shell.rs
+++ b/src/handlers/layer_shell.rs
@@ -174,22 +174,24 @@ impl State {
                         self.niri.layer_shell_on_demand_focus = Some(layer.clone());
                     }
                 } else {
-                    self.niri.mapped_layer_surfaces.remove(layer);
+                    let was_mapped = self.niri.mapped_layer_surfaces.remove(layer).is_some();
                     self.niri.unmapped_layer_surfaces.insert(surface.clone());
 
                     // After layer surface unmaps it has to perform the initial commit-configure
                     // sequence again. This is a workaround until Smithay properly resets
                     // initial_configure_sent upon the surface unmapping itself as it does for
                     // toplevels.
-                    with_states(surface, |states| {
-                        let mut data = states
-                            .data_map
-                            .get::<LayerSurfaceData>()
-                            .unwrap()
-                            .lock()
-                            .unwrap();
-                        data.initial_configure_sent = false;
-                    });
+                    if was_mapped {
+                        with_states(surface, |states| {
+                            let mut data = states
+                                .data_map
+                                .get::<LayerSurfaceData>()
+                                .unwrap()
+                                .lock()
+                                .unwrap();
+                            data.initial_configure_sent = false;
+                        });
+                    }
                 }
             } else {
                 let scale = output.current_scale();


### PR DESCRIPTION
Fixes regression caused by 2415346caaa4121ed202b8e376fb40b2a44eb61f.