### PR TITLE
Draft: PipeWire explicit sync

### DIFF
--- a/src/pw_utils.rs
+++ b/src/pw_utils.rs
@@ -600,6 +600,10 @@ impl PipeWire {
                             assert!((*spa_data).type_ & (1 << DataType::DmaBuf.as_raw()) > 0);
 
                             (*spa_data).type_ = DataType::DmaBuf.as_raw();
+                            // With DMA-BUFs, consumers should ignore the maxsize field, and
+                            // producers are allowed to set it to 0.
+                            //
+                            // https://docs.pipewire.org/page_dma_buf.html
                             (*spa_data).maxsize = 1;
                             (*spa_data).fd = fd.as_raw_fd() as i64;
                             (*spa_data).flags = SPA_DATA_FLAG_READWRITE;
@@ -880,6 +884,13 @@ impl Cast {
             zip(buffer.datas_mut(), zip(dmabuf.strides(), dmabuf.offsets()))
         {
             let chunk = data.chunk_mut();
+            // With DMA-BUFs, consumers should ignore the size field, and producers are allowed to
+            // set it to 0.
+            //
+            // https://docs.pipewire.org/page_dma_buf.html
+            //
+            // However, OBS checks for size != 0 as a workaround for old compositor versions,
+            // so we set it to 1.
             *chunk.size_mut() = 1;
             *chunk.stride_mut() = stride as i32;
             *chunk.offset_mut() = offset;
@@ -931,6 +942,13 @@ impl Cast {
             zip(buffer.datas_mut(), zip(dmabuf.strides(), dmabuf.offsets()))
         {
             let chunk = data.chunk_mut();
+            // With DMA-BUFs, consumers should ignore the size field, and producers are allowed to
+            // set it to 0.
+            //
+            // https://docs.pipewire.org/page_dma_buf.html
+            //
+            // However, OBS checks for size != 0 as a workaround for old compositor versions,
+            // so we set it to 1.
             *chunk.size_mut() = 1;
             *chunk.stride_mut() = stride as i32;
             *chunk.offset_mut() = offset;


### PR DESCRIPTION
Fixes #1432, should fix NVIDIA screencast flickering.

Largely follows the Mutter impl: https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/3876

TODO: clean-up, and also waiting for the buffers to become ready even without explicit sync, which should fix NVIDIA screencast flickering when explicit sync is unavailable.

Unfortunately, I found kinda serious bugs in both OBS and PipeWire which cause them to break on stream size renegotiation (most frequently, resizing a window cast, but also switching dynamic cast target). May need to avoid explicit sync until those are fixed and backported.

- https://github.com/obsproject/obs-studio/pull/12411
- https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/4807