### PR TITLE
Introduce WorkspaceDimensions struct

### DIFF
--- a/src/layout/dimensions.rs
+++ b/src/layout/dimensions.rs
@@ -1,0 +1,58 @@
+use smithay::utils::{Logical, Rectangle, Size};
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceDimensions {
+    /// Latest known output scale for this workspace.
+    ///
+    /// This should be set from the current workspace output, or, if all outputs have been
+    /// disconnected, preserved until a new output is connected.
+    scale: smithay::output::Scale,
+
+    /// Latest known view size for this workspace.
+    ///
+    /// This should be computed from the current workspace output size, or, if all outputs have
+    /// been disconnected, preserved until a new output is connected.
+    view_size: Size<f64, Logical>,
+
+    /// Latest known working area for this workspace.
+    ///
+    /// Not rounded to physical pixels.
+    ///
+    /// This is similar to view size, but takes into account things like layer shell exclusive
+    /// zones.
+    working_area: Rectangle<f64, Logical>,
+}
+
+impl WorkspaceDimensions {
+    pub fn new(
+        scale: smithay::output::Scale,
+        view_size: Size<f64, Logical>,
+        working_area: Rectangle<f64, Logical>,
+    ) -> Self {
+        Self {
+            scale,
+            view_size,
+            working_area,
+        }
+    }
+
+    pub fn scale(&self) -> smithay::output::Scale {
+        self.scale
+    }
+
+    pub fn fractional_scale(&self) -> f64 {
+        self.scale.fractional_scale()
+    }
+
+    pub fn view_size(&self) -> Size<f64, Logical> {
+        self.view_size
+    }
+
+    pub fn working_area(&self) -> Rectangle<f64, Logical> {
+        self.working_area
+    }
+
+    pub fn set_working_area(&mut self, working_area: Rectangle<f64, Logical>) {
+        self.working_area = working_area;
+    }
+}

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -75,6 +75,7 @@ use crate::utils::{
 use crate::window::ResolvedWindowRules;
 
 pub mod closing_window;
+pub mod dimensions;
 pub mod floating;
 pub mod focus_ring;
 pub mod insert_hint_element;

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -10,6 +10,7 @@ use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Logical, Point, Rectangle, Scale, Serial, Size};
 
 use super::closing_window::{ClosingWindow, ClosingWindowRenderElement};
+use super::dimensions::WorkspaceDimensions;
 use super::monitor::InsertPosition;
 use super::tab_indicator::{TabIndicator, TabIndicatorRenderElement, TabInfo};
 use super::tile::{Tile, TileRenderElement, TileRenderSnapshot};
