### PR TITLE
Fix wayland event loop overflow after only a few hundred millisecond

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create the compositor.
     let mut event_loop = EventLoop::try_new().unwrap();
-    let display = Display::new().unwrap();
+    let mut display = Display::new().unwrap();
+    display.backend().set_max_buffer_size(1024 * 1024);
     let mut state = State::new(
         config,
         event_loop.handle(),


### PR DESCRIPTION
This is needed on higher-end systems, because if I use a high polling rate mice (1kHz), and the app stops receiving events for 200 ms, that is enough to overflow the event buffer, and crashes the app.

With this patch, the buffer can be increased, and these apps can have more time handling inputs

the default buffer size is 4096 bytes, which is pretty small.  
The buffer can be set with the global `max-buffer-size` config.  
If the config is not specified, the value won't be overwritten.  

I'll set ready-to-merge on this PR when https://github.com/Smithay/wayland-rs/pull/815 is merged and released.