### PR TITLE
Fixed `focus` option for `move-column-to-workspace-up`, `move-column-…

### DIFF
--- a/docs/wiki/Accessibility.md
+++ b/docs/wiki/Accessibility.md
@@ -12,7 +12,7 @@ If you're shipping niri and would like to make it work better for screen readers
 
 - Change the default terminal from Alacritty to one that supports screen readers. For example, [GNOME Console](https://gitlab.gnome.org/GNOME/console) or [GNOME Terminal](https://gitlab.gnome.org/GNOME/gnome-terminal) should work well.
 - Change the default application launcher and screen locker to ones that support screen readers. Suggestions welcome! Likely, something GTK-based will work fine.
-- Add some `spawn-at-startup` command that plays a sound which will indicate to users that niri has finished loading.
+- Add some [`spawn-at-startup`](./Configuration:-Miscellaneous.md#spawn-at-startup) command that plays a sound which will indicate to users that niri has finished loading.
 - Add `spawn-at-startup "orca"` to run Orca automatically at niri startup.
 
 ## Desktop zoom

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1844,8 +1844,8 @@ pub enum Action {
     FocusWorkspaceUpUnderMouse,
     FocusWorkspace(#[knuffel(argument)] WorkspaceReference),
     FocusWorkspacePrevious,
-    MoveWindowToWorkspaceDown,
-    MoveWindowToWorkspaceUp,
+    MoveWindowToWorkspaceDown(#[knuffel(property(name = "focus"), default = true)] bool),
+    MoveWindowToWorkspaceUp(#[knuffel(property(name = "focus"), default = true)] bool),
     MoveWindowToWorkspace(
         #[knuffel(argument)] WorkspaceReference,
         #[knuffel(property(name = "focus"), default = true)] bool,
@@ -2089,8 +2089,12 @@ impl From<niri_ipc::Action> for Action {
                 Self::FocusWorkspace(WorkspaceReference::from(reference))
             }
             niri_ipc::Action::FocusWorkspacePrevious {} => Self::FocusWorkspacePrevious,
-            niri_ipc::Action::MoveWindowToWorkspaceDown {} => Self::MoveWindowToWorkspaceDown,
-            niri_ipc::Action::MoveWindowToWorkspaceUp {} => Self::MoveWindowToWorkspaceUp,
+            niri_ipc::Action::MoveWindowToWorkspaceDown { focus } => {
+                Self::MoveWindowToWorkspaceDown(focus)
+            }
+            niri_ipc::Action::MoveWindowToWorkspaceUp { focus } => {
+                Self::MoveWindowToWorkspaceUp(focus)
+            }
             niri_ipc::Action::MoveWindowToWorkspace {
                 window_id: None,
                 reference,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -447,9 +447,23 @@ pub enum Action {
     /// Focus the previous workspace.
     FocusWorkspacePrevious {},
     /// Move the focused window to the workspace below.
-    MoveWindowToWorkspaceDown {},
+    MoveWindowToWorkspaceDown {
+        /// Whether the focus should follow the target workspace.
+        ///
+        /// If `true` (the default), the focus will follow the window to the new workspace. If
+        /// `false`, the focus will remain on the original workspace.
+        #[cfg_attr(feature = "clap", arg(long, action = clap::ArgAction::Set, default_value_t = true))]
+        focus: bool,
+    },
     /// Move the focused window to the workspace above.
-    MoveWindowToWorkspaceUp {},
+    MoveWindowToWorkspaceUp {
+        /// Whether the focus should follow the target workspace.
+        ///
+        /// If `true` (the default), the focus will follow the window to the new workspace. If
+        /// `false`, the focus will remain on the original workspace.
+        #[cfg_attr(feature = "clap", arg(long, action = clap::ArgAction::Set, default_value_t = true))]
+        focus: bool,
+    },
     /// Move a window to a workspace.
     #[cfg_attr(
         feature = "clap",

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1138,14 +1138,14 @@ impl State {
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
-            Action::MoveWindowToWorkspaceDown => {
-                self.niri.layout.move_to_workspace_down();
+            Action::MoveWindowToWorkspaceDown(focus) => {
+                self.niri.layout.move_to_workspace_down(focus);
                 self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
-            Action::MoveWindowToWorkspaceUp => {
-                self.niri.layout.move_to_workspace_up();
+            Action::MoveWindowToWorkspaceUp(focus) => {
+                self.niri.layout.move_to_workspace_up(focus);
                 self.maybe_warp_cursor_to_focus();
                 // FIXME: granular
                 self.niri.queue_redraw_all();

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2178,18 +2178,18 @@ impl<W: LayoutElement> Layout<W> {
         workspace.focus_window_up_or_bottom();
     }
 
-    pub fn move_to_workspace_up(&mut self) {
+    pub fn move_to_workspace_up(&mut self, focus: bool) {
         let Some(monitor) = self.active_monitor() else {
             return;
         };
-        monitor.move_to_workspace_up();
+        monitor.move_to_workspace_up(focus);
     }
 
-    pub fn move_to_workspace_down(&mut self) {
+    pub fn move_to_workspace_down(&mut self, focus: bool) {
         let Some(monitor) = self.active_monitor() else {
             return;
         };
-        monitor.move_to_workspace_down();
+        monitor.move_to_workspace_down(focus);
     }
 
     pub fn move_to_workspace(

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -601,13 +601,13 @@ impl<W: LayoutElement> Monitor<W> {
 
     pub fn move_down_or_to_workspace_down(&mut self) {
         if !self.active_workspace().move_down() {
-            self.move_to_workspace_down();
+            self.move_to_workspace_down(true);
         }
     }
 
     pub fn move_up_or_to_workspace_up(&mut self) {
         if !self.active_workspace().move_up() {
-            self.move_to_workspace_up();
+            self.move_to_workspace_up(true);
         }
     }
 
@@ -623,7 +623,7 @@ impl<W: LayoutElement> Monitor<W> {
         }
     }
 
-    pub fn move_to_workspace_up(&mut self) {
+    pub fn move_to_workspace_up(&mut self, focus: bool) {
         let source_workspace_idx = self.active_workspace_idx;
 
         let new_idx = source_workspace_idx.saturating_sub(1);
@@ -637,13 +637,19 @@ impl<W: LayoutElement> Monitor<W> {
             return;
         };
 
+        let activate = if focus {
+            ActivateWindow::Yes
+        } else {
+            ActivateWindow::Smart
+        };
+
         self.add_tile(
             removed.tile,
             MonitorAddWindowTarget::Workspace {
                 id: new_id,
                 column_idx: None,
             },
-            ActivateWindow::Yes,
+            activate,
             true,
             removed.width,
             removed.is_full_width,
@@ -651,7 +657,7 @@ impl<W: LayoutElement> Monitor<W> {
         );
     }
 
-    pub fn move_to_workspace_down(&mut self) {
+    pub fn move_to_workspace_down(&mut self, focus: bool) {
         let source_workspace_idx = self.active_workspace_idx;
 
         let new_idx = min(source_workspace_idx + 1, self.workspaces.len() - 1);
@@ -665,13 +671,19 @@ impl<W: LayoutElement> Monitor<W> {
             return;
         };
 
+        let activate = if focus {
+            ActivateWindow::Yes
+        } else {
+            ActivateWindow::Smart
+        };
+
         self.add_tile(
             removed.tile,
             MonitorAddWindowTarget::Workspace {
                 id: new_id,
                 column_idx: None,
             },
-            ActivateWindow::Yes,
+            activate,
             true,
             removed.width,
             removed.is_full_width,
@@ -748,7 +760,7 @@ impl<W: LayoutElement> Monitor<W> {
 
         let workspace = &mut self.workspaces[source_workspace_idx];
         if workspace.floating_is_active() {
-            self.move_to_workspace_up();
+            self.move_to_workspace_up(activate);
             return;
         }
 
@@ -769,7 +781,7 @@ impl<W: LayoutElement> Monitor<W> {
 
         let workspace = &mut self.workspaces[source_workspace_idx];
         if workspace.floating_is_active() {
-            self.move_to_workspace_down();
+            self.move_to_workspace_down(activate);
             return;
         }
 
@@ -790,7 +802,12 @@ impl<W: LayoutElement> Monitor<W> {
 
         let workspace = &mut self.workspaces[source_workspace_idx];
         if workspace.floating_is_active() {
-            self.move_to_workspace(None, idx, ActivateWindow::Smart);
+            let activate = if activate {
+                ActivateWindow::Smart
+            } else {
+                ActivateWindow::No
+            };
+            self.move_to_workspace(None, idx, activate);
             return;
         }
 

--- a/src/tests/floating.rs
+++ b/src/tests/floating.rs
@@ -349,7 +349,7 @@ fn moving_across_workspaces_doesnt_cancel_resize() {
 
     // Move to a different workspace before the window has a chance to respond. This will remove it
     // from one floating layout and add into a different one, potentially causing a size request.
-    f.niri().layout.move_to_workspace_down();
+    f.niri().layout.move_to_workspace_down(true);
     // Drop the Activated state to force a configure.
     f.niri_focus_output(2);
     f.double_roundtrip(id);
@@ -369,7 +369,7 @@ fn moving_across_workspaces_doesnt_cancel_resize() {
     // Focus, adding Activated, and move to workspace down, causing removing and adding to a
     // floating layout.
     f.niri_focus_output(1);
-    f.niri().layout.move_to_workspace_down();
+    f.niri().layout.move_to_workspace_down(true);
     f.double_roundtrip(id);
 
     // This should request the current size (300 × 300) since the window responded to the change.

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -228,9 +228,9 @@ fn collect_actions(config: &Config) -> Vec<&Action> {
         actions.push(&bind.action);
     } else if binds
         .iter()
-        .any(|bind| matches!(bind.action, Action::MoveWindowToWorkspaceDown))
+        .any(|bind| matches!(bind.action, Action::MoveWindowToWorkspaceDown(_)))
     {
-        actions.push(&Action::MoveWindowToWorkspaceDown);
+        actions.push(&Action::MoveWindowToWorkspaceDown(true));
     } else {
         actions.push(&Action::MoveColumnToWorkspaceDown(true));
     }
@@ -243,9 +243,9 @@ fn collect_actions(config: &Config) -> Vec<&Action> {
         actions.push(&bind.action);
     } else if binds
         .iter()
-        .any(|bind| matches!(bind.action, Action::MoveWindowToWorkspaceUp))
+        .any(|bind| matches!(bind.action, Action::MoveWindowToWorkspaceUp(_)))
     {
-        actions.push(&Action::MoveWindowToWorkspaceUp);
+        actions.push(&Action::MoveWindowToWorkspaceUp(true));
     } else {
         actions.push(&Action::MoveColumnToWorkspaceUp(true));
     }
@@ -468,8 +468,8 @@ fn action_name(action: &Action) -> String {
         Action::FocusWorkspaceUp => String::from("Switch Workspace Up"),
         Action::MoveColumnToWorkspaceDown(_) => String::from("Move Column to Workspace Down"),
         Action::MoveColumnToWorkspaceUp(_) => String::from("Move Column to Workspace Up"),
-        Action::MoveWindowToWorkspaceDown => String::from("Move Window to Workspace Down"),
-        Action::MoveWindowToWorkspaceUp => String::from("Move Window to Workspace Up"),
+        Action::MoveWindowToWorkspaceDown(_) => String::from("Move Window to Workspace Down"),
+        Action::MoveWindowToWorkspaceUp(_) => String::from("Move Window to Workspace Up"),
         Action::SwitchPresetColumnWidth => String::from("Switch Preset Column Widths"),
         Action::MaximizeColumn => String::from("Maximize Column"),
         Action::ConsumeOrExpelWindowLeft => String::from("Consume or Expel Window Left"),


### PR DESCRIPTION
…to-workspace-down`, `move-column-to-workspace` and `move-window-to-workspace`

- Added parameter `activate` to `monitor.move_to_workspace_up`

- Added parameter `activate` to `monitor.move_to_workspace_down`

- Added parameter `activate` to `layout.move_to_workspace_up`

- Added parameter `activate` to `layout.move_to_workspace_down`

From this issue: https://github.com/YaLTeR/niri/issues/1805

This is what I came up with. I'm not sure how to run tests yet, but looks good to me when tested manually.

Some extra notes:

```text
has focus property:
	move-column-to-workspace-up
	move-column-to-workspace-down
	move-column-to-workspace
	move-window-to-workspace
no focus property (is this by design?):
	move-window-to-workspace-up
	move-window-to-workspace-down

with manual testing (no focus property set, and set to false):
	move-column-to-workspace-up: works correctly
	move-column-to-workspace-down: works correctly
	move-column-to-workspace: works correctly

	move-window-to-workspace-up: works correctly (always focus) (unchanged)
	move-window-to-workspace-down: works correctly (always focus) (unchanged)
	move-window-to-workspace: works correctly
```

