### PR TITLE
Allow NIRI_SOCKET to be derived

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,6 +2330,7 @@ name = "niri-ipc"
 version = "25.5.1"
 dependencies = [
  "clap",
+ "directories",
  "schemars",
  "serde",
  "serde_json",

--- a/niri-ipc/Cargo.toml
+++ b/niri-ipc/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [dependencies]
 clap = { workspace = true, optional = true }
+directories = "6.0.0"
 schemars = { version = "1.0.0", optional = true }
 serde.workspace = true
 serde_json.workspace = true

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -5,16 +5,16 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
-use std::{env, io, process};
+use std::{io, process};
 
 use anyhow::Context;
 use async_channel::{Receiver, Sender, TrySendError};
 use calloop::futures::Scheduler;
 use calloop::io::Async;
-use directories::BaseDirs;
 use futures_util::io::{AsyncReadExt, BufReader};
 use futures_util::{select_biased, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, FutureExt as _};
 use niri_config::OutputName;
+use niri_ipc::socket::socket_dir;
 use niri_ipc::state::{EventStreamState, EventStreamStatePart as _};
 use niri_ipc::{
     Event, KeyboardLayouts, OutputConfigChanged, Overview, Reply, Request, Response, Workspace,
@@ -141,14 +141,6 @@ impl Drop for IpcServer {
             let _ = unlink(socket_path);
         }
     }
-}
-
-fn socket_dir() -> PathBuf {
-    BaseDirs::new()
-        .as_ref()
-        .and_then(|x| x.runtime_dir())
-        .map(|x| x.to_owned())
-        .unwrap_or_else(env::temp_dir)
 }
 
 fn on_new_ipc_client(state: &mut State, stream: UnixStream) {


### PR DESCRIPTION
This PR allows the `niri` CLI to find a running instance of niri without the `NIRI_SOCKET` environment variable defined. Because I use S6 as my init system and run niri as well as my terminal emulator under S6 user services, `NIRI_SOCKET` isn't part of my terminal environment.

This PR finds the running `niri` instance by optionally using the `WAYLAND_DISPLAY` environment variable to filter instances of the IPC socket in the `socket_dir`. If there's more than one option for what the socket could be, it errors out and says that `NIRI_SOCKET ` isn't defined