@@ -67,16 +68,11 @@ pub struct ScrollingSpace<W: LayoutElement> {
     /// Windows in the closing animation.
     closing_windows: Vec<ClosingWindow>,
 
-    /// View size for this space.
-    view_size: Size<f64, Logical>,
-
-    /// Working area for this space.
+    /// Dimensions (output scale/view size/working area) for this space.
     ///
-    /// Takes into account layer-shell exclusive zones and niri struts.
-    working_area: Rectangle<f64, Logical>,
-
-    /// Scale of the output the space is on (and rounds its sizes to).
-    scale: f64,
+    /// This should be set from the current workspace output, or, if all outputs have been
+    /// disconnected, preserved until a new output is connected.
+    dimensions: WorkspaceDimensions,
 
     /// Clock for driving animations.
     clock: Clock,
@@ -249,14 +245,12 @@ pub enum ScrollDirection {
 }
 
 impl<W: LayoutElement> ScrollingSpace<W> {
-    pub fn new(
-        view_size: Size<f64, Logical>,
-        working_area: Rectangle<f64, Logical>,
-        scale: f64,
-        clock: Clock,
-        options: Rc<Options>,
-    ) -> Self {
-        let working_area = compute_working_area(working_area, scale, options.struts);
+    pub fn new(mut dimensions: WorkspaceDimensions, clock: Clock, options: Rc<Options>) -> Self {
+        dimensions.set_working_area(compute_working_area(
+            dimensions.working_area(),
+            dimensions.fractional_scale(),
+            options.struts,
+        ));
 
         Self {
             columns: Vec::new(),
@@ -267,31 +261,30 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             activate_prev_column_on_removal: None,
             view_offset_before_fullscreen: None,
             closing_windows: Vec::new(),
-            view_size,
-            working_area,
-            scale,
+            dimensions,
             clock,
             options,
         }
     }
 
-    pub fn update_config(
-        &mut self,
-        view_size: Size<f64, Logical>,
-        working_area: Rectangle<f64, Logical>,
-        scale: f64,
-        options: Rc<Options>,
-    ) {
-        let working_area = compute_working_area(working_area, scale, options.struts);
+    pub fn update_config(&mut self, mut dimensions: WorkspaceDimensions, options: Rc<Options>) {
+        dimensions.set_working_area(compute_working_area(
+            dimensions.working_area(),
+            dimensions.fractional_scale(),
+            options.struts,
+        ));
 
         for (column, data) in zip(&mut self.columns, &mut self.data) {
-            column.update_config(view_size, working_area, scale, options.clone());
+            column.update_config(
+                dimensions.view_size(),
+                dimensions.working_area(),
+                dimensions.fractional_scale(),
+                options.clone(),
+            );
             data.update(column);
         }
 
-        self.view_size = view_size;
-        self.working_area = working_area;
-        self.scale = scale;
+        self.dimensions = dimensions;
         self.options = options;
 
         // Apply always-center and such right away.
@@ -362,7 +355,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
     pub fn update_render_elements(&mut self, is_active: bool) {
         let view_pos = Point::from((self.view_pos(), 0.));
-        let view_size = self.view_size;
+        let view_size = self.dimensions.view_size();
         let active_idx = self.active_column_idx;
         for (col_idx, (col, col_x)) in self.columns_mut().enumerate() {
             let is_active = is_active && col_idx == active_idx;
@@ -429,14 +422,15 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             .unwrap_or(self.options.default_column_display);
         let will_tab = display_mode == ColumnDisplay::Tabbed;
         let extra_size = if will_tab {
-            TabIndicator::new(self.options.tab_indicator).extra_size(1, self.scale)
+            TabIndicator::new(self.options.tab_indicator)
+                .extra_size(1, self.dimensions.fractional_scale())
         } else {
             Size::from((0., 0.))
         };
 
         compute_toplevel_bounds(
             border_config,
-            self.working_area.size,
+            self.dimensions.working_area().size,
             extra_size,
             self.options.gaps,
         )
@@ -455,12 +449,13 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             .unwrap_or(self.options.default_column_display);
         let will_tab = display_mode == ColumnDisplay::Tabbed;
         let extra = if will_tab {
-            TabIndicator::new(self.options.tab_indicator).extra_size(1, self.scale)
+            TabIndicator::new(self.options.tab_indicator)
+                .extra_size(1, self.dimensions.fractional_scale())
         } else {
             Size::from((0., 0.))
         };
 
-        let working_size = self.working_area.size;
+        let working_size = self.dimensions.working_area().size;
 
         let width = if let Some(size) = width {
             let size = match resolve_preset_size(size, &self.options, working_size.w, extra.w) {
@@ -478,7 +473,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             0
         };
 
-        let mut full_height = self.working_area.size.h - self.options.gaps * 2.;
+        let mut full_height = self.dimensions.working_area().size.h - self.options.gaps * 2.;
         if !border.off {
             full_height -= border.width.0 * 2.;
         }
@@ -520,15 +515,15 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let target_x = target_x.unwrap_or_else(|| self.target_view_pos());
 
         let new_offset = compute_new_view_offset(
-            target_x + self.working_area.loc.x,
-            self.working_area.size.w,
+            target_x + self.dimensions.working_area().loc.x,
+            self.dimensions.working_area().size.w,
             col_x,
             width,
             self.options.gaps,
         );
 
         // Non-fullscreen windows are always offset at least by the working area position.
-        new_offset - self.working_area.loc.x
+        new_offset - self.dimensions.working_area().loc.x
     }
 
     fn compute_new_view_offset_centered(
@@ -543,11 +538,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         // Columns wider than the view are left-aligned (the fit code can deal with that).
-        if self.working_area.size.w <= width {
+        if self.dimensions.working_area().size.w <= width {
             return self.compute_new_view_offset_fit(target_x, col_x, width, is_fullscreen);
         }
 
-        -(self.working_area.size.w - width) / 2. - self.working_area.loc.x
+        -(self.dimensions.working_area().size.w - width) / 2. - self.dimensions.working_area().loc.x
     }
 
     fn compute_new_view_offset_for_column_fit(&self, target_x: Option<f64>, idx: usize) -> f64 {
@@ -620,7 +615,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 } + self.options.gaps * 2.;
 
                 // If it fits together, do a normal animation, otherwise center the new column.
-                if total_width <= self.working_area.size.w {
+                if total_width <= self.dimensions.working_area().size.w {
                     self.compute_new_view_offset_for_column_fit(target_x, idx)
                 } else {
                     self.compute_new_view_offset_for_column_centered(target_x, idx)
@@ -651,7 +646,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let offset_delta = old_col_x - new_col_x;
         self.view_offset.offset(offset_delta);
 
-        let pixel = 1. / self.scale;
+        let pixel = 1. / self.dimensions.fractional_scale();
 
         // If our view offset is already this or animating towards this, we don't need to do
         // anything.
@@ -831,9 +826,9 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     ) {
         let column = Column::new_with_tile(
             tile,
-            self.view_size,
-            self.working_area,
-            self.scale,
+            self.dimensions.view_size(),
+            self.dimensions.working_area(),
+            self.dimensions.fractional_scale(),
             width,
             is_full_width,
             true,
@@ -941,9 +936,9 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         });
 
         column.update_config(
-            self.view_size,
-            self.working_area,
-            self.scale,
+            self.dimensions.view_size(),
+            self.dimensions.working_area(),
+            self.dimensions.fractional_scale(),
             self.options.clone(),
         );
         self.data.insert(idx, ColumnData::new(&column));
@@ -1271,8 +1266,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 let width = self.data[col_idx].width;
                 let offset = if centered {
                     // FIXME: when view_offset becomes fractional, this can be made additive too.
-                    let new_offset =
-                        -(self.working_area.size.w - width) / 2. - self.working_area.loc.x;
+                    let new_offset = -(self.dimensions.working_area().size.w - width) / 2.
+                        - self.dimensions.working_area().loc.x;
                     new_offset - self.view_offset.target()
                 } else if resize.edges.contains(ResizeEdge::LEFT) {
                     -offset
@@ -1336,7 +1331,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let new_col_x = self.column_x(column_idx);
         let from_view_offset = target_x - new_col_x;
 
-        (from_view_offset - new_view_offset).abs() / self.working_area.size.w
+        (from_view_offset - new_view_offset).abs() / self.dimensions.working_area().size.w
     }
 
     pub fn activate_window(&mut self, window: &W::Id) -> bool {
@@ -1435,7 +1430,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             blocker
         };
 
-        let scale = Scale::from(self.scale);
+        let scale = Scale::from(self.dimensions.fractional_scale());
         let res = ClosingWindow::new(
             renderer, snapshot, scale, tile_size, tile_pos, blocker, anim,
         );
@@ -2150,8 +2145,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         // Consider the end of an ongoing animation because that's what compute to fit does too.
         let view_x = self.target_view_pos();
-        let working_x = self.working_area.loc.x;
-        let working_w = self.working_area.size.w;
+        let working_x = self.dimensions.working_area().loc.x;
+        let working_w = self.dimensions.working_area().size.w;
 
         // Count all columns that are fully visible inside the working area.
         let mut width_taken = 0.;
@@ -2279,7 +2274,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     pub fn tiles_with_render_positions(
         &self,
     ) -> impl Iterator<Item = (&Tile<W>, Point<f64, Logical>, bool)> {
-        let scale = self.scale;
+        let scale = self.dimensions.fractional_scale();
         let view_off = Point::from((-self.view_pos(), 0.));
         self.columns_in_render_order()
             .flat_map(move |(col, col_x)| {
@@ -2300,7 +2295,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         &mut self,
         round: bool,
     ) -> impl Iterator<Item = (&mut Tile<W>, Point<f64, Logical>)> {
-        let scale = self.scale;
+        let scale = self.dimensions.fractional_scale();
         let view_off = Point::from((-self.view_pos(), 0.));
         self.columns_in_render_order_mut()
             .flat_map(move |(col, col_x)| {
@@ -2326,11 +2321,13 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let mut hint_area = match position {
             InsertPosition::NewColumn(column_index) => {
                 if column_index == 0 || column_index == self.columns.len() {
-                    let size =
-                        Size::from((300., self.working_area.size.h - self.options.gaps * 2.));
+                    let size = Size::from((
+                        300.,
+                        self.dimensions.working_area().size.h - self.options.gaps * 2.,
+                    ));
                     let mut loc = Point::from((
                         self.column_x(column_index),
-                        self.working_area.loc.y + self.options.gaps,
+                        self.dimensions.working_area().loc.y + self.options.gaps,
                     ));
                     if column_index == 0 && !self.columns.is_empty() {
                         loc.x -= size.w + self.options.gaps;
@@ -2340,11 +2337,13 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     error!("insert hint column index is out of range");
                     return None;
                 } else {
-                    let size =
-                        Size::from((300., self.working_area.size.h - self.options.gaps * 2.));
+                    let size = Size::from((
+                        300.,
+                        self.dimensions.working_area().size.h - self.options.gaps * 2.,
+                    ));
                     let loc = Point::from((
                         self.column_x(column_index) - size.w / 2. - self.options.gaps / 2.,
-                        self.working_area.loc.y + self.options.gaps,
+                        self.dimensions.working_area().loc.y + self.options.gaps,
                     ));
                     Rectangle::new(loc, size)
                 }
@@ -2432,7 +2431,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let tile_size = tile.tile_size();
         let tile_rect = Rectangle::new(tile_pos, tile_size);
 
-        let view = Rectangle::from_size(self.view_size);
+        let view = Rectangle::from_size(self.dimensions.view_size());
         view.intersection(tile_rect)
     }
 
@@ -2608,8 +2607,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         // Consider the end of an ongoing animation because that's what compute to fit does too.
         let view_x = self.target_view_pos();
-        let working_x = self.working_area.loc.x;
-        let working_w = self.working_area.size.w;
+        let working_x = self.dimensions.working_area().loc.x;
+        let working_w = self.dimensions.working_area().size.w;
 
         // Count all columns that are fully visible inside the working area.
         let mut width_taken = 0.;
@@ -2708,9 +2707,9 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             // Create a column manually to disable the resize animation.
             let column = Column::new_with_tile(
                 removed.tile,
-                self.view_size,
-                self.working_area,
-                self.scale,
+                self.dimensions.view_size(),
+                self.dimensions.working_area(),
+                self.dimensions.fractional_scale(),
                 removed.width,
                 removed.is_full_width,
                 false,
@@ -2762,10 +2761,13 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     ) -> Vec<ScrollingSpaceRenderElement<R>> {
         let mut rv = vec![];
 
-        let scale = Scale::from(self.scale);
+        let scale = Scale::from(self.dimensions.fractional_scale());
 
         // Draw the closing windows on top of the other windows.
-        let view_rect = Rectangle::new(Point::from((self.view_pos(), 0.)), self.view_size);
+        let view_rect = Rectangle::new(
+            Point::from((self.view_pos(), 0.)),
+            self.dimensions.view_size(),
+        );
         for closing in self.closing_windows.iter().rev() {
             let elem = closing.render(renderer.as_gles_renderer(), view_rect, scale, target);
             rv.push(elem.into());
@@ -2824,7 +2826,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
     pub fn window_under(&self, pos: Point<f64, Logical>) -> Option<(&W, HitType)> {
         // This matches self.tiles_with_render_positions().
-        let scale = self.scale;
+        let scale = self.dimensions.fractional_scale();
         let view_off = Point::from((-self.view_pos(), 0.));
         for (col, col_x) in self.columns_in_render_order() {
             let col_off = Point::from((col_x, 0.));
@@ -2931,7 +2933,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         gesture.tracker.push(delta_x, timestamp);
 
         let norm_factor = if gesture.is_touchpad {
-            self.working_area.size.w / VIEW_GESTURE_WORKING_AREA_MOVEMENT
+            self.dimensions.working_area().size.w / VIEW_GESTURE_WORKING_AREA_MOVEMENT
         } else {
             1.
         };
@@ -2986,7 +2988,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         } else {
             let gaps = self.options.gaps;
 
-            let mut leftmost = -self.working_area.size.w;
+            let mut leftmost = -self.dimensions.working_area().size.w;
 
             let last_col_idx = self.columns.len() - 1;
             let last_col_x = self
@@ -2995,7 +2997,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 .take(last_col_idx)
                 .fold(0., |col_x, col| col_x + col.width() + gaps);
             let last_col_width = self.data[last_col_idx].width;
-            let mut rightmost = last_col_x + last_col_width - self.working_area.loc.x;
+            let mut rightmost = last_col_x + last_col_width - self.dimensions.working_area().loc.x;
 
             let active_col_x = self
                 .columns
@@ -3035,7 +3037,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         gesture.tracker.push(0., now);
 
         let norm_factor = if gesture.is_touchpad {
-            self.working_area.size.w / VIEW_GESTURE_WORKING_AREA_MOVEMENT
+            self.dimensions.working_area().size.w / VIEW_GESTURE_WORKING_AREA_MOVEMENT
         } else {
             1.
         };
@@ -3063,8 +3065,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let mut snapping_points = Vec::new();
 
-        let left_strut = self.working_area.loc.x;
-        let right_strut = self.view_size.w - self.working_area.size.w - self.working_area.loc.x;
+        let left_strut = self.dimensions.working_area().loc.x;
+        let right_strut = self.dimensions.view_size().w
+            - self.dimensions.working_area().size.w
+            - self.dimensions.working_area().loc.x;
 
         if self.is_centering_focused_column() {
             let mut col_x = 0.;
@@ -3073,10 +3077,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
                 let view_pos = if col.is_fullscreen {
                     col_x
-                } else if self.working_area.size.w <= col_w {
+                } else if self.dimensions.working_area().size.w <= col_w {
                     col_x - left_strut
                 } else {
-                    col_x - (self.working_area.size.w - col_w) / 2. - left_strut
+                    col_x - (self.dimensions.working_area().size.w - col_w) / 2. - left_strut
                 };
                 snapping_points.push(Snap { view_pos, col_idx });
 
@@ -3088,52 +3092,54 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 CenterFocusedColumn::OnOverflow
             );
 
-            let view_width = self.view_size.w;
-            let working_area_width = self.working_area.size.w;
+            let view_width = self.dimensions.view_size().w;
+            let working_area_width = self.dimensions.working_area().size.w;
             let gaps = self.options.gaps;
 
-            let snap_points =
-                |col_x, col: &Column<W>, prev_col_w: Option<f64>, next_col_w: Option<f64>| {
-                    let col_w = col.width();
+            let snap_points = |col_x,
+                               col: &Column<W>,
+                               prev_col_w: Option<f64>,
+                               next_col_w: Option<f64>| {
+                let col_w = col.width();
 
-                    // Normal columns align with the working area, but fullscreen columns align with
-                    // the view size.
-                    if col.is_fullscreen {
-                        let left = col_x;
-                        let right = col_x + col_w;
-                        (left, right)
+                // Normal columns align with the working area, but fullscreen columns align with
+                // the view size.
+                if col.is_fullscreen {
+                    let left = col_x;
+                    let right = col_x + col_w;
+                    (left, right)
+                } else {
+                    // Logic from compute_new_view_offset.
+                    let padding = ((working_area_width - col_w) / 2.).clamp(0., gaps);
+
+                    let center = if self.dimensions.working_area().size.w <= col_w {
+                        col_x - left_strut
                     } else {
-                        // Logic from compute_new_view_offset.
-                        let padding = ((working_area_width - col_w) / 2.).clamp(0., gaps);
+                        col_x - (self.dimensions.working_area().size.w - col_w) / 2. - left_strut
+                    };
+                    let is_overflowing = |adj_col_w: Option<f64>| {
+                        center_on_overflow
+                            && adj_col_w
+                                .filter(|adj_col_w| {
+                                    center_on_overflow
+                                        && adj_col_w + 3.0 * gaps + col_w > working_area_width
+                                })
+                                .is_some()
+                    };
 
-                        let center = if self.working_area.size.w <= col_w {
-                            col_x - left_strut
-                        } else {
-                            col_x - (self.working_area.size.w - col_w) / 2. - left_strut
-                        };
-                        let is_overflowing = |adj_col_w: Option<f64>| {
-                            center_on_overflow
-                                && adj_col_w
-                                    .filter(|adj_col_w| {
-                                        center_on_overflow
-                                            && adj_col_w + 3.0 * gaps + col_w > working_area_width
-                                    })
-                                    .is_some()
-                        };
-
-                        let left = if is_overflowing(next_col_w) {
-                            center
-                        } else {
-                            col_x - padding - left_strut
-                        };
-                        let right = if is_overflowing(prev_col_w) {
-                            center + view_width
-                        } else {
-                            col_x + col_w + padding + right_strut
-                        };
-                        (left, right)
-                    }
-                };
+                    let left = if is_overflowing(next_col_w) {
+                        center
+                    } else {
+                        col_x - padding - left_strut
+                    };
+                    let right = if is_overflowing(prev_col_w) {
+                        center + view_width
+                    } else {
+                        col_x + col_w + padding + right_strut
+                    };
+                    (left, right)
+                }
+            };
 
             // Prevent the gesture from snapping further than the first/last column, as this is
             // generally undesired.
@@ -3226,13 +3232,13 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     let col_w = col.width();
 
                     if col.is_fullscreen {
-                        if target_snap.view_pos + self.view_size.w < col_x + col_w {
+                        if target_snap.view_pos + self.dimensions.view_size().w < col_x + col_w {
                             break;
                         }
                     } else {
-                        let padding =
-                            ((self.working_area.size.w - col_w) / 2.).clamp(0., self.options.gaps);
-                        if target_snap.view_pos + left_strut + self.working_area.size.w
+                        let padding = ((self.dimensions.working_area().size.w - col_w) / 2.)
+                            .clamp(0., self.options.gaps);
+                        if target_snap.view_pos + left_strut + self.dimensions.working_area().size.w
                             < col_x + col_w + padding
                         {
                             break;
@@ -3252,8 +3258,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                             break;
                         }
                     } else {
-                        let padding =
-                            ((self.working_area.size.w - col_w) / 2.).clamp(0., self.options.gaps);
+                        let padding = ((self.dimensions.working_area().size.w - col_w) / 2.)
+                            .clamp(0., self.options.gaps);
                         if col_x - padding < target_snap.view_pos + left_strut {
                             break;
                         }
@@ -3490,7 +3496,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 let border_config = win.rules().border.resolve_against(self.options.border);
                 let bounds = compute_toplevel_bounds(
                     border_config,
-                    self.working_area.size,
+                    self.dimensions.working_area().size,
                     extra_size,
                     self.options.gaps,
                 );
@@ -3516,7 +3522,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
     #[cfg(test)]
     pub fn view_size(&self) -> Size<f64, Logical> {
-        self.view_size
+        self.dimensions.view_size()
     }
 
     #[cfg(test)]
@@ -3541,14 +3547,18 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
     #[cfg(test)]
     pub fn verify_invariants(&self, working_area: Rectangle<f64, Logical>) {
-        assert!(self.view_size.w > 0.);
-        assert!(self.view_size.h > 0.);
-        assert!(self.scale > 0.);
-        assert!(self.scale.is_finite());
+        assert!(self.dimensions.view_size().w > 0.);
+        assert!(self.dimensions.view_size().h > 0.);
+        assert!(self.dimensions.fractional_scale() > 0.);
+        assert!(self.dimensions.fractional_scale().is_finite());
         assert_eq!(self.columns.len(), self.data.len());
         assert_eq!(
-            self.working_area,
-            compute_working_area(working_area, self.scale, self.options.struts)
+            self.dimensions.working_area(),
+            compute_working_area(
+                working_area,
+                self.dimensions.fractional_scale(),
+                self.options.struts
+            )
         );
 
         if !self.columns.is_empty() {
@@ -3557,7 +3567,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             for (column, data) in zip(&self.columns, &self.data) {
                 assert!(Rc::ptr_eq(&self.options, &column.options));
                 assert_eq!(self.clock, column.clock);
-                assert_eq!(self.scale, column.scale);
+                assert_eq!(self.dimensions.fractional_scale(), column.scale);
                 column.verify_invariants();
 
                 let mut data2 = *data;


### PR DESCRIPTION
This commit introduces WorkspaceDimensions to replace the triplet of view_size/workspace_area/scale that is passed from Workspace to ScrollingSpace and FloatingSpace.

This will also make it easier to support horizontal columns for portrait monitors, as we can add the notion of column axis to WorkspaceDimensions and also add member functions to access the various flavours of dimensions (like workspace size along the primary and secondary axis).