### PR TITLE
Allow resolving key codes with a fixed layout.

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -19,7 +19,7 @@ use niri_ipc::{
 };
 use smithay::backend::renderer::Color32F;
 use smithay::input::keyboard::keysyms::KEY_NoSymbol;
-use smithay::input::keyboard::xkb::{keysym_from_name, KEYSYM_CASE_INSENSITIVE};
+use smithay::input::keyboard::xkb::{LayoutIndex, keysym_from_name, KEYSYM_CASE_INSENSITIVE};
 use smithay::input::keyboard::{Keysym, XkbConfig};
 use smithay::reexports::input;
 
@@ -152,6 +152,8 @@ pub struct Xkb {
     pub options: Option<String>,
     #[knuffel(child, unwrap(argument))]
     pub file: Option<String>,
+    #[knuffel(child, unwrap(argument))]
+    pub resolve_keycode_with_layout: Option<LayoutIndex>
 }
 
 impl Xkb {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -17,7 +17,7 @@ use smithay::backend::input::{
     TabletToolTipState, TouchEvent,
 };
 use smithay::backend::libinput::LibinputInputBackend;
-use smithay::input::keyboard::{keysyms, FilterResult, Keysym, Layout, ModifiersState};
+use smithay::input::keyboard::{keysyms, FilterResult, Keysym, KeysymHandle, Layout, ModifiersState};
 use smithay::input::pointer::{
     AxisFrame, ButtonEvent, CursorIcon, CursorImageStatus, Focus, GestureHoldBeginEvent,
     GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent,
@@ -368,7 +368,7 @@ impl State {
             |this, mods, keysym| {
                 let key_code = event.key_code();
                 let modified = keysym.modified_sym();
-                let raw = keysym.raw_latin_sym_or_raw_current_sym();
+                let raw = resolve_keycode_to_raw_sym(&this.niri.config.borrow().input, &keysym);
 
                 if let Some(dialog) = &this.niri.exit_confirm_dialog {
                     if dialog.is_open() && pressed && raw == Some(Keysym::Return) {
@@ -3881,6 +3881,27 @@ impl State {
         if let Some(action) = action {
             self.do_action(action, true);
         }
+    }
+}
+
+/// Resolve a key press into a raw key symbol.
+///
+/// If the user configured a fixed layout for key bindings, then the key
+/// press is resolved with respect to that specified layout.  Otherwise the
+/// key press is resolved with respect to the current active layout and for
+/// non-ASCII symbols, falls back to the first layout with an ASCII symbol.
+fn resolve_keycode_to_raw_sym(config: &niri_config::Input, keysym: &KeysymHandle) -> Option<Keysym> {
+    if let Some(layout_index) = config.keyboard.xkb.resolve_keycode_with_layout {
+        // The internal implementation of raw_syms_for_key_in_layout()
+        // calls xkbcommon::xkb::Keymap::key_get_syms_by_level(),
+        // which wraps around if the layout index is out of range,
+        // for details see there.
+        let layout = Layout(layout_index);
+        let xkb = keysym.xkb().lock().unwrap();
+        xkb.raw_syms_for_key_in_layout(keysym.raw_code(), layout).first().copied()
+    } else {
+        // Resolve keycode with respect to the current layout.
+        keysym.raw_latin_sym_or_raw_current_sym()
     }
 }
 


### PR DESCRIPTION
This is a draft for resolving a key press with respect to a fixed layout. See  https://github.com/YaLTeR/niri/discussions/1919 for the issue background.

The implementation is straight forward: the `raw_latin_sym_or_raw_current_sym()` call is replaced with a check if a fixed layout should be used.
In this case they layouts are not traversed like in [raw_latin_sym_or_raw_current_sym](https://smithay.github.io/smithay/smithay/input/keyboard/struct.KeysymHandle.html#method.raw_latin_sym_or_raw_current_sym) but the layout at the configured index is used directly, which becomes a three-liner. If the user does not configure such an index, then the previous resolution behaviour is used.

I briefly considered, whether it would be possible to specify a complete separate xkb-keyboard configuration for resolving keybindings of Niri (e.g. `us`) and another (e.g. `fr`) for everything else.  In particular keyboad layout switching would not be done as both are configs with a *single* layout.
However, this approach seems to be complicated as there is a global xkb keyboard state.  Hence the user has to configure multiple layouts in a single config (e.g. `us,fr`) and an index.

### Things to consider:

 * Sway allows to bind keycodes (roughly the "physical key" without symbolic meaning of a layout, see `bindcode` command in *sway(5)*).  This might be an alternative method to fixing the layout, which I have not investigated.
 * The config name `resolve_keycode_with_layout` is up to debate
 * The config option type is currently `Option<LayoutIndex>`.  There might be a more suitable type, e.g. `Layout`. Note that `LayoutIndex` is defined as `u32` (https://docs.rs/xkbcommon/latest/xkbcommon/xkb/type.LayoutIndex.html).
 * We currently do not check if the user-configured layout index is between 0 and n-1.  However, the function [key_get_syms_by_level](https://docs.rs/xkbcommon/latest/xkbcommon/xkb/struct.Keymap.html#method.key_get_syms_by_level) used under the hood, does the clipping for us.  In my tests it was a reduction module n.
   We could add an explicit (Niri side) range check for that, if required.
 * Instead of having the "fallback to latin keybindings" (which is a misnomer as it falls back to ASCII-bindings!) we could always resolve with respect to the current layout.  If ASCII fallback is wanted, setting the resolving layout index should provide that behaviour.
   
### What is missing:

If this seems like a sensible solution to the problem, I would
 * provide documentation about the new config knob
 * add an action to change the resolving layout index to Niri's IPC