### PR TITLE
revert nushell completion for flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,6 @@
               installShellCompletion --cmd niri \
                 --bash <($out/bin/niri completions bash) \
                 --fish <($out/bin/niri completions fish) \
-                --nushell <($out/bin/niri completions nushell) \
                 --zsh <($out/bin/niri completions zsh)
 
               install -Dm644 resources/niri.desktop -t $out/share/wayland-sessions


### PR DESCRIPTION
- #2009 modified the nix package in an invalid way

theoretically we could install a nushell completion here, but `installShellCompletion` isn't it (see https://github.com/NixOS/nixpkgs/issues/384084). [we already support all the shells it supports](https://github.com/NixOS/nixpkgs/blob/8f4200d165b73db63dc277e9984a480984415593/pkgs/build-support/install-shell-files/setup-hook.sh#L104).

for now, just remove it.