### PR TITLE
handle `SIGINT`, `SIGTERM`, `SIGHUP`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "async-task",
  "bitflags 2.9.1",
  "futures-io",
+ "nix 0.29.0",
  "polling",
  "rustix 0.38.44",
  "slab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ async-io = { version = "2.4.1", optional = true }
 atomic = "0.6.1"
 bitflags.workspace = true
 bytemuck = { version = "1.23.1", features = ["derive"] }
-calloop = { version = "0.14.2", features = ["executor", "futures-io"] }
+calloop = { version = "0.14.2", features = ["executor", "futures-io", "signals"] }
 clap = { workspace = true, features = ["string"] }
 clap_complete = "4.5.55"
 directories = "6.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, mem};
 
+use calloop::EventLoop;
 use clap::{CommandFactory, Parser};
 use directories::ProjectDirs;
 use niri::cli::{Cli, Sub};
@@ -26,7 +27,6 @@ use niri_config::Config;
 use niri_ipc::socket::SOCKET_PATH_ENV;
 use portable_atomic::Ordering;
 use sd_notify::NotifyState;
-use smithay::reexports::calloop::EventLoop;
 use smithay::reexports::wayland_server::Display;
 use tracing_subscriber::EnvFilter;
 


### PR DESCRIPTION
Currently, if you start `niri` from the command line and then press  `Ctrl+C`, or it is `kill`-ed, niri will not exit gracefully and it will leave some garbage runtime files (namely, `$NIRI_SOCKET` is not cleaned up). This leads to quite the mess if you're repeatedly starting and stopping niri to test things.

<img width="403" height="330" alt="too many niri IPC sockets" src="https://github.com/user-attachments/assets/7b79ddd0-e41d-4576-8db3-a9cccecb5128" />

This PR adds a simple signal handler using the `signals` feature of `calloop`. No new transitive dependencies are added to niri, but `calloop` now depends on `nix`.

---

I also changed the import of `smithay::reexports::calloop::EventLoop` to one of `calloop::EventLoop` in `main.rs`. This way, the imports don't have two separate instances of `calloop`. We already reference toplevel `calloop` by name in the file anyways; there is no good reason to use the smithay reexport.