### PR TITLE
make hot corner size configurable.

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1341,6 +1341,10 @@ impl Default for DndEdgeWorkspaceSwitch {
 pub struct HotCorners {
     #[knuffel(child)]
     pub off: bool,
+    #[knuffel(child,unwrap(argument), default = FloatOrInt(1.))]
+    pub x: FloatOrInt<0, 1_000_000>,
+    #[knuffel(child,unwrap(argument), default = FloatOrInt(1.))]
+    pub y: FloatOrInt<0, 1_000_000>,
 }
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2292,7 +2292,7 @@ impl State {
             && pointer.current_focus().is_none()
             && !self.niri.screenshot_ui.is_open()
         {
-            let hot_corner = Rectangle::from_size(Size::from((1., 1.)));
+            let hot_corner = Rectangle::from_size(Size::from((hot_corners.x.0, hot_corners.y.0)));
             if let Some((_, pos_within_output)) = self.niri.output_under(pos) {
                 let inside_hot_corner = hot_corner.contains(pos_within_output);
                 if inside_hot_corner && !was_inside_hot_corner {
@@ -2381,7 +2381,7 @@ impl State {
             && pointer.current_focus().is_none()
             && !self.niri.screenshot_ui.is_open()
         {
-            let hot_corner = Rectangle::from_size(Size::from((1., 1.)));
+            let hot_corner = Rectangle::from_size(Size::from((hot_corners.x.0, hot_corners.y.0)));
             if let Some((_, pos_within_output)) = self.niri.output_under(pos) {
                 let inside_hot_corner = hot_corner.contains(pos_within_output);
                 if inside_hot_corner && !was_inside_hot_corner {


### PR DESCRIPTION
I don't think my current approach should be the final solution and I am open to suggestions!
also my usage of `FloatOrInt<0, 1_000_000>` seems wrong to me. What would be an more appropriate limit than 1_000_000?
```kdl
gestures {
    hot-corners {
    	x 10
    	y 10
    }
}
```
any ideas how to structure the config are welcome!

I also think that the user should be able to configure 4 hot corners not just 1.