### PR TITLE
Added IPC command to change layer opacity dynamically

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -97,6 +97,17 @@ pub enum Request {
         /// Configuration to apply.
         action: OutputAction,
     },
+    /// Change layer configuration temporarily.
+    ///
+    /// The configuration is changed temporarily and not saved into the config file. If the layer
+    /// configuration subsequently changes in the config file, these temporary changes will be
+    /// forgotten.
+    Layer {
+        /// Layer name.
+        layer: String,
+        /// Configuration to apply.
+        action: LayerAction,
+    },
     /// Start continuously receiving events from the compositor.
     ///
     /// The compositor should reply with `Reply::Ok(Response::Handled)`, then continuously send
@@ -158,6 +169,8 @@ pub enum Response {
     PickedColor(Option<PickedColor>),
     /// Output configuration change result.
     OutputConfigChanged(OutputConfigChanged),
+    /// Layer configuration change result.
+    LayerConfigChanged(LayerConfigChanged),
     /// Information about the overview.
     OverviewState(Overview),
 }
@@ -900,6 +913,22 @@ pub enum ColumnDisplay {
     Tabbed,
 }
 
+/// Layer actions that niri can perform.
+// Variants in this enum should match the spelling of the ones in niri-config. Most thigs from
+// niri-config should be present here.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[cfg_attr(feature = "clap", command(subcommand_value_name = "ACTION"))]
+#[cfg_attr(feature = "clap", command(subcommand_help_heading = "Actions"))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub enum LayerAction {
+    /// Set the layer opacity
+    Opacity {
+        /// Opacity to set. Must be between 0.0 and 1.0
+        opacity: f32,
+    }
+}
+
 /// Output actions that niri can perform.
 // Variants in this enum should match the spelling of the ones in niri-config. Most thigs from
 // niri-config should be present here.
@@ -1150,6 +1179,16 @@ pub struct Window {
     pub is_floating: bool,
     /// Whether this window requests your attention.
     pub is_urgent: bool,
+}
+
+/// Layer configuration change result.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub enum LayerConfigChanged {
+    /// The change was applied to the target layer.
+    Applied,
+    /// The target layer was not found
+    LayerNotFound,
 }
 
 /// Output configuration change result.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
-use niri_ipc::{Action, OutputAction};
+use niri_ipc::{Action, OutputAction, LayerAction};
 
 use crate::utils::version;
 
@@ -98,6 +98,19 @@ pub enum Msg {
         /// Configuration to apply.
         #[command(subcommand)]
         action: OutputAction,
+    },
+    /// Change layer configuration temporarily.
+    ///
+    /// The configuration is changed temporarily and not saved into the config file. If the layer
+    /// configuration subsequently changes in the config file, these temporary changes will be
+    /// forgotten.
+    Layer {
+        /// Layer name.
+        #[arg()]
+        layer: String,
+        /// Configuration to apply.
+        #[command(subcommand)]
+        action: LayerAction,
     },
     /// Start continuously receiving events from the compositor.
     EventStream,

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -118,6 +118,10 @@ impl MappedLayer {
         &self.rules
     }
 
+    pub fn rules_mut(&mut self) -> &mut ResolvedLayerRules {
+        &mut self.rules
+    }
+
     /// Recomputes the resolved layer rules and returns whether they changed.
     pub fn recompute_layer_rules(&mut self, rules: &[LayerRule], is_at_startup: bool) -> bool {
         let new_rules = ResolvedLayerRules::compute(rules, &self.surface, is_at_startup);


### PR DESCRIPTION
layer opacity can be changed using the following syntax:
`niri msg layer <namespace> opacity <opacity>`

The dynamic configuration gets overriden with a live-reload of the configuration file.

---

I don't know anything about the niri codebase or Rust in general, but I was desperate enough to implement this feature anyway. It might be of low quality or buggy because of my non-existent experience in Rust.

It will also be incomplete because I couldn't find a way to return `LayerConfigChanged::LayerNotFound` to the client without the compiler yelling at me.

But maybe this works as inspiration or a starting point for a new feature with far more options than just opacity.