### PR TITLE
Add FileChooser portal endpoint to gtk exception list

### DIFF
--- a/resources/niri-portals.conf
+++ b/resources/niri-portals.conf
@@ -2,4 +2,5 @@
 default=gnome;gtk;
 org.freedesktop.impl.portal.Access=gtk;
 org.freedesktop.impl.portal.Notification=gtk;
+org.freedesktop.impl.portal.FileChooser=gtk;
 org.freedesktop.impl.portal.Secret=gnome-keyring;


### PR DESCRIPTION
I was trying to build something with [`rfd`](https://github.com/PolyMeilex/rfd) recently and couldn't get it to actually show the file chooser dialog in niri until I added this manual exception to the portals list.

The Gnome portal claims that it supports this endpoint, but I get 'this name is not activatable' errors in journalctl whenever the system tries to use Gnome for this endpoint, so I think the Gnome portal is just kinda lying.

I also guess I can't guarantee this is something that everyone needs or whatever, but it seems like the pretty clear and simple fix to what is probably also a few other people's problem.