### PR TITLE
feat: not focus follow mouse when column is fullwidth

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -373,6 +373,8 @@ pub struct Touch {
 pub struct FocusFollowsMouse {
     #[knuffel(property, str)]
     pub max_scroll_amount: Option<Percent>,
+    #[knuffel(property)]
+    pub not_scroll_on_maximized: Option<bool>,
 }
 
 #[derive(knuffel::Decode, Debug, PartialEq, Eq, Clone, Copy)]
@@ -4302,6 +4304,7 @@ mod tests {
                 focus_follows_mouse: Some(
                     FocusFollowsMouse {
                         max_scroll_amount: None,
+                        not_scroll_on_maximized: None,
                     },
                 ),
                 workspace_auto_back_and_forth: true,

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -61,6 +61,8 @@ input {
     // Focus windows and outputs automatically when moving the mouse into them.
     // Setting max-scroll-amount="0%" makes it work only on windows already fully on screen.
     // focus-follows-mouse max-scroll-amount="0%"
+    // Setting not_scroll_on_maximized=true makes it work only on current windows not maximized.
+    // focus-follows-mouse not_scroll_on_maximized=true
 }
 
 // You can configure outputs by their name, which you can find
@@ -211,13 +213,13 @@ layout {
         // radius. It has to assume that windows have square corners, leading to
         // shadow artifacts inside the CSD rounded corners. This setting fixes
         // those artifacts.
-        // 
+        //
         // However, instead you may want to set prefer-no-csd and/or
         // geometry-corner-radius. Then, niri will know the corner radius and
         // draw the shadow correctly, without having to draw it behind the
         // window. These will also remove client-side shadows if the window
         // draws any.
-        // 
+        //
         // draw-behind-window true
 
         // You can change how shadows look. The values below are in logical

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1551,6 +1551,14 @@ impl<W: LayoutElement> Layout<W> {
         0.
     }
 
+    pub fn is_active_column_full_width(&self) -> bool {
+        let Some(ws) = self.active_workspace() else {
+            return true;
+        };
+
+        return ws.is_active_column_full_width();
+    }
+
     pub fn should_trigger_focus_follows_mouse_on(&self, window: &W::Id) -> bool {
         // During an animation, it's easy to trigger focus-follows-mouse on the previous workspace,
         // especially when clicking to switch workspace on a bar of some kind. This cancels the

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -1339,6 +1339,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         (from_view_offset - new_view_offset).abs() / self.working_area.size.w
     }
 
+    pub fn is_active_column_full_width(&self) -> bool {
+        self.columns[self.active_column_idx].is_full_width
+    }
+
     pub fn activate_window(&mut self, window: &W::Id) -> bool {
         let column_idx = self.columns.iter().position(|col| col.contains(window));
         let Some(column_idx) = column_idx else {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1615,6 +1615,10 @@ impl<W: LayoutElement> Workspace<W> {
         self.scrolling.scroll_amount_to_activate(window)
     }
 
+    pub fn is_active_column_full_width(&self) -> bool {
+        self.scrolling.is_active_column_full_width()
+    }
+
     pub fn is_urgent(&self) -> bool {
         self.windows().any(|win| win.is_urgent())
     }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -5814,6 +5814,12 @@ impl Niri {
                     return;
                 }
 
+                if let Some(nsom) = ffm.not_scroll_on_maximized {
+                    if nsom && self.layout.is_active_column_full_width() {
+                        return;
+                    }
+                }
+
                 if let Some(threshold) = ffm.max_scroll_amount {
                     if self.layout.scroll_amount_to_activate(window) > threshold.0 {
                         return;


### PR DESCRIPTION
This PR add an property `not-scroll-on-maximized` for `focus-follows-mouse`
When set `focus-follows-mouse not-scroll-on-maximized=true`, If current Column is at full width, the focus will not follow the mouse.

For 2 reasons:
- not sure a bug(since triggering instability), even if I maximize the window, the edge of the screen may still trigger the focus to shift to the out-of-view window.
- In the following settings, you can display adjacent objects on the edge without triggering focus when the mouse moves over them.
```kdl
layout{
  struts {
    left 16
    right 16
  }
}
```