### PR TITLE
feat: add dynamic overview zoom functionality

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1331,10 +1331,82 @@ pub struct HotCorners {
     pub off: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ZoomRange {
+    pub min: FloatOrInt<0, 1>,
+    pub max: FloatOrInt<0, 1>,
+}
+
+impl<S: knuffel::traits::ErrorSpan> knuffel::Decode<S> for ZoomRange {
+    fn decode_node(
+        node: &knuffel::ast::SpannedNode<S>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) -> Result<Self, knuffel::errors::DecodeError<S>> {
+        if let Some(type_name) = &node.type_name {
+            ctx.emit_error(DecodeError::unexpected(
+                type_name,
+                "type name",
+                "no type name expected for this node",
+            ));
+        }
+
+        let mut iter_args = node.arguments.iter();
+
+        let first = iter_args
+            .next()
+            .ok_or_else(|| DecodeError::missing(node, "at least one argument is required"))?;
+
+        let min = <FloatOrInt<0, 1> as knuffel::DecodeScalar<S>>::decode(first, ctx)?;
+
+        let max = if let Some(second) = iter_args.next() {
+            <FloatOrInt<0, 1> as knuffel::DecodeScalar<S>>::decode(second, ctx)?
+        } else {
+            min
+        };
+
+        if max.0 < min.0 {
+            return Err(DecodeError::conversion(
+                node,
+                format!(
+                    "max zoom ({}) must be greater than or equal to min zoom ({})",
+                    max.0, min.0
+                ),
+            ));
+        }
+
+        if let Some(arg) = iter_args.next() {
+            ctx.emit_error(DecodeError::unexpected(
+                &arg.literal,
+                "argument",
+                "expected at most 2 arguments",
+            ));
+        }
+
+        for name in node.properties.keys() {
+            ctx.emit_error(DecodeError::unexpected(
+                name,
+                "property",
+                format!("unexpected property `{}`", name.escape_default()),
+            ));
+        }
+
+        for child in node.children.as_ref().map(|lst| &lst[..]).unwrap_or(&[]) {
+            ctx.emit_error(DecodeError::unexpected(
+                child,
+                "node",
+                format!("unexpected node `{}`", child.node_name.escape_default()),
+            ));
+        }
+
+        Ok(ZoomRange { min, max })
+    }
+}
+
+
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
 pub struct Overview {
-    #[knuffel(child, unwrap(argument), default = Self::default().zoom)]
-    pub zoom: FloatOrInt<0, 1>,
+    #[knuffel(child, default = Self::default().zoom)]
+    pub zoom: ZoomRange,
     #[knuffel(child, default = Self::default().backdrop_color)]
     pub backdrop_color: Color,
     #[knuffel(child, default)]
@@ -1344,7 +1416,10 @@ pub struct Overview {
 impl Default for Overview {
     fn default() -> Self {
         Self {
-            zoom: FloatOrInt(0.5),
+            zoom: ZoomRange {
+                min: FloatOrInt(0.5),
+                max: FloatOrInt(0.5),
+            },
             backdrop_color: DEFAULT_BACKDROP_COLOR,
             workspace_shadow: WorkspaceShadow::default(),
         }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2444,7 +2444,21 @@ impl<W: LayoutElement> Layout<W> {
 
     pub fn overview_zoom(&self) -> f64 {
         let progress = self.overview_progress.as_ref().map(|p| p.value());
-        compute_overview_zoom(&self.options, progress)
+
+        let workspace_count = match &self.monitor_set {
+            MonitorSet::Normal { monitors, active_monitor_idx, .. } => {
+                monitors[*active_monitor_idx]
+                    .workspaces
+                    .iter()
+                    .filter(|ws| ws.has_windows())
+                    .count()
+            }
+            MonitorSet::NoOutputs { workspaces } => {
+                workspaces.iter().filter(|ws| ws.has_windows()).count()
+            }
+        };
+
+        compute_overview_zoom(&self.options, progress, workspace_count)
     }
 
     #[cfg(test)]
@@ -5260,9 +5274,12 @@ impl<W: LayoutElement> Default for MonitorSet<W> {
     }
 }
 
-fn compute_overview_zoom(options: &Options, overview_progress: Option<f64>) -> f64 {
-    // Clamp to some sane values.
-    let zoom = options.overview.zoom.0.clamp(0.0001, 0.75);
+fn compute_overview_zoom(options: &Options, overview_progress: Option<f64>, workspace_count: usize) -> f64 {
+    let config_min_zoom = options.overview.zoom.min.0;
+    let config_max_zoom = options.overview.zoom.max.0;
+
+    let dynamic_zoom = 1.0 / (workspace_count.max(1) as f64);
+    let zoom = dynamic_zoom.clamp(config_min_zoom, config_max_zoom).clamp(0.0001, 0.75);
 
     if let Some(p) = overview_progress {
         (1. - p * (1. - zoom)).max(0.0001)

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -1177,7 +1177,8 @@ impl<W: LayoutElement> Monitor<W> {
 
     pub fn overview_zoom(&self) -> f64 {
         let progress = self.overview_progress.as_ref().map(|p| p.value());
-        compute_overview_zoom(&self.options, progress)
+        let workspace_count = self.workspaces.iter().filter(|ws| ws.has_windows()).count();
+        compute_overview_zoom(&self.options, progress, workspace_count)
     }
 
     pub(super) fn set_overview_progress(&mut self, progress: Option<&super::OverviewProgress>) {
@@ -1256,7 +1257,7 @@ impl<W: LayoutElement> Monitor<W> {
                 // - first_y = to * from_height - switch_anim.value() * from_height - to * current_height
                 // - first_y = -switch_anim.value() * from_height + to * (from_height - current_height)
                 let from = progress_anim.from();
-                let from_zoom = compute_overview_zoom(&self.options, Some(from));
+                let from_zoom = compute_overview_zoom(&self.options, Some(from), self.workspaces.len());
                 let from_ws_height_with_gap = self.workspace_size_with_gap(from_zoom).h;
 
                 let zoom = self.overview_zoom();

--- a/wiki/Configuration:-Miscellaneous.md
+++ b/wiki/Configuration:-Miscellaneous.md
@@ -24,7 +24,7 @@ cursor {
 }
 
 overview {
-    zoom 0.5
+    zoom 0.3 0.7
     backdrop-color "#262626"
 
     workspace-shadow {
@@ -163,7 +163,7 @@ Settings for the [Overview](./Overview.md).
 #### `zoom`
 
 Control how much the workspaces zoom out in the overview.
-`zoom` ranges from 0 to 0.75 where lower values make everything smaller.
+`zoom` ranges from 0 to 0.75 where lower values make everything smaller. If a single float is provided the zoom level will always be set to that. if two floats are provided then the zoom level will be set dynamically within that range based on how many non-empty workspaces there are.
 
 ```kdl
 // Make workspaces four times smaller than normal in the overview.


### PR DESCRIPTION
Regarding https://github.com/YaLTeR/niri/discussions/1673, here is what i meant. 

It uses a very simple algorithm to decide zoom. It maintains backwards compatibility so that users who prefer the current static zoom level will not be affected.

I did not change any logic pertaining to the centered workspace.

