### PR TITLE
Downgrade xcursor: 0.3.9 -> 0.3.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4835,9 +4835,9 @@ checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xcursor"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635887f4315a33cb714eb059bdbd7c1c92bfa71bc5b9d5115460502f788c2ab5"
+checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
 
 [[package]]
 name = "xkbcommon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ tracy-client.workspace = true
 url = { version = "2.5.4", optional = true }
 wayland-backend = "0.3.10"
 wayland-scanner = "0.31.6"
-xcursor = "0.3.9"
+xcursor = "0.3.8"
 zbus = { version = "5.7.1", optional = true }
 
 [dependencies.smithay]


### PR DESCRIPTION
Fixes #1897 
This PR downgrades xcursor from 0.3.9 to 0.3.8.

xcursor bump 0.3.8 -> 0.3.9 seems to have caused problems with cursor themes in various situations. Reverting this bump seems to have fixed this problem.
