### PR TITLE
force xdg deactivation on invisable workspaces

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2329,6 +2329,8 @@ pub struct DebugConfig {
     pub strict_new_window_focus_policy: bool,
     #[knuffel(child)]
     pub honor_xdg_activation_with_invalid_serial: bool,
+    #[knuffel(child)]
+    pub force_xdg_deactivation_on_invisible_workspaces: bool,
 }
 
 #[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -361,6 +361,7 @@ pub struct Options {
     // Debug flags.
     pub disable_resize_throttling: bool,
     pub disable_transactions: bool,
+    pub force_xdg_deactivation_on_invisible_workspaces: bool,
 }
 
 impl Default for Options {
@@ -393,6 +394,7 @@ impl Default for Options {
                 PresetSize::Proportion(0.5),
                 PresetSize::Proportion(2. / 3.),
             ],
+            force_xdg_deactivation_on_invisible_workspaces: false,
         }
     }
 }
@@ -658,6 +660,7 @@ impl Options {
             overview: config.overview,
             disable_resize_throttling: config.debug.disable_resize_throttling,
             disable_transactions: config.debug.disable_transactions,
+            force_xdg_deactivation_on_invisible_workspaces: config.debug.force_xdg_deactivation_on_invisible_workspaces,
             preset_window_heights,
         }
     }
@@ -5123,8 +5126,15 @@ impl<W: LayoutElement> Layout<W> {
                         mon.dnd_scroll_gesture_end();
                     }
 
+                    let active_ws_id = mon.active_workspace_ref().id();
                     for (ws_idx, ws) in mon.workspaces.iter_mut().enumerate() {
-                        ws.refresh(is_active);
+
+                        let active = match self.options.force_xdg_deactivation_on_invisible_workspaces {
+                            false => is_active,
+                            true => is_active && ws.id() == active_ws_id,
+                        };
+
+                        ws.refresh(active);
 
                         if let Some(is_scrolling) = ongoing_scrolling_dnd {
                             // Lock or unlock the view for scrolling interactive move.

--- a/wiki/Configuration:-Debug-Options.md
+++ b/wiki/Configuration:-Debug-Options.md
@@ -29,6 +29,7 @@ debug {
     disable-monitor-names
     strict-new-window-focus-policy
     honor-xdg-activation-with-invalid-serial 
+    force-xdg-deactivation-on-invisible-workspaces
 }
 
 binds {
@@ -275,6 +276,19 @@ debug {
 }
 ```
 
+### `force-xdg-deactivation-on-invisible-workspaces`
+
+<sup>Since: 25.05.2</sup>
+
+This is related to honor-xdg-activation-with-invalid-serial in some way, some of the chromium based chat clients (e.g. teams-for-linux) don't send notifications if they happen to be active on a workspace that is not visible on any monitor.
+
+
+```kdl
+debug {
+    force-xdg-deactivation-on-invisible-workspaces
+}
+```
+    
 ### Key Bindings
 
 These are not debug options, but rather key bindings.


### PR DESCRIPTION
This debug option provides a workaround for many Chromium-based chat applications that fail to show notifications when they're active in a workspace that's not currently visible and don't have keyboard focus