### PR TITLE
input: do not force redraw to hide an already hidden cursor

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -472,6 +472,8 @@ impl State {
     }
 
     fn hide_cursor_if_needed(&mut self) {
+        // If the pointer is already invisible, don't reset it back to Hidden causing one frame
+        // of hover.
         if !self.niri.pointer_visibility.is_visible() {
             return;
         }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -472,6 +472,10 @@ impl State {
     }
 
     fn hide_cursor_if_needed(&mut self) {
+        if !self.niri.pointer_visibility.is_visible() {
+            return;
+        }
+
         if !self.niri.config.borrow().cursor.hide_when_typing {
             return;
         }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -5986,8 +5986,13 @@ impl Niri {
             .event_loop
             .insert_source(timer, move |_, _, state| {
                 state.niri.pointer_inactivity_timer = None;
-                state.niri.pointer_visibility = PointerVisibility::Hidden;
-                state.niri.queue_redraw_all();
+
+                // If the pointer is already invisible, don't reset it back to Hidden causing one
+                // frame of hover.
+                if state.niri.pointer_visibility.is_visible() {
+                    state.niri.pointer_visibility = PointerVisibility::Hidden;
+                    state.niri.queue_redraw_all();
+                }
 
                 TimeoutAction::Drop
             })


### PR DESCRIPTION
This fixes a visual issue I've noticed where it would "activate" "surfaces" which are not yet activated for a really short time. Maybe there is some deeper issue and this fix is just hiding it, not exactly sure.

I've tried to record a video of the issue, in this example I move the cursor above an element in the "Gnome Font Viewer", switch windows to deactivate the focus and then when i switch the font viewer back into the video but focus a terminal, when I type, the font viewers entry (second row first column 13s in) will flash gray shortly.


https://github.com/user-attachments/assets/17a99574-db5d-4278-9ebb-ad1d1f552fc5

