### PR TITLE
Emit config reloaded event through IPC

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -42,6 +42,8 @@ pub struct Config {
     #[knuffel(child, default)]
     pub layout: Layout,
     #[knuffel(child, default)]
+    pub no_failed_config_reloaded_notification: bool,
+    #[knuffel(child, default)]
     pub prefer_no_csd: bool,
     #[knuffel(child, default)]
     pub cursor: Cursor,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1341,6 +1341,11 @@ pub enum Event {
         /// The new state of the overview.
         is_open: bool,
     },
+    /// The configuration is reloaded
+    ConfigReloaded {
+        /// Whether the operation failed or not
+        failed: bool
+    }
 }
 
 impl FromStr for WorkspaceReferenceArg {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -456,6 +456,9 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                     Event::OverviewOpenedOrClosed { is_open: opened } => {
                         println!("Overview toggled: {opened}");
                     }
+                    Event::ConfigReloaded { failed } => {
+                        println!("Config reloaded: {failed}");
+                    }
                 }
             }
         }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -739,4 +739,15 @@ impl State {
         state.apply(event.clone());
         server.send_event(event);
     }
+
+    pub fn ipc_config_reloaded(&mut self, failed: bool) {
+        let Some(server) = &self.niri.ipc_server else {
+            return;
+        };
+        let mut state = server.event_stream_state.borrow_mut();
+
+        let event = Event::ConfigReloaded { failed };
+        state.apply(event.clone());
+        server.send_event(event);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         event_loop
             .handle()
             .insert_source(rx, |event, _, state| match event {
-                calloop::channel::Event::Msg(config) => state.reload_config(config),
+                calloop::channel::Event::Msg(config) => {
+                    let failed = config.is_err();
+                    state.reload_config(config);
+                    state.ipc_config_reloaded(failed);
+                }
                 calloop::channel::Event::Closed => (),
             })
             .unwrap();

--- a/src/ui/config_error_notification.rs
+++ b/src/ui/config_error_notification.rs
@@ -79,6 +79,12 @@ impl ConfigErrorNotification {
     }
 
     pub fn show(&mut self) {
+        let c = self.config.borrow();
+
+        if c.no_failed_config_reloaded_notification {
+            return;
+        }
+
         if self.created_path.is_some() {
             self.created_path = None;
             self.buffers.borrow_mut().clear();


### PR DESCRIPTION
Add the `ConfigReloaded { failed: bool }` which is emitted though IPC's `event-stream`.

Also add the option to disable the built-in "failed to reload config" notification.