### PR TITLE
feat: add hint to disable "Important Hotkeys" in the default config file

### DIFF
--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -266,6 +266,11 @@ layout {
 // This line starts waybar, a commonly used bar for Wayland compositors.
 spawn-at-startup "waybar"
 
+// Uncomment the following to disable "Important Hotkeys" pop-up at startup
+/-hotkey-overlay {
+    skip-at-startup
+}
+
 // Uncomment this line to ask the clients to omit their client-side decorations if possible.
 // If the client will specifically ask for CSD, the request will be honored.
 // Additionally, clients will be informed that they are tiled, removing some client-side rounded corners.

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -266,9 +266,9 @@ layout {
 // This line starts waybar, a commonly used bar for Wayland compositors.
 spawn-at-startup "waybar"
 
-// Uncomment the following to disable "Important Hotkeys" pop-up at startup
-/-hotkey-overlay {
-    skip-at-startup
+hotkey-overlay {
+    // Uncomment this line to disable the "Important Hotkeys" pop-up at startup.
+    // skip-at-startup
 }
 
 // Uncomment this line to ask the clients to omit their client-side decorations if possible.


### PR DESCRIPTION
Motivation: Avoids the need to google how to turn it off, for new users (I faced this as well)