### PR TITLE
Support backlight adjustment keys in default config

### DIFF
--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -364,7 +364,7 @@ binds {
     XF86AudioMute        allow-when-locked=true { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SINK@" "toggle"; }
     XF86AudioMicMute     allow-when-locked=true { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SOURCE@" "toggle"; }
 
-    // Example brightness key mappings for brightnessctl
+    // Example brightness key mappings for brightnessctl.
     XF86MonBrightnessUp allow-when-locked=true { spawn "brightnessctl" "--class=backlight" "set" "+10%"; }
     XF86MonBrightnessDown allow-when-locked=true { spawn "brightnessctl" "--class=backlight" "set" "10%-"; }
 

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -364,6 +364,10 @@ binds {
     XF86AudioMute        allow-when-locked=true { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SINK@" "toggle"; }
     XF86AudioMicMute     allow-when-locked=true { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SOURCE@" "toggle"; }
 
+    // Example brightness key mappings for brightnessctl
+    XF86MonBrightnessUp allow-when-locked=true { spawn "brightnessctl" "--class=backlight" "set" "+10%"; }
+    XF86MonBrightnessDown allow-when-locked=true { spawn "brightnessctl" "--class=backlight" "set" "10%-"; }
+
     // Open/close the Overview: a zoomed-out view of workspaces and windows.
     // You can also move the mouse into the top-left hot corner,
     // or do a four-finger swipe up on a touchpad.


### PR DESCRIPTION
[Related Discussion](https://github.com/YaLTeR/niri/discussions/364)

This PR adds support for setting the backlight of a display using the brightness control keys found on many (most?) laptops in the default config. The motivation here is to have one less thing that a new user is forced to go configure themselves to get there hardware working as expected when first starting. I chose [`brightnessctl`](https://github.com/Hummer12007/brightnessctl) over [`light`](https://gitlab.com/dpeukert/light) because the latter appears to be archived.

I chose +/-10% somewhat randomly, if folks would prefer a different default value I think that's fine.