### PR TITLE
Add an option to disable moving the view when the user clicks a window

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -104,6 +104,8 @@ pub struct Input {
     #[knuffel(child)]
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
     #[knuffel(child)]
+    pub disable_moving_view_when_focus_clicked: bool,
+    #[knuffel(child)]
     pub workspace_auto_back_and_forth: bool,
     #[knuffel(child, unwrap(argument, str))]
     pub mod_key: Option<ModKey>,
@@ -4014,6 +4016,7 @@ mod tests {
                 warp-mouse-to-focus
                 focus-follows-mouse
                 workspace-auto-back-and-forth
+                disable-moving-view-when-focus-clicked
 
                 mod-key "Mod5"
                 mod-key-nested "Super"
@@ -4354,6 +4357,7 @@ mod tests {
                         max_scroll_amount: None,
                     },
                 ),
+                disable_moving_view_when_focus_clicked: true,
                 workspace_auto_back_and_forth: true,
                 mod_key: Some(
                     IsoLevel3Shift,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2641,7 +2641,11 @@ impl State {
                 }
 
                 if !is_overview_open {
-                    self.niri.layout.activate_window(&window);
+                    if !self.niri.config.borrow().input.disable_moving_view_when_focus_clicked {
+                        self.niri.layout.activate_window(&window);
+                    } else {
+                        self.niri.layout.activate_window_without_moving_view(&window);
+                    }
                 }
 
                 // FIXME: granular.

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1631,6 +1631,19 @@ impl<W: LayoutElement> Workspace<W> {
         }
     }
 
+    pub fn activate_window_without_moving_view(&mut self, window: &W::Id) -> bool {
+        // The view stays the same in activate_window when floating
+        if self.floating.activate_window(window) {
+            self.floating_is_active = FloatingActive::Yes;
+            true
+        } else if self.scrolling.activate_window_without_moving_view(window) {
+            self.floating_is_active = FloatingActive::No;
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn activate_window_without_raising(&mut self, window: &W::Id) -> bool {
         if self.floating.activate_window_without_raising(window) {
             self.floating_is_active = FloatingActive::Yes;

--- a/wiki/Configuration:-Input.md
+++ b/wiki/Configuration:-Input.md
@@ -99,6 +99,7 @@ input {
     // disable-power-key-handling
     // warp-mouse-to-focus
     // focus-follows-mouse max-scroll-amount="0%"
+    // disable-moving-view-when-focus-clicked
     // workspace-auto-back-and-forth
 
     // mod-key "Super"
@@ -315,6 +316,12 @@ input {
     focus-follows-mouse max-scroll-amount="0%"
 }
 ```
+
+#### `disable-moving-view-when-focus-clicked`
+
+By default, niri will move the view in order to fit the focused window under any circumstances.
+This option allows to disable moving the view only when the user clicks a window. The window will be focused but the view will not change.
+Any other way that focuses a window (e.g. bindings, moving or resizing) is not affected by this option.
 
 #### `workspace-auto-back-and-forth`
 


### PR DESCRIPTION
This PR adds an option to disable moving the view when the user clicks a window. 
The option name is a bit weird but I couldn't find a better one. I wouldn't have any problem if the name would be changed to something better.