### PR TITLE
Exact fullscreen state

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -14,8 +14,8 @@ use knuffel::Decode as _;
 use layer_rule::LayerRule;
 use miette::{miette, Context, IntoDiagnostic};
 use niri_ipc::{
-    ColumnDisplay, ConfiguredMode, LayoutSwitchTarget, PositionChange, SizeChange, Transform,
-    WorkspaceReferenceArg,
+    ColumnDisplay, ConfiguredMode, FullscreenSetAction, LayoutSwitchTarget, PositionChange,
+    SizeChange, Transform, WorkspaceReferenceArg,
 };
 use smithay::backend::renderer::Color32F;
 use smithay::input::keyboard::keysyms::KEY_NoSymbol;
@@ -1714,9 +1714,9 @@ pub enum Action {
     CloseWindow,
     #[knuffel(skip)]
     CloseWindowById(u64),
-    FullscreenWindow,
+    FullscreenWindow(#[knuffel(argument, str, default)] FullscreenSetAction),
     #[knuffel(skip)]
-    FullscreenWindowById(u64),
+    FullscreenWindowById(u64, FullscreenSetAction),
     ToggleWindowedFullscreen,
     #[knuffel(skip)]
     ToggleWindowedFullscreenById(u64),
@@ -1950,8 +1950,13 @@ impl From<niri_ipc::Action> for Action {
             }
             niri_ipc::Action::CloseWindow { id: None } => Self::CloseWindow,
             niri_ipc::Action::CloseWindow { id: Some(id) } => Self::CloseWindowById(id),
-            niri_ipc::Action::FullscreenWindow { id: None } => Self::FullscreenWindow,
-            niri_ipc::Action::FullscreenWindow { id: Some(id) } => Self::FullscreenWindowById(id),
+            niri_ipc::Action::FullscreenWindow { id: None, action } => {
+                Self::FullscreenWindow(action)
+            }
+            niri_ipc::Action::FullscreenWindow {
+                id: Some(id),
+                action,
+            } => Self::FullscreenWindowById(id, action),
             niri_ipc::Action::ToggleWindowedFullscreen { id: None } => {
                 Self::ToggleWindowedFullscreen
             }

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -530,7 +530,11 @@ binds {
     Mod+Shift+R { switch-preset-window-height; }
     Mod+Ctrl+R { reset-window-height; }
     Mod+F { maximize-column; }
-    Mod+Shift+F { fullscreen-window; }
+
+    // - "toggle", default behavior, toggling between fullscreen and normal
+    // - "normal", setting a window into its normal size independent of its current state
+    // - "fullscreen", setting a window into fullscreen independent of its current state
+    Mod+Shift+F { fullscreen-window "toggle"; }
 
     // Expand the focused column to space not taken up by other fully visible columns.
     // Makes the column "fill the rest of the space".

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -675,19 +675,23 @@ impl State {
                     mapped.toplevel().send_close();
                 }
             }
-            Action::FullscreenWindow => {
+            Action::FullscreenWindow(fullscreen_action) => {
                 let focus = self.niri.layout.focus().map(|m| m.window.clone());
                 if let Some(window) = focus {
-                    self.niri.layout.toggle_fullscreen(&window);
+                    self.niri
+                        .layout
+                        .set_fullscreen_by_action(&window, fullscreen_action);
                     // FIXME: granular
                     self.niri.queue_redraw_all();
                 }
             }
-            Action::FullscreenWindowById(id) => {
+            Action::FullscreenWindowById(id, fullscreen_action) => {
                 let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
                 let window = window.map(|(_, m)| m.window.clone());
                 if let Some(window) = window {
-                    self.niri.layout.toggle_fullscreen(&window);
+                    self.niri
+                        .layout
+                        .set_fullscreen_by_action(&window, fullscreen_action);
                     // FIXME: granular
                     self.niri.queue_redraw_all();
                 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -42,7 +42,7 @@ use niri_config::{
     CenterFocusedColumn, Config, CornerRadius, FloatOrInt, PresetSize, Struts,
     Workspace as WorkspaceConfig, WorkspaceReference,
 };
-use niri_ipc::{ColumnDisplay, PositionChange, SizeChange};
+use niri_ipc::{ColumnDisplay, FullscreenSetAction, PositionChange, SizeChange};
 use scrolling::{Column, ColumnWidth};
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::utils::RescaleRenderElement;
@@ -3801,6 +3801,14 @@ impl<W: LayoutElement> Layout<W> {
                 ws.toggle_fullscreen(id);
                 return;
             }
+        }
+    }
+
+    pub fn set_fullscreen_by_action(&mut self, id: &W::Id, action: FullscreenSetAction) {
+        match action {
+            FullscreenSetAction::Toggle => self.toggle_fullscreen(id),
+            FullscreenSetAction::Normal => self.set_fullscreen(id, false),
+            FullscreenSetAction::Fullscreen => self.set_fullscreen(id, true),
         }
     }
 


### PR DESCRIPTION
As already proposed in #337 and #338 I've implemented an way to control the fullscreen mode more precisely.
There are now 3 actions: `fullscreen`, `normal` and `toggle`. Because `toggle` is the default it is fully downwards compatible.

## IPC-Controll

```bash
niri msg action fullscreen-window --action fullscreen
niri msg action fullscreen-window --action normal
niri msg action fullscreen-window --action toggle
niri msg action fullscreen-window # Equal to toggle
````

## Config

```kdl
// - "toggle", default behavior, toggling between fullscreen and normal
// - "normal", setting a window into its normal size independent of its current state
// - "fullscreen", setting a window into fullscreen independent of its current state
 Mod+Shift+F { fullscreen-window "toggle"; }
```