### PR TITLE
Add config option for first-column-width

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -529,6 +529,8 @@ pub struct Layout {
     pub preset_column_widths: Vec<PresetSize>,
     #[knuffel(child)]
     pub default_column_width: Option<DefaultPresetSize>,
+    #[knuffel(child)]
+    pub first_column_width: Option<DefaultPresetSize>,
     #[knuffel(child, unwrap(children), default)]
     pub preset_window_heights: Vec<PresetSize>,
     #[knuffel(child, unwrap(argument), default)]
@@ -557,6 +559,7 @@ impl Default for Layout {
             insert_hint: Default::default(),
             preset_column_widths: Default::default(),
             default_column_width: Default::default(),
+            first_column_width: Default::default(),
             center_focused_column: Default::default(),
             always_center_single_column: false,
             empty_workspace_above_first: false,
@@ -1404,6 +1407,8 @@ pub struct WindowRule {
     // Rules applied at initial configure.
     #[knuffel(child)]
     pub default_column_width: Option<DefaultPresetSize>,
+    #[knuffel(child)]
+    pub first_column_width: Option<DefaultPresetSize>,
     #[knuffel(child)]
     pub default_window_height: Option<DefaultPresetSize>,
     #[knuffel(child, unwrap(argument))]

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -940,8 +940,18 @@ impl State {
                 });
             }
 
-            width = ws.resolve_default_width(rules.default_width, false);
-            floating_width = ws.resolve_default_width(rules.default_width, true);
+            width = ws.resolve_default_width(
+                rules.default_width,
+                rules.first_width,
+                ws.is_scrolling_empty(),
+                false,
+            );
+            floating_width = ws.resolve_default_width(
+                rules.default_width,
+                rules.first_width,
+                ws.is_scrolling_empty(),
+                true,
+            );
             height = ws.resolve_default_height(rules.default_height, false);
             floating_height = ws.resolve_default_height(rules.default_height, true);
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -39,7 +39,7 @@ use std::time::Duration;
 
 use monitor::{InsertHint, InsertPosition, InsertWorkspace, MonitorAddWindowTarget};
 use niri_config::{
-    CenterFocusedColumn, Config, CornerRadius, FloatOrInt, PresetSize, Struts,
+    CenterFocusedColumn, Config, CornerRadius, DefaultPresetSize, FloatOrInt, PresetSize, Struts,
     Workspace as WorkspaceConfig, WorkspaceReference,
 };
 use niri_ipc::{ColumnDisplay, PositionChange, SizeChange};
@@ -351,6 +351,8 @@ pub struct Options {
     pub default_column_display: ColumnDisplay,
     /// Column or window widths that `toggle_width()` switches between.
     pub preset_column_widths: Vec<PresetSize>,
+    /// Initial width for new columns created on empty workspaces.
+    pub first_column_width: Option<DefaultPresetSize>,
     /// Initial width for new columns.
     pub default_column_width: Option<PresetSize>,
     /// Window height that `toggle_window_height()` switches between.
@@ -384,6 +386,7 @@ impl Default for Options {
                 PresetSize::Proportion(2. / 3.),
             ],
             default_column_width: None,
+            first_column_width: None,
             animations: Default::default(),
             gestures: Default::default(),
             overview: Default::default(),
@@ -655,6 +658,7 @@ impl Options {
             default_column_display: layout.default_column_display,
             preset_column_widths,
             default_column_width,
+            first_column_width: layout.first_column_width,
             animations: config.animations.clone(),
             gestures: config.gestures,
             overview: config.overview,

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -748,8 +748,22 @@ impl<W: LayoutElement> Workspace<W> {
     pub fn resolve_default_width(
         &self,
         default_width: Option<Option<PresetSize>>,
+        first_width: Option<Option<PresetSize>>,
+        is_first: bool,
         is_floating: bool,
     ) -> Option<PresetSize> {
+        if is_first {
+            match first_width {
+                Some(Some(width)) => return Some(width),
+                Some(None) => return None,
+                None if is_floating => return None,
+                None => match self.options.first_column_width {
+                    Some(width) => return width.0,
+                    None => (),
+                },
+            }
+        }
+
         match default_width {
             Some(Some(width)) => Some(width),
             Some(None) => None,
@@ -1761,6 +1775,10 @@ impl<W: LayoutElement> Workspace<W> {
 
     pub fn working_area(&self) -> Rectangle<f64, Logical> {
         self.working_area
+    }
+
+    pub fn is_scrolling_empty(&self) -> bool {
+        self.scrolling.is_empty()
     }
 
     #[cfg(test)]

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -37,6 +37,13 @@ pub struct ResolvedWindowRules {
     /// - `Some(Some(width))`: set to a particular width.
     pub default_width: Option<Option<PresetSize>>,
 
+    /// Default width used if this window is the first window of the workspace.
+    ///
+    /// - `None`: unset (fall back to global_default if set, otherwise to default_width).
+    /// - `Some(None)`: set to empty (window picks its own width).
+    /// - `Some(Some(width))`: set to a particular width.
+    pub first_width: Option<Option<PresetSize>>,
+
     /// Default height for this window.
     ///
     /// - `None`: unset (global default should be used).
@@ -172,6 +179,7 @@ impl ResolvedWindowRules {
     pub const fn empty() -> Self {
         Self {
             default_width: None,
+            first_width: None,
             default_height: None,
             default_column_display: None,
             default_floating_position: None,
@@ -272,6 +280,10 @@ impl ResolvedWindowRules {
 
                 if let Some(x) = rule.default_column_width {
                     resolved.default_width = Some(x.0);
+                }
+
+                if let Some(x) = rule.first_column_width {
+                    resolved.first_width = Some(x.0);
                 }
 
                 if let Some(x) = rule.default_window_height {

--- a/wiki/Configuration:-Layout.md
+++ b/wiki/Configuration:-Layout.md
@@ -20,6 +20,7 @@ layout {
     }
 
     default-column-width { proportion 0.5; }
+    first-column-width { proprtion 1.0; }
 
     preset-window-heights {
         proportion 0.33333
@@ -216,6 +217,30 @@ layout {
 >
 > This is a bit [unclearly defined](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/155) in the Wayland protocol, so some clients may misinterpret it.
 > Either way, `default-column-width {}` is most useful for specific windows, in form of a [window rule](./Configuration:-Window-Rules.md#default-column-width) with the same syntax.
+
+### `first-column-width`
+
+Set the default width of new windows opened on workspaces without any columns.
+
+The syntax is the same as in `default-column-width` above.
+
+```kdl
+layout {
+    // New windows on empty worksapces at the full size of the output.
+    default-column-width { proportion 1.0; }
+}
+```
+
+As with `default-column-width`, you can leave the brackets empty, in which case the windows themselves will decide their initial width.
+
+```kdl
+layout {
+    // New windows on empty workspaces decide their initial width themselves.
+    default-column-width {}
+}
+```
+
+If `first-column-width` is **not** set, then niri will use `default-column-width` instead.
 
 ### `preset-window-heights`
 

--- a/wiki/Configuration:-Window-Rules.md
+++ b/wiki/Configuration:-Window-Rules.md
@@ -40,6 +40,7 @@ window-rule {
 
     // Properties that apply once upon window opening.
     default-column-width { proportion 0.75; }
+    first-column-width { proportion 1.0; }
     default-window-height { fixed 500; }
     open-on-output "Some Company CoolMonitor 1234"
     open-on-workspace "chat"
@@ -341,6 +342,23 @@ window-rule {
     default-column-width { fixed 1200; }
 }
 ```
+
+#### `first-column-width`
+
+Set the default width of new windows opened on workspaces without any columns.
+
+The syntax and behaviour is the the same as in `default-column-width` above, except that it only applies to windows created on workspaces without any tiled windows.
+
+```kdl
+// Make terminals on empty workspaces take up the full screen
+window-rule {
+    match app-id="^alacritty$"
+
+    first-column-width { proportion 1.0; }
+}
+```
+
+If `first-column-width` is **not** set, then niri will fallback to the global setting.
 
 #### `default-window-height`
 


### PR DESCRIPTION
This would address something like #859, but with more options for configuration.

This option makes it so windows opened workspaces without any existing windows (not counting floating) may have a specific width applied. It exists as both a global layout rule and also as a window rule.

A potential issue with this could be the behaviour around leaving this option unset? If it is not set at all, then it falls back to `default-column-width`, but there is no way to explicitly set this option and keep this functionality. Happy to take a look at rewriting this if that's a problem, but it seems like it would require new config syntax in order to be able to have all the options of:
- fall back to `default-column-width`
- let the window decide
- explicitly set the window's width

There is also no way in this implementation to specify falling back to the global `default-column-width` in a window rule if `first-column-width` is already set globally.