### PR TITLE
fix: compiler warnings (mismatched_lifetime_syntaxes)

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -155,7 +155,7 @@ pub struct Xkb {
 }
 
 impl Xkb {
-    pub fn to_xkb_config(&self) -> XkbConfig {
+    pub fn to_xkb_config(&self) -> XkbConfig<'_> {
         XkbConfig {
             rules: &self.rules,
             model: &self.model,

--- a/src/render_helpers/border.rs
+++ b/src/render_helpers/border.rs
@@ -286,7 +286,7 @@ impl RenderElement<GlesRenderer> for BorderRenderElement {
         RenderElement::<GlesRenderer>::draw(&self.inner, frame, src, dst, damage, opaque_regions)
     }
 
-    fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
+    fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
         self.inner.underlying_storage(renderer)
     }
 }
@@ -303,7 +303,10 @@ impl<'render> RenderElement<TtyRenderer<'render>> for BorderRenderElement {
         RenderElement::<TtyRenderer<'_>>::draw(&self.inner, frame, src, dst, damage, opaque_regions)
     }
 
-    fn underlying_storage(&self, renderer: &mut TtyRenderer<'render>) -> Option<UnderlyingStorage> {
+    fn underlying_storage(
+        &self,
+        renderer: &mut TtyRenderer<'render>,
+    ) -> Option<UnderlyingStorage<'_>> {
         self.inner.underlying_storage(renderer)
     }
 }

--- a/src/render_helpers/clipped_surface.rs
+++ b/src/render_helpers/clipped_surface.rs
@@ -230,7 +230,7 @@ impl RenderElement<GlesRenderer> for ClippedSurfaceRenderElement<GlesRenderer> {
         Ok(())
     }
 
-    fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
+    fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
         // If scanout for things other than Wayland buffers is implemented, this will need to take
         // the target GPU into account.
         None
