### PR TITLE
Assume Mod key as held in Overview to replace hardcoded bindings

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1696,11 +1696,7 @@ pub enum Action {
     FocusWindowInColumn(#[knuffel(argument)] u8),
     FocusWindowPrevious,
     FocusColumnLeft,
-    #[knuffel(skip)]
-    FocusColumnLeftUnderMouse,
     FocusColumnRight,
-    #[knuffel(skip)]
-    FocusColumnRightUnderMouse,
     FocusColumnFirst,
     FocusColumnLast,
     FocusColumnRightOrFirst,
@@ -1751,11 +1747,7 @@ pub enum Action {
     CenterWindowById(u64),
     CenterVisibleColumns,
     FocusWorkspaceDown,
-    #[knuffel(skip)]
-    FocusWorkspaceDownUnderMouse,
     FocusWorkspaceUp,
-    #[knuffel(skip)]
-    FocusWorkspaceUpUnderMouse,
     FocusWorkspace(#[knuffel(argument)] WorkspaceReference),
     FocusWorkspacePrevious,
     MoveWindowToWorkspaceDown,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -369,6 +369,7 @@ impl State {
                 let key_code = event.key_code();
                 let modified = keysym.modified_sym();
                 let raw = keysym.raw_latin_sym_or_raw_current_sym();
+                let modifiers = modifiers_from_state(*mods);
 
                 if let Some(dialog) = &this.niri.exit_confirm_dialog {
                     if dialog.is_open() && pressed && raw == Some(Keysym::Return) {
@@ -405,7 +406,7 @@ impl State {
                     modified,
                     raw,
                     pressed,
-                    *mods,
+                    modifiers,
                     &this.niri.screenshot_ui,
                     this.niri.config.borrow().input.disable_power_key_handling,
                     is_inhibiting_shortcuts,
@@ -414,7 +415,7 @@ impl State {
                 if matches!(res, FilterResult::Forward) {
                     // If we didn't find any bind, try other hardcoded keys.
                     if this.niri.keyboard_focus.is_overview() && pressed {
-                        if let Some(bind) = raw.and_then(|raw| hardcoded_overview_bind(raw, *mods))
+                        if let Some(bind) = raw.and_then(|raw| hardcoded_overview_bind(raw, modifiers))
                         {
                             this.niri.suppressed_keys.insert(key_code);
                             return FilterResult::Intercept(Some(bind));
@@ -2364,7 +2365,7 @@ impl State {
                 .and_then(|trigger| {
                     let config = self.niri.config.borrow();
                     let bindings = &config.binds;
-                    find_configured_bind(bindings, mod_key, trigger, mods)
+                    find_configured_bind(bindings, mod_key, trigger, modifiers)
                 }) {
                     self.niri.suppressed_buttons.insert(button_code);
                     self.handle_bind(bind.clone());
@@ -2407,7 +2408,7 @@ impl State {
             }
 
             if button == Some(MouseButton::Middle) && !pointer.is_grabbed() {
-                let mod_down = modifiers_from_state(mods).contains(mod_key.to_modifiers());
+                let mod_down = modifiers.contains(mod_key.to_modifiers());
                 if mod_down {
                     let output_ws = if is_overview_open {
                         self.niri.workspace_under_cursor(true)
@@ -2452,7 +2453,7 @@ impl State {
 
                 // Check if we need to start an interactive move.
                 if button == Some(MouseButton::Left) && !pointer.is_grabbed() {
-                    let mod_down = modifiers_from_state(mods).contains(mod_key.to_modifiers());
+                    let mod_down = modifiers.contains(mod_key.to_modifiers());
                     if is_overview_open || mod_down {
                         let location = pointer.current_location();
                         let (output, pos_within_output) = self.niri.output_under(location).unwrap();
@@ -2485,7 +2486,7 @@ impl State {
                 }
                 // Check if we need to start an interactive resize.
                 else if button == Some(MouseButton::Right) && !pointer.is_grabbed() {
-                    let mod_down = modifiers_from_state(mods).contains(mod_key.to_modifiers());
+                    let mod_down = modifiers.contains(mod_key.to_modifiers());
                     if mod_down {
                         let location = pointer.current_location();
                         let (output, pos_within_output) = self.niri.output_under(location).unwrap();
@@ -2711,12 +2712,12 @@ impl State {
                         let config = self.niri.config.borrow();
                         let bindings = &config.binds;
                         let bind_left =
-                            find_configured_bind(bindings, mod_key, Trigger::WheelScrollLeft, mods);
+                            find_configured_bind(bindings, mod_key, Trigger::WheelScrollLeft, modifiers);
                         let bind_right = find_configured_bind(
                             bindings,
                             mod_key,
                             Trigger::WheelScrollRight,
-                            mods,
+                            modifiers,
                         );
                         (bind_left, bind_right)
                     };
@@ -2793,9 +2794,9 @@ impl State {
                         let config = self.niri.config.borrow();
                         let bindings = &config.binds;
                         let bind_up =
-                            find_configured_bind(bindings, mod_key, Trigger::WheelScrollUp, mods);
+                            find_configured_bind(bindings, mod_key, Trigger::WheelScrollUp, modifiers);
                         let bind_down =
-                            find_configured_bind(bindings, mod_key, Trigger::WheelScrollDown, mods);
+                            find_configured_bind(bindings, mod_key, Trigger::WheelScrollDown, modifiers);
                         (bind_up, bind_down)
                     };
 
@@ -2933,9 +2934,9 @@ impl State {
                     let config = self.niri.config.borrow();
                     let bindings = &config.binds;
                     let bind_left =
-                        find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollLeft, mods);
+                        find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollLeft, modifiers);
                     let bind_right =
-                        find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollRight, mods);
+                        find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollRight, modifiers);
                     drop(config);
 
                     if let Some(right) = bind_right {
@@ -2958,9 +2959,9 @@ impl State {
                     let config = self.niri.config.borrow();
                     let bindings = &config.binds;
                     let bind_up =
-                        find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollUp, mods);
+                        find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollUp, modifiers);
                     let bind_down =
-                        find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollDown, mods);
+                        find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollDown, modifiers);
                     drop(config);
 
                     if let Some(down) = bind_down {
@@ -3810,7 +3811,7 @@ fn should_intercept_key(
     modified: Keysym,
     raw: Option<Keysym>,
     pressed: bool,
-    mods: ModifiersState,
+    modifiers: Modifiers,
     screenshot_ui: &ScreenshotUi,
     disable_power_key_handling: bool,
     is_inhibiting_shortcuts: bool,
@@ -3827,7 +3828,7 @@ fn should_intercept_key(
         mod_key,
         modified,
         raw,
-        mods,
+        modifiers,
         disable_power_key_handling,
     );
 
@@ -3844,7 +3845,7 @@ fn should_intercept_key(
 
         if use_screenshot_ui_action {
             if let Some(raw) = raw {
-                final_bind = screenshot_ui.action(raw, mods).map(|action| Bind {
+                final_bind = screenshot_ui.action(raw, modifiers).map(|action| Bind {
                     key: Key {
                         trigger: Trigger::Keysym(raw),
                         // Not entirely correct but it doesn't matter in how we currently use it.
@@ -3891,7 +3892,7 @@ fn find_bind(
     mod_key: ModKey,
     modified: Keysym,
     raw: Option<Keysym>,
-    mods: ModifiersState,
+    modifiers: Modifiers,
     disable_power_key_handling: bool,
 ) -> Option<Bind> {
     use keysyms::*;
@@ -3929,19 +3930,18 @@ fn find_bind(
     }
 
     let trigger = Trigger::Keysym(raw?);
-    find_configured_bind(bindings, mod_key, trigger, mods)
+    find_configured_bind(bindings, mod_key, trigger, modifiers)
 }
 
 fn find_configured_bind(
     bindings: &Binds,
     mod_key: ModKey,
     trigger: Trigger,
-    mods: ModifiersState,
+    mut modifiers: Modifiers,
 ) -> Option<Bind> {
     // Handle configured binds.
-    let mut modifiers = modifiers_from_state(mods);
 
-    let mod_down = modifiers_from_state(mods).contains(mod_key.to_modifiers());
+    let mod_down = modifiers.contains(mod_key.to_modifiers());
     if mod_down {
         modifiers |= Modifiers::COMPOSITOR;
     }
@@ -4110,8 +4110,7 @@ fn allowed_during_screenshot(action: &Action) -> bool {
     )
 }
 
-fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Bind> {
-    let mods = modifiers_from_state(mods);
+fn hardcoded_overview_bind(raw: Keysym, mods: Modifiers) -> Option<Bind> {
     if !mods.is_empty() {
         return None;
     }
@@ -4470,7 +4469,7 @@ mod tests {
         // that matters is that they are different between cases.
 
         let close_key_code = Keycode::from(close_keysym.raw() + 8u32);
-        let close_key_event = |suppr: &mut HashSet<Keycode>, mods: ModifiersState, pressed| {
+        let close_key_event = |suppr: &mut HashSet<Keycode>, mods: Modifiers, pressed| {
             should_intercept_key(
                 suppr,
                 &bindings,
@@ -4487,7 +4486,7 @@ mod tests {
         };
 
         // Key event with the code which can't trigger any action.
-        let none_key_event = |suppr: &mut HashSet<Keycode>, mods: ModifiersState, pressed| {
+        let none_key_event = |suppr: &mut HashSet<Keycode>, mods: Modifiers, pressed| {
             should_intercept_key(
                 suppr,
                 &bindings,
@@ -4503,11 +4502,7 @@ mod tests {
             )
         };
 
-        let mut mods = ModifiersState {
-            logo: true,
-            ctrl: true,
-            ..Default::default()
-        };
+        let mut mods = Modifiers::SUPER | Modifiers::CTRL;
 
         // Action press/release.
 
@@ -4527,11 +4522,11 @@ mod tests {
 
         // Remove mod to make it for a binding.
 
-        mods.shift = true;
+        mods.insert(Modifiers::SHIFT);
         let filter = close_key_event(&mut suppressed_keys, mods, true);
         assert!(matches!(filter, FilterResult::Forward));
 
-        mods.shift = false;
+        mods.remove(Modifiers::SHIFT);
         let filter = close_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Forward));
 
@@ -4574,7 +4569,7 @@ mod tests {
             }))
         ));
 
-        mods = Default::default();
+        mods = Modifiers::empty();
         let filter = close_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Intercept(None)));
 
@@ -4586,11 +4581,7 @@ mod tests {
         // With inhibited shortcuts, we don't intercept our shortcut.
         is_inhibiting_shortcuts.set(true);
 
-        mods = ModifiersState {
-            logo: true,
-            ctrl: true,
-            ..Default::default()
-        };
+        mods = Modifiers::SUPER | Modifiers::CTRL;
 
         let filter = close_key_event(&mut suppressed_keys, mods, true);
         assert!(matches!(filter, FilterResult::Forward));
@@ -4699,10 +4690,7 @@ mod tests {
                 &bindings,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::q),
-                ModifiersState {
-                    logo: true,
-                    ..Default::default()
-                }
+                Modifiers::SUPER,
             )
             .as_ref(),
             Some(&bindings.0[0])
@@ -4712,7 +4700,7 @@ mod tests {
                 &bindings,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::q),
-                ModifiersState::default(),
+                Modifiers::empty(),
             ),
             None,
         );
@@ -4722,10 +4710,7 @@ mod tests {
                 &bindings,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::h),
-                ModifiersState {
-                    logo: true,
-                    ..Default::default()
-                }
+                Modifiers::SUPER,
             )
             .as_ref(),
             Some(&bindings.0[1])
@@ -4735,7 +4720,7 @@ mod tests {
                 &bindings,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::h),
-                ModifiersState::default(),
+                Modifiers::empty(),
             ),
             None,
         );
@@ -4745,10 +4730,7 @@ mod tests {
                 &bindings,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::j),
-                ModifiersState {
-                    logo: true,
-                    ..Default::default()
-                }
+                Modifiers::SUPER,
             ),
             None,
         );
@@ -4757,7 +4739,7 @@ mod tests {
                 &bindings,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::j),
-                ModifiersState::default(),
+                Modifiers::empty(),
             )
             .as_ref(),
             Some(&bindings.0[2])
@@ -4768,10 +4750,7 @@ mod tests {
                 &bindings,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::k),
-                ModifiersState {
-                    logo: true,
-                    ..Default::default()
-                }
+                Modifiers::SUPER,
             )
             .as_ref(),
             Some(&bindings.0[3])
@@ -4781,7 +4760,7 @@ mod tests {
                 &bindings,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::k),
-                ModifiersState::default(),
+                Modifiers::empty(),
             ),
             None,
         );
@@ -4791,11 +4770,7 @@ mod tests {
                 &bindings,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::l),
-                ModifiersState {
-                    logo: true,
-                    alt: true,
-                    ..Default::default()
-                }
+                Modifiers::SUPER | Modifiers::ALT,
             )
             .as_ref(),
             Some(&bindings.0[4])
@@ -4805,10 +4780,7 @@ mod tests {
                 &bindings,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::l),
-                ModifiersState {
-                    logo: true,
-                    ..Default::default()
-                },
+                Modifiers::SUPER,
             ),
             None,
         );

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -42,8 +42,8 @@ use self::resize_grab::ResizeGrab;
 use self::spatial_movement_grab::SpatialMovementGrab;
 use crate::layout::scrolling::ScrollDirection;
 use crate::layout::{ActivateWindow, LayoutElement as _};
-use crate::niri::{CastTarget, PointerVisibility, State};
-use crate::ui::screenshot_ui::ScreenshotUi;
+use crate::niri::{CastTarget, KeyboardFocus, PointerVisibility, State};
+use crate::ui::screenshot_ui;
 use crate::utils::spawning::spawn;
 use crate::utils::{center, get_monotonic_time, ResizeEdge};
 
@@ -407,7 +407,7 @@ impl State {
                     raw,
                     pressed,
                     modifiers,
-                    &this.niri.screenshot_ui,
+                    &this.niri.keyboard_focus,
                     this.niri.config.borrow().input.disable_power_key_handling,
                     is_inhibiting_shortcuts,
                 );
@@ -3812,7 +3812,7 @@ fn should_intercept_key(
     raw: Option<Keysym>,
     pressed: bool,
     modifiers: Modifiers,
-    screenshot_ui: &ScreenshotUi,
+    keyboard_focus: &KeyboardFocus,
     disable_power_key_handling: bool,
     is_inhibiting_shortcuts: bool,
 ) -> FilterResult<Option<Bind>> {
@@ -3834,7 +3834,7 @@ fn should_intercept_key(
 
     // Allow only a subset of compositor actions while the screenshot UI is open, since the user
     // cannot see the screen.
-    if screenshot_ui.is_open() {
+    if keyboard_focus.is_screenshotui() {
         let mut use_screenshot_ui_action = true;
 
         if let Some(bind) = &final_bind {
@@ -3845,7 +3845,7 @@ fn should_intercept_key(
 
         if use_screenshot_ui_action {
             if let Some(raw) = raw {
-                final_bind = screenshot_ui.action(raw, modifiers).map(|action| Bind {
+                final_bind = screenshot_ui::hardcoded_screenshot_bind(raw, modifiers).map(|action| Bind {
                     key: Key {
                         trigger: Trigger::Keysym(raw),
                         // Not entirely correct but it doesn't matter in how we currently use it.
@@ -4440,7 +4440,6 @@ mod tests {
     use std::cell::Cell;
 
     use super::*;
-    use crate::animation::Clock;
 
     #[test]
     fn bindings_suppress_keys() {
@@ -4461,7 +4460,7 @@ mod tests {
         let comp_mod = ModKey::Super;
         let mut suppressed_keys = HashSet::new();
 
-        let screenshot_ui = ScreenshotUi::new(Clock::default(), Default::default());
+        let keyboard_focus = KeyboardFocus::Layout { surface: None };
         let disable_power_key_handling = false;
         let is_inhibiting_shortcuts = Cell::new(false);
 
@@ -4479,7 +4478,7 @@ mod tests {
                 Some(close_keysym),
                 pressed,
                 mods,
-                &screenshot_ui,
+                &keyboard_focus,
                 disable_power_key_handling,
                 is_inhibiting_shortcuts.get(),
             )
@@ -4496,7 +4495,7 @@ mod tests {
                 Some(Keysym::l),
                 pressed,
                 mods,
-                &screenshot_ui,
+                &keyboard_focus,
                 disable_power_key_handling,
                 is_inhibiting_shortcuts.get(),
             )

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -609,6 +609,10 @@ impl KeyboardFocus {
     pub fn is_overview(&self) -> bool {
         matches!(self, KeyboardFocus::Overview)
     }
+
+    pub fn is_screenshotui(&self) -> bool {
+        matches!(self, KeyboardFocus::ScreenshotUi)
+    }
 }
 
 pub struct State {

--- a/src/ui/screenshot_ui.rs
+++ b/src/ui/screenshot_ui.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use anyhow::Context;
 use arrayvec::ArrayVec;
-use niri_config::{Action, Config};
+use niri_config::{Action, Config, Modifiers};
 use niri_ipc::SizeChange;
 use pango::{Alignment, FontDescription};
 use pangocairo::cairo::{self, ImageSurface};
@@ -17,7 +17,7 @@ use smithay::backend::renderer::element::utils::{Relocate, RelocateRenderElement
 use smithay::backend::renderer::element::Kind;
 use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
 use smithay::backend::renderer::{ExportMem, Texture as _};
-use smithay::input::keyboard::{Keysym, ModifiersState};
+use smithay::input::keyboard::Keysym;
 use smithay::output::{Output, WeakOutput};
 use smithay::utils::{Buffer, Physical, Point, Rectangle, Scale, Size, Transform};
 
@@ -655,7 +655,7 @@ impl ScreenshotUi {
         Ok((rect.size, copy.to_vec()))
     }
 
-    pub fn action(&self, raw: Keysym, mods: ModifiersState) -> Option<Action> {
+    pub fn action(&self, raw: Keysym, mods: Modifiers) -> Option<Action> {
         if !matches!(self, Self::Open { .. }) {
             return None;
         }
@@ -883,27 +883,27 @@ impl OutputScreenshot {
     }
 }
 
-fn action(raw: Keysym, mods: ModifiersState) -> Option<Action> {
+fn action(raw: Keysym, mods: Modifiers) -> Option<Action> {
     if raw == Keysym::Escape {
         return Some(Action::CancelScreenshot);
     }
 
-    if mods.alt || mods.shift {
+    if mods.intersects(Modifiers::ALT | Modifiers::SHIFT) {
         return None;
     }
 
-    if !mods.ctrl && (raw == Keysym::space || raw == Keysym::Return) {
+    if !mods.contains(Modifiers::CTRL) && (raw == Keysym::space || raw == Keysym::Return) {
         return Some(Action::ConfirmScreenshot {
             write_to_disk: true,
         });
     }
-    if mods.ctrl && raw == Keysym::c {
+    if mods.contains(Modifiers::CTRL) && raw == Keysym::c {
         return Some(Action::ConfirmScreenshot {
             write_to_disk: false,
         });
     }
 
-    if !mods.ctrl && raw == Keysym::p {
+    if !mods.contains(Modifiers::CTRL) && raw == Keysym::p {
         return Some(Action::ScreenshotTogglePointer);
     }
 

--- a/src/ui/screenshot_ui.rs
+++ b/src/ui/screenshot_ui.rs
@@ -655,14 +655,6 @@ impl ScreenshotUi {
         Ok((rect.size, copy.to_vec()))
     }
 
-    pub fn action(&self, raw: Keysym, mods: Modifiers) -> Option<Action> {
-        if !matches!(self, Self::Open { .. }) {
-            return None;
-        }
-
-        action(raw, mods)
-    }
-
     pub fn selection_output(&self) -> Option<&Output> {
         if let Self::Open {
             selection: (output, _, _),
@@ -883,7 +875,7 @@ impl OutputScreenshot {
     }
 }
 
-fn action(raw: Keysym, mods: Modifiers) -> Option<Action> {
+pub fn hardcoded_screenshot_bind(raw: Keysym, mods: Modifiers) -> Option<Action> {
     if raw == Keysym::Escape {
         return Some(Action::CancelScreenshot);
     }

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -8,9 +8,10 @@ It lets you see what's going on at a glance, navigate, and drag windows around.
 https://github.com/user-attachments/assets/379a5d1f-acdb-4c11-b36c-e85fd91f0995
 
 Open it with the `toggle-overview` bind, via the top-left hot corner, or using a touchpad four-finger swipe up.
-While in the overview, all keyboard shortcuts keep working, while pointing devices get easier:
+While in the overview, the navigation gets easier:
 
-- Mouse: left click and drag windows to move them, right click and drag to scroll workspaces left/right, scroll to switch workspaces (no holding Mod required).
+- Keyboard: all keyboard shortcuts keep working, shortcuts featuring Mod key no longer require it to be held.
+- Mouse: left click and drag windows to move them, right click and drag to scroll workspaces left/right. Other button and scroll wheel bindings with Mod do not require holding it.
 - Touchpad: two-finger scrolling that matches the normal three-finger gestures.
 - Touchscreen: one-finger scrolling, or one-finger long press to move a window.
 


### PR DESCRIPTION
The simplified navigation in Overview mode relies on [hardcoded keybindings](https://github.com/YaLTeR/niri/blob/8ba57fcf25d2fc9565131684a839d58703f1dae7/src/input/mod.rs#L4113), which currently include the arrow keys and the [scroll wheel](https://github.com/YaLTeR/niri/blob/8ba57fcf25d2fc9565131684a839d58703f1dae7/src/input/mod.rs#L2685). This is somewhat limiting for users who prefer custom navigation methods (like HJKL) or have defined further navigation keybindings. These custom bindings still work, but require holding down Mod, which feels inconsistent since arrow keys don’t.

This PR makes Overview mode treat the Mod key as held while open, both for keyboard and mouse.  All user-defined navigation keybindings (including arrow keys and scroll wheel in the default config) continue working as expected. Additionally, actions such as closing windows, moving/focusing windows, jumping to first/last windows, switching monitors, navigating workspaces with PageUp/PageDown get easier out of the box while in Overview.

For now, I removed `FocusColumn{Left,Right}UnderMouse` as they are not accessible from the config. I am not completely sure what is the use case for changing a focus on an inactive workspace and whether its worth complicating regular `FocusColumn{Left,Right}` to keep this functionality.

Also previously suggested by @Quackdoc in #1440