### PR TITLE
Expand screenshot UI to handle more moving actions

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -776,7 +776,7 @@ impl State {
             Action::MoveColumnLeftOrToMonitorLeft => {
                 if self.niri.screenshot_ui.is_open() {
                     self.niri.screenshot_ui.move_left();
-                } if let Some(output) = self.niri.output_left() {
+                } else if let Some(output) = self.niri.output_left() {
                     if self.niri.layout.move_column_left_or_to_output(&output)
                         && !self.maybe_warp_cursor_to_focus_centered()
                     {


### PR DESCRIPTION
Currently, screenshot UI handles MoveColumn{Left,Right} and MoveWindow{Up,Down} which move the screenshot selection as if it were a floating window. If the user happens to replace the movement actions with MoveColumn\*OrToMonitor\*/MoveWindow\*OrToWorkspace\* variants (which also handle floating windows just fine), they are left with no bindings to move selection in the screenshot mode.

Expand the allowed bindings in screenshot mode to include MoveColumn\*OrToMonitor\* and MoveWindow\*OrToWorkspace\* and adjust their logic to move the screenshot selection.