### PR TITLE
Try to request RR scheduling policy for main pid

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,36 +38,6 @@ const DEFAULT_LOG_FILTER: &str = "niri=debug,smithay::backend::renderer::gles=er
 static GLOBAL: tracy_client::ProfiledAllocator<std::alloc::System> =
     tracy_client::ProfiledAllocator::new(std::alloc::System, 100);
 
-// SCHED_RESET_ON_FORK only exists on Linux.
-#[cfg(target_os = "linux")]
-fn set_rt_scheduling() {
-    let res = unsafe {
-        // Work around libc crate exposing more fields on musl.
-        let mut param: libc::sched_param = std::mem::zeroed();
-        // Set SCHED_RESET_ON_FORK and request minimal realtime round-robin prio for main pid.
-        param.sched_priority = libc::sched_get_priority_min(libc::SCHED_RR);
-
-        libc::pthread_setschedparam(
-            libc::pthread_self(),
-            libc::SCHED_RR | libc::SCHED_RESET_ON_FORK,
-            &param,
-        )
-    };
-
-    match res {
-        libc::EPERM => debug!("no permission to set real-time policy"),
-        libc::EINVAL => debug!("real-time policy not recognized or scheduling params wrong"),
-        libc::ESRCH => debug!("thread ID not found for real-time policy"),
-        0 => (),
-        _ => warn!("unknown failure setting real-time policy: {res}"),
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-fn set_rt_scheduling() {
-    ()
-}
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set backtrace defaults if not set.
     if env::var_os("RUST_BACKTRACE").is_none() {
@@ -276,7 +246,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         state.niri.config_error_notification.show_created(path);
     }
 
-    set_rt_scheduling();
+    niri::utils::realtime::set_rt_scheduling();
 
     // Run the compositor.
     event_loop

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -33,6 +33,7 @@ use crate::handlers::KdeDecorationsModeState;
 use crate::niri::ClientState;
 
 pub mod id;
+pub mod realtime;
 pub mod scale;
 pub mod signals;
 pub mod spawning;

--- a/src/utils/realtime.rs
+++ b/src/utils/realtime.rs
@@ -1,0 +1,29 @@
+// SCHED_RESET_ON_FORK only exists on Linux.
+#[cfg(target_os = "linux")]
+pub fn set_rt_scheduling() {
+    let res = unsafe {
+        // Work around libc crate exposing more fields on musl.
+        let mut param: libc::sched_param = std::mem::zeroed();
+        // Set SCHED_RESET_ON_FORK and request minimal realtime round-robin prio for main pid.
+        param.sched_priority = libc::sched_get_priority_min(libc::SCHED_RR);
+
+        libc::pthread_setschedparam(
+            libc::pthread_self(),
+            libc::SCHED_RR | libc::SCHED_RESET_ON_FORK,
+            &param,
+        )
+    };
+
+    match res {
+        libc::EPERM => debug!("no permission to set real-time policy"),
+        libc::EINVAL => debug!("real-time policy not recognized or scheduling params wrong"),
+        libc::ESRCH => debug!("thread ID not found for real-time policy"),
+        0 => (),
+        _ => warn!("unknown failure setting real-time policy: {res}"),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn set_rt_scheduling() {
+    ()
+}


### PR DESCRIPTION
Try to request the minimum priority for round robin scheduling. This should fix input handling problems under high-load since niri should be scheduled with a higher priority. Tested by running niri on the tty backend and spawning terminals, terminals do not inherit round-robin scheduling.

To verify RR scheduling run "ps -acT | grep niri" and also check the scheduling classes of spawned terminals.