### PR TITLE
Add nushell completion support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_nushell"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0c951694691e65bf9d421d597d68416c22de9632e884c28412cb8cd8b73dce"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,6 +2277,7 @@ dependencies = [
  "calloop-wayland-source 0.4.0",
  "clap",
  "clap_complete",
+ "clap_complete_nushell",
  "directories",
  "drm-ffi",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ tracy-client.workspace = true
 url = { version = "2.5.4", optional = true }
 wayland-backend = "0.3.10"
 wayland-scanner = "0.31.6"
-xcursor = "0.3.9"
+xcursor = "0.3.10"
 zbus = { version = "5.7.1", optional = true }
 
 [dependencies.smithay]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ bytemuck = { version = "1.23.1", features = ["derive"] }
 calloop = { version = "0.14.2", features = ["executor", "futures-io"] }
 clap = { workspace = true, features = ["string"] }
 clap_complete = "4.5.54"
+clap_complete_nushell = "4.5.8"
 directories = "6.0.0"
 drm-ffi = "0.9.0"
 fastrand = "2.3.0"

--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,7 @@
               installShellCompletion --cmd niri \
                 --bash <($out/bin/niri completions bash) \
                 --fish <($out/bin/niri completions fish) \
+                --nushell <($out/bin/niri completions nushell) \
                 --zsh <($out/bin/niri completions zsh)
 
               install -Dm644 resources/niri.desktop -t $out/share/wayland-sessions

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,8 +2,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use clap_complete::{Generator, Shell};
-use clap_complete_nushell::Nushell;
+use clap_complete::Shell;
 use niri_ipc::{Action, OutputAction};
 
 use crate::utils::version;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,8 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use clap_complete::Shell;
+use clap_complete::{Generator, Shell};
+use clap_complete_nushell::Nushell;
 use niri_ipc::{Action, OutputAction};
 
 use crate::utils::version;
@@ -17,15 +18,17 @@ pub enum CompletionShell {
     Nushell,
 }
 
-impl From<CompletionShell> for Shell {
-    fn from(shell: CompletionShell) -> Self {
+impl TryFrom<CompletionShell> for Shell {
+    type Error = &'static str;
+
+    fn try_from(shell: CompletionShell) -> Result<Self, Self::Error> {
         match shell {
-            CompletionShell::Bash => Shell::Bash,
-            CompletionShell::Elvish => Shell::Elvish,
-            CompletionShell::Fish => Shell::Fish,
-            CompletionShell::PowerShell => Shell::PowerShell,
-            CompletionShell::Zsh => Shell::Zsh,
-            CompletionShell::Nushell => panic!("Nushell should be handled separately"),
+            CompletionShell::Bash => Ok(Shell::Bash),
+            CompletionShell::Elvish => Ok(Shell::Elvish),
+            CompletionShell::Fish => Ok(Shell::Fish),
+            CompletionShell::PowerShell => Ok(Shell::PowerShell),
+            CompletionShell::Zsh => Ok(Shell::Zsh),
+            CompletionShell::Nushell => Err("Nushell should be handled separately"),
         }
     }
 }
@@ -79,9 +82,7 @@ pub enum Sub {
     /// Cause a panic to check if the backtraces are good.
     Panic,
     /// Generate shell completions.
-    Completions {
-        shell: CompletionShell, // Changed from Shell to CompletionShell
-    },
+    Completions { shell: CompletionShell },
 }
 
 #[derive(Subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,29 @@ use niri_ipc::{Action, OutputAction};
 
 use crate::utils::version;
 
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum CompletionShell {
+    Bash,
+    Elvish,
+    Fish,
+    PowerShell,
+    Zsh,
+    Nushell,
+}
+
+impl From<CompletionShell> for Shell {
+    fn from(shell: CompletionShell) -> Self {
+        match shell {
+            CompletionShell::Bash => Shell::Bash,
+            CompletionShell::Elvish => Shell::Elvish,
+            CompletionShell::Fish => Shell::Fish,
+            CompletionShell::PowerShell => Shell::PowerShell,
+            CompletionShell::Zsh => Shell::Zsh,
+            CompletionShell::Nushell => panic!("Nushell should be handled separately"),
+        }
+    }
+}
+
 #[derive(Parser)]
 #[command(author, version = version(), about, long_about = None)]
 #[command(args_conflicts_with_subcommands = true)]
@@ -56,7 +79,9 @@ pub enum Sub {
     /// Cause a panic to check if the backtraces are good.
     Panic,
     /// Generate shell completions.
-    Completions { shell: Shell },
+    Completions {
+        shell: CompletionShell, // Changed from Shell to CompletionShell
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,31 +7,6 @@ use niri_ipc::{Action, OutputAction};
 
 use crate::utils::version;
 
-#[derive(Clone, Debug, clap::ValueEnum)]
-pub enum CompletionShell {
-    Bash,
-    Elvish,
-    Fish,
-    PowerShell,
-    Zsh,
-    Nushell,
-}
-
-impl TryFrom<CompletionShell> for Shell {
-    type Error = &'static str;
-
-    fn try_from(shell: CompletionShell) -> Result<Self, Self::Error> {
-        match shell {
-            CompletionShell::Bash => Ok(Shell::Bash),
-            CompletionShell::Elvish => Ok(Shell::Elvish),
-            CompletionShell::Fish => Ok(Shell::Fish),
-            CompletionShell::PowerShell => Ok(Shell::PowerShell),
-            CompletionShell::Zsh => Ok(Shell::Zsh),
-            CompletionShell::Nushell => Err("Nushell should be handled separately"),
-        }
-    }
-}
-
 #[derive(Parser)]
 #[command(author, version = version(), about, long_about = None)]
 #[command(args_conflicts_with_subcommands = true)]
@@ -132,4 +107,29 @@ pub enum Msg {
     RequestError,
     /// Print the overview state.
     OverviewState,
+}
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum CompletionShell {
+    Bash,
+    Elvish,
+    Fish,
+    PowerShell,
+    Zsh,
+    Nushell,
+}
+
+impl TryFrom<CompletionShell> for Shell {
+    type Error = &'static str;
+
+    fn try_from(shell: CompletionShell) -> Result<Self, Self::Error> {
+        match shell {
+            CompletionShell::Bash => Ok(Shell::Bash),
+            CompletionShell::Elvish => Ok(Shell::Elvish),
+            CompletionShell::Fish => Ok(Shell::Fish),
+            CompletionShell::PowerShell => Ok(Shell::PowerShell),
+            CompletionShell::Zsh => Ok(Shell::Zsh),
+            CompletionShell::Nushell => Err("Nushell should be handled separately"),
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,10 @@ use std::process::Command;
 use std::{env, mem};
 
 use clap::{CommandFactory, Parser};
+use clap_complete::Shell;
+use clap_complete_nushell::Nushell;
 use directories::ProjectDirs;
-use niri::cli::{Cli, Sub};
+use niri::cli::{Cli, CompletionShell, Sub};
 #[cfg(feature = "dbus")]
 use niri::dbus;
 use niri::ipc::client::handle_msg;
@@ -108,7 +110,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             Sub::Panic => cause_panic(),
             Sub::Completions { shell } => {
-                clap_complete::generate(shell, &mut Cli::command(), "niri", &mut io::stdout());
+                match shell {
+                    CompletionShell::Nushell => {
+                        clap_complete::generate(
+                            Nushell,
+                            &mut Cli::command(),
+                            "niri",
+                            &mut io::stdout(),
+                        );
+                    }
+                    other => {
+                        clap_complete::generate(
+                            Shell::from(other),
+                            &mut Cli::command(),
+                            "niri",
+                            &mut io::stdout(),
+                        );
+                    }
+                }
                 return Ok(());
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,8 +120,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         );
                     }
                     other => {
+                        let generator = Shell::try_from(other).unwrap();
                         clap_complete::generate(
-                            Shell::from(other),
+                            generator,
                             &mut Cli::command(),
                             "niri",
                             &mut io::stdout(),


### PR DESCRIPTION
Adds `clap_complete_nushell` crate and implements it into the `niri completions` command.