### PR TITLE
Support Bluetooth media controls in default config

### DIFF
--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -266,6 +266,10 @@ layout {
 // This line starts waybar, a commonly used bar for Wayland compositors.
 spawn-at-startup "waybar"
 
+// This line starts mpris-proxy in order to handle bluetooth media controls if
+// 1) bluetooth is available, 2) mpris-proxy is installed, and 3) mpris-proxy is not already running.
+spawn-at-startup "bash" "-c" "which systemctl && systemctl -q is-active bluetooth && which mpris-proxy && ps -d | grep -q mpris-proxy || mpris-proxy"
+
 // Uncomment this line to ask the clients to omit their client-side decorations if possible.
 // If the client will specifically ask for CSD, the request will be honored.
 // Additionally, clients will be informed that they are tiled, removing some client-side rounded corners.


### PR DESCRIPTION
This PR adds a line to the default config to conditionally auto-start `mpris-proxy`. Running mpris-proxy allows Bluetooth devices such as headphones to [control media playback](https://wiki.archlinux.org/title/MPRIS#Bluetooth).

The motivation here is to reduce the amount of concepts a new user has to learn and manual setup they have to perform in order for their hardware to work as they expect.

I've tested this command on my machine and its working nicely. I've tried to be defensive enough in this script so that it will only run the command in a circumstance where it makes sense to do so as described in the comment. It does depend on systemd, but should fail silently without causing harm if systemd is not available.

All that said:

- If there's a better way to solve the problem of Bluetooth media controls not working by default rather than a `spawn-at-startup` in the default config, I'm all for it.
- If this feels like too specific a circumstance/too far outside Niri's scope to support, then I'll understand if this PR gets closed. At least this PR's existence should provide some search-ability for users trying to troubleshoot.