### PR TITLE
feat: add WASD and HJKL hardcoded_overview_bind

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4230,6 +4230,17 @@ fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Bind> {
         Keysym::Right => Action::FocusColumnRight,
         Keysym::Up => Action::FocusWindowOrWorkspaceUp,
         Keysym::Down => Action::FocusWindowOrWorkspaceDown,
+
+        Keysym::W => Action::FocusWindowOrWorkspaceUp,
+        Keysym::A => Action::FocusColumnLeft,
+        Keysym::S => Action::FocusWindowOrWorkspaceDown,
+        Keysym::D => Action::FocusColumnRight,
+
+        Keysym::H => Action::FocusColumnLeft,
+        Keysym::J => Action::FocusWindowOrWorkspaceDown,
+        Keysym::K => Action::FocusWindowOrWorkspaceUp,
+        Keysym::L => Action::FocusColumnRight,
+
         _ => {
             return None;
         }


### PR DESCRIPTION
Ideally, there should be a way to configure these, but this should be a good stop-gap for having these as default in overview mode, until it can be implemented 