### PR TITLE
Bump MSRV to 1.83

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y ${{ env.DEPS_APT }} libadwaita-1-dev
 
-      - uses: dtolnay/rust-toolchain@1.80.1
+      - uses: dtolnay/rust-toolchain@1.83
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Ivan Molodetskikh <yalterz@gmail.com>"]
 license = "GPL-3.0-or-later"
 edition = "2021"
 repository = "https://github.com/YaLTeR/niri"
-rust-version = "1.80.1"
+rust-version = "1.83"
 
 [workspace.dependencies]
 anyhow = "1.0.98"

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -400,12 +400,10 @@ impl XdgShellHandler for State {
 
         let keyboard_grab_mismatches = keyboard.is_grabbed()
             && !(keyboard.has_grab(serial)
-                || grab
-                    .previous_serial()
-                    .map_or(true, |s| keyboard.has_grab(s)));
+                || grab.previous_serial().is_none_or(|s| keyboard.has_grab(s)));
         let pointer_grab_mismatches = pointer.is_grabbed()
             && !(pointer.has_grab(serial)
-                || grab.previous_serial().map_or(true, |s| pointer.has_grab(s)));
+                || grab.previous_serial().is_none_or(|s| pointer.has_grab(s)));
         if (can_receive_keyboard_focus && keyboard_grab_mismatches) || pointer_grab_mismatches {
             trace!("ignoring popup grab because of current grab mismatch");
             grab.ungrab(PopupUngrabStrategy::All);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2656,7 +2656,7 @@ impl State {
             pointer
                 .current_focus()
                 .map(|surface| self.niri.find_root_shell_surface(&surface))
-                .map_or(true, |root| {
+                .is_none_or(|root| {
                     !self
                         .niri
                         .mapped_layer_surfaces

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2915,13 +2915,13 @@ impl<W: LayoutElement> Layout<W> {
     pub fn are_animations_ongoing(&self, output: Option<&Output>) -> bool {
         // Keep advancing animations if we might need to scroll the view.
         if let Some(dnd) = &self.dnd {
-            if output.map_or(true, |output| *output == dnd.output) {
+            if output.is_none_or(|output| *output == dnd.output) {
                 return true;
             }
         }
 
         if let Some(InteractiveMoveState::Moving(move_)) = &self.interactive_move {
-            if output.map_or(true, |output| *output == move_.output) {
+            if output.is_none_or(|output| *output == move_.output) {
                 if move_.tile.are_animations_ongoing() {
                     return true;
                 }
@@ -2965,7 +2965,7 @@ impl<W: LayoutElement> Layout<W> {
 
         let zoom = self.overview_zoom();
         if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
-            if output.map_or(true, |output| move_.output == *output) {
+            if output.is_none_or(|output| move_.output == *output) {
                 let pos_within_output = move_.tile_render_location(zoom);
                 let view_rect =
                     Rectangle::new(pos_within_output.upscale(-1.), output_size(&move_.output));
@@ -2986,7 +2986,7 @@ impl<W: LayoutElement> Layout<W> {
         };
 
         for (idx, mon) in monitors.iter_mut().enumerate() {
-            if output.map_or(true, |output| mon.output == *output) {
+            if output.is_none_or(|output| mon.output == *output) {
                 let is_active = self.is_active
                     && idx == *active_monitor_idx
                     && !matches!(self.interactive_move, Some(InteractiveMoveState::Moving(_)));
@@ -3516,7 +3516,7 @@ impl<W: LayoutElement> Layout<W> {
 
             let mon = &mut monitors[mon_idx];
             let activate = activate.map_smart(|| {
-                window.map_or(true, |win| {
+                window.is_none_or(|win| {
                     mon_idx == *active_monitor_idx
                         && mon.active_window().map(|win| win.id()) == Some(win)
                 })

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -701,9 +701,7 @@ impl<W: LayoutElement> Monitor<W> {
         let new_id = self.workspaces[new_idx].id();
 
         let activate = activate.map_smart(|| {
-            window.map_or(true, |win| {
-                self.active_window().map(|win| win.id()) == Some(win)
-            })
+            window.is_none_or(|win| self.active_window().map(|win| win.id()) == Some(win))
         });
 
         let workspace = &mut self.workspaces[source_workspace_idx];

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1241,7 +1241,7 @@ impl<W: LayoutElement> Workspace<W> {
 
     pub fn toggle_window_floating(&mut self, id: Option<&W::Id>) {
         let active_id = self.active_window().map(|win| win.id().clone());
-        let target_is_active = id.map_or(true, |id| Some(id) == active_id.as_ref());
+        let target_is_active = id.is_none_or(|id| Some(id) == active_id.as_ref());
         let Some(id) = id.cloned().or(active_id) else {
             return;
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "dbus")]
     dbus::DBusServers::start(&mut state, cli.session);
 
-    if env::var_os("NIRI_DISABLE_SYSTEM_MANAGER_NOTIFY").map_or(true, |x| x != "1") {
+    if env::var_os("NIRI_DISABLE_SYSTEM_MANAGER_NOTIFY").is_none_or(|x| x != "1") {
         // Notify systemd we're ready.
         if let Err(err) = sd_notify::notify(true, &[NotifyState::Ready]) {
             warn!("error notifying systemd: {err:?}");

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -3940,7 +3940,7 @@ impl Niri {
         self.layout.update_render_elements(output);
 
         for (out, state) in self.output_state.iter_mut() {
-            if output.map_or(true, |output| out == output) {
+            if output.is_none_or(|output| out == output) {
                 let scale = Scale::from(out.current_scale().fractional_scale());
                 let transform = out.current_transform();
 

--- a/src/utils/transaction.rs
+++ b/src/utils/transaction.rs
@@ -158,7 +158,7 @@ impl TransactionBlocker {
 
 impl Blocker for TransactionBlocker {
     fn state(&self) -> BlockerState {
-        if self.0.upgrade().map_or(true, |x| x.is_completed()) {
+        if self.0.upgrade().is_none_or(|x| x.is_completed()) {
             BlockerState::Released
         } else {
             BlockerState::Pending


### PR DESCRIPTION
- Adds support for ControlFlow::Break/Continue (used in #1704)
- Requires applying a few new clippy lints

This PR was initially just blended into #1704, but is rather independent so submitted separately at @YaLTeR's request.