### PR TITLE
fix: retain relative position inside column when switching

### DIFF
--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -1479,10 +1479,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     }
 
     fn activate_column_retain_tile_pos(&mut self, new_active_column_idx: usize) -> bool {
-        let prev_row = self.columns[self.active_column_idx].active_tile_idx;
+        let prev_tile_idx = self.columns[self.active_column_idx].active_tile_idx;
         self.activate_column(new_active_column_idx);
-        let tiles = self.columns[self.active_column_idx].tiles.len();
-        return self.columns[self.active_column_idx].activate_idx(min(prev_row, tiles - 1));
+        let tiles_len = self.columns[self.active_column_idx].tiles.len();
+        return self.columns[self.active_column_idx]
+            .activate_idx(min(prev_tile_idx, tiles_len - 1));
     }
 
     pub fn focus_right(&mut self) -> bool {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -1475,8 +1475,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         if self.active_column_idx == 0 {
             return false;
         }
-        self.activate_column(self.active_column_idx - 1);
-        true
+        return self.activate_column_retain_tile_pos(self.active_column_idx - 1);
+    }
+
+    fn activate_column_retain_tile_pos(&mut self, new_active_column_idx: usize) -> bool {
+        let prev_row = self.columns[self.active_column_idx].active_tile_idx;
+        self.activate_column(new_active_column_idx);
+        let tiles = self.columns[self.active_column_idx].tiles.len();
+        return self.columns[self.active_column_idx].activate_idx(min(prev_row, tiles - 1));
     }
 
     pub fn focus_right(&mut self) -> bool {
@@ -1484,8 +1490,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             return false;
         }
 
-        self.activate_column(self.active_column_idx + 1);
-        true
+        return self.activate_column_retain_tile_pos(self.active_column_idx + 1);
     }
 
     pub fn focus_column_first(&mut self) {


### PR DESCRIPTION
The current behavior when switching to a column is to just focus its first tile. This PR changes this behavior to try to retain the index of the focused window in the previous column. Draft because I realize this is something that should probably be configurable, though I am unsure which section should receive the field.

First PR here so please let me know if there's anything I can change.