@@ -259,7 +259,7 @@ impl<'render> RenderElement<TtyRenderer<'render>>
     fn underlying_storage(
         &self,
         _renderer: &mut TtyRenderer<'render>,
-    ) -> Option<UnderlyingStorage> {
+    ) -> Option<UnderlyingStorage<'_>> {
         // If scanout for things other than Wayland buffers is implemented, this will need to take
         // the target GPU into account.
         None

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -105,7 +105,7 @@ impl<E> IntoIterator for SplitElements<E> {
 }
 
 impl<E> SplitElements<E> {
-    pub fn iter(&self) -> std::iter::Chain<std::slice::Iter<E>, std::slice::Iter<E>> {
+    pub fn iter(&self) -> std::iter::Chain<std::slice::Iter<'_, E>, std::slice::Iter<'_, E>> {
         self.popups.iter().chain(&self.normal)
     }
 

--- a/src/render_helpers/offscreen.rs
+++ b/src/render_helpers/offscreen.rs
@@ -347,7 +347,7 @@ impl<'render> RenderElement<TtyRenderer<'render>> for OffscreenRenderElement {
     fn underlying_storage(
         &self,
         _renderer: &mut TtyRenderer<'render>,
-    ) -> Option<UnderlyingStorage> {
+    ) -> Option<UnderlyingStorage<'_>> {
         // If scanout for things other than Wayland buffers is implemented, this will need to take
         // the target GPU into account.
         None

--- a/src/render_helpers/primary_gpu_texture.rs
+++ b/src/render_helpers/primary_gpu_texture.rs
@@ -67,7 +67,7 @@ impl RenderElement<GlesRenderer> for PrimaryGpuTextureRenderElement {
         Ok(())
     }
 
-    fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
+    fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
         // If scanout for things other than Wayland buffers is implemented, this will need to take
         // the target GPU into account.
         None
@@ -91,7 +91,7 @@ impl<'render> RenderElement<TtyRenderer<'render>> for PrimaryGpuTextureRenderEle
     fn underlying_storage(
         &self,
         _renderer: &mut TtyRenderer<'render>,
-    ) -> Option<UnderlyingStorage> {
+    ) -> Option<UnderlyingStorage<'_>> {
         // If scanout for things other than Wayland buffers is implemented, this will need to take
         // the target GPU into account.
         None

--- a/src/render_helpers/render_elements.rs
+++ b/src/render_helpers/render_elements.rs
@@ -113,7 +113,7 @@ macro_rules! niri_render_elements {
                 }
             }
 
-            fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
+            fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
                 match self {
                     $($name::$variant(elem) => elem.underlying_storage(renderer)),+
                 }
@@ -141,7 +141,7 @@ macro_rules! niri_render_elements {
             fn underlying_storage(
                 &self,
                 renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
-            ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
+            ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
                 match self {
                     $($name::$variant(elem) => elem.underlying_storage(renderer)),+
                 }

--- a/src/render_helpers/resize.rs
+++ b/src/render_helpers/resize.rs
@@ -174,7 +174,7 @@ impl RenderElement<GlesRenderer> for ResizeRenderElement {
         Ok(())
     }
 
-    fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
+    fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
         self.0.underlying_storage(renderer)
     }
 }
@@ -193,7 +193,10 @@ impl<'render> RenderElement<TtyRenderer<'render>> for ResizeRenderElement {
         Ok(())
     }
 
-    fn underlying_storage(&self, renderer: &mut TtyRenderer<'render>) -> Option<UnderlyingStorage> {
+    fn underlying_storage(
+        &self,
+        renderer: &mut TtyRenderer<'render>,
+    ) -> Option<UnderlyingStorage<'_>> {
         self.0.underlying_storage(renderer)
     }
 }

--- a/src/render_helpers/shader_element.rs
+++ b/src/render_helpers/shader_element.rs
@@ -509,7 +509,7 @@ impl RenderElement<GlesRenderer> for ShaderRenderElement {
         Ok(())
     }
 
-    fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
+    fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
         // If scanout for things other than Wayland buffers is implemented, this will need to take
         // the target GPU into account.
         None
@@ -535,7 +535,7 @@ impl<'render> RenderElement<TtyRenderer<'render>> for ShaderRenderElement {
     fn underlying_storage(
         &self,
         _renderer: &mut TtyRenderer<'render>,
-    ) -> Option<UnderlyingStorage> {
+    ) -> Option<UnderlyingStorage<'_>> {
         // If scanout for things other than Wayland buffers is implemented, this will need to take
         // the target GPU into account.
         None

--- a/src/render_helpers/shaders/mod.rs
+++ b/src/render_helpers/shaders/mod.rs
@@ -297,7 +297,7 @@ pub fn set_custom_open_program(renderer: &mut GlesRenderer, src: Option<&str>) {
     }
 }
 
-pub fn mat3_uniform(name: &str, mat: Mat3) -> Uniform {
+pub fn mat3_uniform(name: &str, mat: Mat3) -> Uniform<'_> {
     Uniform::new(
         name,
         UniformValue::Matrix3x3 {

--- a/src/render_helpers/shadow.rs
+++ b/src/render_helpers/shadow.rs
@@ -247,7 +247,7 @@ impl RenderElement<GlesRenderer> for ShadowRenderElement {
         RenderElement::<GlesRenderer>::draw(&self.inner, frame, src, dst, damage, opaque_regions)
     }
 
-    fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
+    fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
         self.inner.underlying_storage(renderer)
     }
 }
@@ -264,7 +264,10 @@ impl<'render> RenderElement<TtyRenderer<'render>> for ShadowRenderElement {
         RenderElement::<TtyRenderer<'_>>::draw(&self.inner, frame, src, dst, damage, opaque_regions)
     }
 
-    fn underlying_storage(&self, renderer: &mut TtyRenderer<'render>) -> Option<UnderlyingStorage> {
+    fn underlying_storage(
+        &self,
+        renderer: &mut TtyRenderer<'render>,
+    ) -> Option<UnderlyingStorage<'_>> {
         self.inner.underlying_storage(renderer)
     }
 }

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -303,7 +303,7 @@ impl Mapped {
         self.credentials.as_ref()
     }
 
-    pub fn offscreen_data(&self) -> Ref<Option<OffscreenData>> {
+    pub fn offscreen_data(&self) -> Ref<'_, Option<OffscreenData>> {
         self.offscreen_data.borrow()
     }
 


### PR DESCRIPTION
This PR fixes 44 compiler warnings related to `mismatched_lifetime_syntaxes` (see logs below) when compiling with rust 1.88.0.

```
$ rustup run stable cargo -V
cargo 1.88.0 (873a06493 2025-05-10)

$ rustup run stable cargo check
    Checking niri-config v25.5.1 (/home/long/github.io/niri-fork/niri-config)
warning: lifetime flowing from input to output with different syntax can be confusing
   --> niri-config/src/lib.rs:158:26
    |
158 |     pub fn to_xkb_config(&self) -> XkbConfig {
    |                          ^^^^^     --------- the lifetime gets resolved as `'_`
    |                          |
    |                          this lifetime flows to the output
    |
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
158 |     pub fn to_xkb_config(&self) -> XkbConfig<'_> {
    |                                             ++++

warning: `niri-config` (lib) generated 1 warning
    Checking niri v25.5.1 (/home/long/github.io/niri-fork)
warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layer/mapped.rs:45:1
    |
45  | / niri_render_elements! {
46  | |     LayerSurfaceRenderElement<R> => {
47  | |         Wayland = WaylandSurfaceRenderElement<R>,
48  | |         SolidColor = SolidColorRenderElement,
...   |
51  | | }
    | |_- in this macro invocation
    |
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layer/mapped.rs:45:1
    |
45  | / niri_render_elements! {
46  | |     LayerSurfaceRenderElement<R> => {
47  | |         Wayland = WaylandSurfaceRenderElement<R>,
48  | |         SolidColor = SolidColorRenderElement,
...   |
51  | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/mod.rs:112:1
    |
112 | / niri_render_elements! {
113 | |     LayoutElementRenderElement<R> => {
114 | |         Wayland = WaylandSurfaceRenderElement<R>,
115 | |         SolidColor = SolidColorRenderElement,
116 | |     }
117 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/mod.rs:112:1
    |
112 | / niri_render_elements! {
113 | |     LayoutElementRenderElement<R> => {
114 | |         Wayland = WaylandSurfaceRenderElement<R>,
115 | |         SolidColor = SolidColorRenderElement,
116 | |     }
117 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/closing_window.rs:56:1
    |
56  | / niri_render_elements! {
57  | |     ClosingWindowRenderElement => {
58  | |         Texture = RelocateRenderElement<RescaleRenderElement<PrimaryGpuTextureRenderElement>>,
59  | |         Shader = ShaderRenderElement,
60  | |     }
61  | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/closing_window.rs:56:1
    |
56  | / niri_render_elements! {
57  | |     ClosingWindowRenderElement => {
58  | |         Texture = RelocateRenderElement<RescaleRenderElement<PrimaryGpuTextureRenderElement>>,
59  | |         Shader = ShaderRenderElement,
60  | |     }
61  | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/floating.rs:70:1
    |
70  | / niri_render_elements! {
71  | |     FloatingSpaceRenderElement<R> => {
72  | |         Tile = TileRenderElement<R>,
73  | |         ClosingWindow = ClosingWindowRenderElement,
74  | |     }
75  | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/floating.rs:70:1
    |
70  | / niri_render_elements! {
71  | |     FloatingSpaceRenderElement<R> => {
72  | |         Tile = TileRenderElement<R>,
73  | |         ClosingWindow = ClosingWindowRenderElement,
74  | |     }
75  | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/focus_ring.rs:25:1
    |
25  | / niri_render_elements! {
26  | |     FocusRingRenderElement => {
27  | |         SolidColor = SolidColorRenderElement,
28  | |         Gradient = BorderRenderElement,
29  | |     }
30  | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/focus_ring.rs:25:1
    |
25  | / niri_render_elements! {
26  | |     FocusRingRenderElement => {
27  | |         SolidColor = SolidColorRenderElement,
28  | |         Gradient = BorderRenderElement,
29  | |     }
30  | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/monitor.rs:172:1
    |
172 | / niri_render_elements! {
173 | |     MonitorInnerRenderElement<R> => {
174 | |         Workspace = CropRenderElement<WorkspaceRenderElement<R>>,
175 | |         InsertHint = CropRenderElement<InsertHintRenderElement>,
...   |
179 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/monitor.rs:172:1
    |
172 | / niri_render_elements! {
173 | |     MonitorInnerRenderElement<R> => {
174 | |         Workspace = CropRenderElement<WorkspaceRenderElement<R>>,
175 | |         InsertHint = CropRenderElement<InsertHintRenderElement>,
...   |
179 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/opening_window.rs:26:1
    |
26  | / niri_render_elements! {
27  | |     OpeningWindowRenderElement => {
28  | |         Offscreen = RelocateRenderElement<RescaleRenderElement<OffscreenRenderElement>>,
29  | |         Shader = ShaderRenderElement,
30  | |     }
31  | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/opening_window.rs:26:1
    |
26  | / niri_render_elements! {
27  | |     OpeningWindowRenderElement => {
28  | |         Offscreen = RelocateRenderElement<RescaleRenderElement<OffscreenRenderElement>>,
29  | |         Shader = ShaderRenderElement,
30  | |     }
31  | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/scrolling.rs:94:1
    |
94  | / niri_render_elements! {
95  | |     ScrollingSpaceRenderElement<R> => {
96  | |         Tile = TileRenderElement<R>,
97  | |         ClosingWindow = ClosingWindowRenderElement,
...   |
100 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/scrolling.rs:94:1
    |
94  | / niri_render_elements! {
95  | |     ScrollingSpaceRenderElement<R> => {
96  | |         Tile = TileRenderElement<R>,
97  | |         ClosingWindow = ClosingWindowRenderElement,
...   |
100 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/tab_indicator.rs:33:1
    |
33  | / niri_render_elements! {
34  | |     TabIndicatorRenderElement => {
35  | |         Gradient = BorderRenderElement,
36  | |     }
37  | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/tab_indicator.rs:33:1
    |
33  | / niri_render_elements! {
34  | |     TabIndicatorRenderElement => {
35  | |         Gradient = BorderRenderElement,
36  | |     }
37  | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/tile.rs:116:1
    |
116 | / niri_render_elements! {
117 | |     TileRenderElement<R> => {
118 | |         LayoutElement = LayoutElementRenderElement<R>,
119 | |         FocusRing = FocusRingRenderElement,
...   |
129 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/tile.rs:116:1
    |
116 | / niri_render_elements! {
117 | |     TileRenderElement<R> => {
118 | |         LayoutElement = LayoutElementRenderElement<R>,
119 | |         FocusRing = FocusRingRenderElement,
...   |
129 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/workspace.rs:135:1
    |
135 | / niri_render_elements! {
136 | |     WorkspaceRenderElement<R> => {
137 | |         Scrolling = ScrollingSpaceRenderElement<R>,
138 | |         Floating = FloatingSpaceRenderElement<R>,
139 | |     }
140 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/layout/workspace.rs:135:1
    |
135 | / niri_render_elements! {
136 | |     WorkspaceRenderElement<R> => {
137 | |         Scrolling = ScrollingSpaceRenderElement<R>,
138 | |         Floating = FloatingSpaceRenderElement<R>,
139 | |     }
140 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
    --> src/render_helpers/render_elements.rs:116:35
     |
116  |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
     |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
     |
    ::: src/niri.rs:6280:1
     |
6280 | / niri_render_elements! {
6281 | |     OutputRenderElements<R> => {
6282 | |         Monitor = MonitorRenderElement<R>,
6283 | |         RescaledTile = RescaleRenderElement<TileRenderElement<R>>,
...    |
6299 | | }
     | |_- in this macro invocation
     |
     = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
     |
116  |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
     |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
    --> src/render_helpers/render_elements.rs:142:17
     |
142  |                   &self,
     |                   ^^^^^ this lifetime flows to the output
143  |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144  |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
     |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
     |
    ::: src/niri.rs:6280:1
     |
6280 | / niri_render_elements! {
6281 | |     OutputRenderElements<R> => {
6282 | |         Monitor = MonitorRenderElement<R>,
6283 | |         RescaledTile = RescaleRenderElement<TileRenderElement<R>>,
...    |
6299 | | }
     | |_- in this macro invocation
     |
     = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
     |
144  |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
     |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/mod.rs:108:17
    |
108 |     pub fn iter(&self) -> std::iter::Chain<std::slice::Iter<E>, std::slice::Iter<E>> {
    |                 ^^^^^                      -------------------  ------------------- the lifetimes get resolved as `'_`
    |                 |                          |
    |                 |                          the lifetimes get resolved as `'_`
    |                 this lifetime flows to the output
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
108 |     pub fn iter(&self) -> std::iter::Chain<std::slice::Iter<'_, E>, std::slice::Iter<'_, E>> {
    |                                                             +++                      +++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/border.rs:289:27
    |
289 |     fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
    |                           ^^^^^ this lifetime flows to the output       ----------------- the lifetime gets resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
289 |     fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
    |                                                                                          ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/border.rs:306:27
    |
306 |     fn underlying_storage(&self, renderer: &mut TtyRenderer<'render>) -> Option<UnderlyingStorage> {
    |                           ^^^^^ this lifetime flows to the output               ----------------- the lifetime gets resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
306 |     fn underlying_storage(&self, renderer: &mut TtyRenderer<'render>) -> Option<UnderlyingStorage<'_>> {
    |                                                                                                  ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/clipped_surface.rs:233:27
    |
233 |     fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
    |                           ^^^^^ this lifetime flows to the output        ----------------- the lifetime gets resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
233 |     fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
    |                                                                                           ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/clipped_surface.rs:260:9
    |
260 |         &self,
    |         ^^^^^ this lifetime flows to the output
261 |         _renderer: &mut TtyRenderer<'render>,
262 |     ) -> Option<UnderlyingStorage> {
    |                 ----------------- the lifetime gets resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
262 |     ) -> Option<UnderlyingStorage<'_>> {
    |                                  ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/offscreen.rs:348:9
    |
348 |         &self,
    |         ^^^^^ this lifetime flows to the output
349 |         _renderer: &mut TtyRenderer<'render>,
350 |     ) -> Option<UnderlyingStorage> {
    |                 ----------------- the lifetime gets resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
350 |     ) -> Option<UnderlyingStorage<'_>> {
    |                                  ++++

warning: lifetime flowing from input to output with different syntax can be confusing
  --> src/render_helpers/primary_gpu_texture.rs:70:27
   |
70 |     fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
   |                           ^^^^^ this lifetime flows to the output        ----------------- the lifetime gets resolved as `'_`
   |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
70 |     fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
   |                                                                                           ++++

warning: lifetime flowing from input to output with different syntax can be confusing
  --> src/render_helpers/primary_gpu_texture.rs:92:9
   |
92 |         &self,
   |         ^^^^^ this lifetime flows to the output
93 |         _renderer: &mut TtyRenderer<'render>,
94 |     ) -> Option<UnderlyingStorage> {
   |                 ----------------- the lifetime gets resolved as `'_`
   |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
94 |     ) -> Option<UnderlyingStorage<'_>> {
   |                                  ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/resize.rs:177:27
    |
177 |     fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
    |                           ^^^^^ this lifetime flows to the output       ----------------- the lifetime gets resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
177 |     fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
    |                                                                                          ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/resize.rs:196:27
    |
196 |     fn underlying_storage(&self, renderer: &mut TtyRenderer<'render>) -> Option<UnderlyingStorage> {
    |                           ^^^^^ this lifetime flows to the output               ----------------- the lifetime gets resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
196 |     fn underlying_storage(&self, renderer: &mut TtyRenderer<'render>) -> Option<UnderlyingStorage<'_>> {
    |                                                                                                  ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/shader_element.rs:512:27
    |
512 |     fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
    |                           ^^^^^ this lifetime flows to the output        ----------------- the lifetime gets resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
512 |     fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
    |                                                                                           ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/shader_element.rs:536:9
    |
536 |         &self,
    |         ^^^^^ this lifetime flows to the output
537 |         _renderer: &mut TtyRenderer<'render>,
538 |     ) -> Option<UnderlyingStorage> {
    |                 ----------------- the lifetime gets resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
538 |     ) -> Option<UnderlyingStorage<'_>> {
    |                                  ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/shaders/mod.rs:300:27
    |
300 | pub fn mat3_uniform(name: &str, mat: Mat3) -> Uniform {
    |                           ^^^^                ------- the lifetime gets resolved as `'_`
    |                           |
    |                           this lifetime flows to the output
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
300 | pub fn mat3_uniform(name: &str, mat: Mat3) -> Uniform<'_> {
    |                                                      ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/shadow.rs:250:27
    |
250 |     fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage> {
    |                           ^^^^^ this lifetime flows to the output       ----------------- the lifetime gets resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
250 |     fn underlying_storage(&self, renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
    |                                                                                          ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/shadow.rs:267:27
    |
267 |     fn underlying_storage(&self, renderer: &mut TtyRenderer<'render>) -> Option<UnderlyingStorage> {
    |                           ^^^^^ this lifetime flows to the output               ----------------- the lifetime gets resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
267 |     fn underlying_storage(&self, renderer: &mut TtyRenderer<'render>) -> Option<UnderlyingStorage<'_>> {
    |                                                                                                  ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/ui/screenshot_ui.rs:105:1
    |
105 | / niri_render_elements! {
106 | |     ScreenshotUiRenderElement => {
107 | |         Screenshot = PrimaryGpuTextureRenderElement,
108 | |         SolidColor = SolidColorRenderElement,
109 | |     }
110 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/ui/screenshot_ui.rs:105:1
    |
105 | / niri_render_elements! {
106 | |     ScreenshotUiRenderElement => {
107 | |         Screenshot = PrimaryGpuTextureRenderElement,
108 | |         SolidColor = SolidColorRenderElement,
109 | |     }
110 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:116:35
    |
116 |               fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                                     ^^^^^ this lifetime flows to the output                                         ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/window/mapped.rs:165:1
    |
165 | / niri_render_elements! {
166 | |     WindowCastRenderElements<R> => {
167 | |         Layout = LayoutElementRenderElement<R>,
...   |
171 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
116 |             fn underlying_storage(&self, renderer: &mut smithay::backend::renderer::gles::GlesRenderer) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                                                                                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/render_helpers/render_elements.rs:142:17
    |
142 |                   &self,
    |                   ^^^^^ this lifetime flows to the output
143 |                   renderer: &mut $crate::backend::tty::TtyRenderer<'render>,
144 |               ) -> Option<smithay::backend::renderer::element::UnderlyingStorage> {
    |                           ------------------------------------------------------ the lifetime gets resolved as `'_`
    |
   ::: src/window/mapped.rs:165:1
    |
165 | / niri_render_elements! {
166 | |     WindowCastRenderElements<R> => {
167 | |         Layout = LayoutElementRenderElement<R>,
...   |
171 | | }
    | |_- in this macro invocation
    |
    = note: this warning originates in the macro `$crate::niri_render_elements` which comes from the expansion of the macro `niri_render_elements` (in Nightly builds, run with -Z macro-backtrace for more info)
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
144 |             ) -> Option<smithay::backend::renderer::element::UnderlyingStorage<'_>> {
    |                                                                               ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/window/mapped.rs:306:27
    |
306 |     pub fn offscreen_data(&self) -> Ref<Option<OffscreenData>> {
    |                           ^^^^^     -------------------------- the lifetime gets resolved as `'_`
    |                           |
    |                           this lifetime flows to the output
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
306 |     pub fn offscreen_data(&self) -> Ref<'_, Option<OffscreenData>> {
    |                                         +++

warning: `niri` (lib) generated 44 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.23s
```