### PR TITLE
feat: flexibility in spawn column location 

### DIFF
--- a/niri-config/src/layout.rs
+++ b/niri-config/src/layout.rs
@@ -54,6 +54,7 @@ impl Default for Layout {
             preset_column_widths: Default::default(),
             default_column_width: Default::default(),
             center_focused_column: Default::default(),
+            new_column_location: Default::default(),
             always_center_single_column: false,
             empty_workspace_above_first: false,
             default_column_display: ColumnDisplay::Normal,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -178,6 +178,15 @@ pub enum CenterFocusedColumn {
     OnOverflow,
 }
 
+#[derive(knuffel::DecodeScalar, Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub enum NewColumnLocation {
+    #[default]
+    RightOfActive,
+    LeftOfActive,
+    FirstOfWorkspace,
+    LastOfWorkspace,
+}
+
 #[derive(knuffel::DecodeScalar, Debug, Default, PartialEq, Eq)]
 pub enum TrackLayout {
     /// The layout change is global.
@@ -541,6 +550,8 @@ pub struct Layout {
     pub preset_window_heights: Vec<PresetSize>,
     #[knuffel(child, unwrap(argument), default)]
     pub center_focused_column: CenterFocusedColumn,
+    #[knuffel(child, unwrap(argument), default)]
+    pub new_column_location: NewColumnLocation,
     #[knuffel(child)]
     pub always_center_single_column: bool,
     #[knuffel(child)]
@@ -566,6 +577,7 @@ impl Default for Layout {
             preset_column_widths: Default::default(),
             default_column_width: Default::default(),
             center_focused_column: Default::default(),
+            new_column_location: Default::default(),
             always_center_single_column: false,
             empty_workspace_above_first: false,
             default_column_display: ColumnDisplay::Normal,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -39,7 +39,7 @@ use std::time::Duration;
 
 use monitor::{InsertHint, InsertPosition, InsertWorkspace, MonitorAddWindowTarget};
 use niri_config::{
-    CenterFocusedColumn, Config, CornerRadius, FloatOrInt, PresetSize, Struts,
+    CenterFocusedColumn, Config, CornerRadius, FloatOrInt, NewColumnLocation, PresetSize, Struts,
     Workspace as WorkspaceConfig, WorkspaceReference,
 };
 use niri_ipc::{ColumnDisplay, PositionChange, SizeChange};
@@ -346,6 +346,7 @@ pub struct Options {
     pub tab_indicator: niri_config::TabIndicator,
     pub insert_hint: niri_config::InsertHint,
     pub center_focused_column: CenterFocusedColumn,
+    pub new_column_location: NewColumnLocation,
     pub always_center_single_column: bool,
     pub empty_workspace_above_first: bool,
     pub default_column_display: ColumnDisplay,
@@ -375,6 +376,7 @@ impl Default for Options {
             tab_indicator: Default::default(),
             insert_hint: Default::default(),
             center_focused_column: Default::default(),
+            new_column_location: Default::default(),
             always_center_single_column: false,
             empty_workspace_above_first: false,
             default_column_display: ColumnDisplay::Normal,
@@ -650,6 +652,7 @@ impl Options {
             tab_indicator: layout.tab_indicator,
             insert_hint: layout.insert_hint,
             center_focused_column: layout.center_focused_column,
+            new_column_location: layout.new_column_location,
             always_center_single_column: layout.always_center_single_column,
             empty_workspace_above_first: layout.empty_workspace_above_first,
             default_column_display: layout.default_column_display,

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -3,7 +3,7 @@ use std::iter::{self, zip};
 use std::rc::Rc;
 use std::time::Duration;
 
-use niri_config::{CenterFocusedColumn, PresetSize, Struts};
+use niri_config::{CenterFocusedColumn, NewColumnLocation, PresetSize, Struts};
 use niri_ipc::{ColumnDisplay, SizeChange};
 use ordered_float::NotNan;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -944,7 +944,12 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             if was_empty {
                 0
             } else {
-                self.active_column_idx + 1
+                match self.options.new_column_location {
+                    NewColumnLocation::RightOfActive => self.active_column_idx + 1,
+                    NewColumnLocation::LeftOfActive => self.active_column_idx,
+                    NewColumnLocation::FirstOfWorkspace => 0,
+                    NewColumnLocation::LastOfWorkspace => self.columns.len(),
+                }
             }
         });
 

--- a/wiki/Configuration:-Layout.md
+++ b/wiki/Configuration:-Layout.md
@@ -8,6 +8,7 @@ Here are the contents of this section at a glance:
 layout {
     gaps 16
     center-focused-column "never"
+    new-column-location "right-of-active"
     always-center-single-column
     empty-workspace-above-first
     default-column-display "tabbed"
@@ -120,6 +121,22 @@ This can be set to:
 ```kdl
 layout {
     center-focused-column "always"
+}
+```
+
+### `new-column-location`
+
+Where to spawn a new column.
+This can be set to:
+
+- `"right-of-active"`: the new column will be placed after the current focused column. This is the default.
+- `"left-of-active"`, the new column will be placed before the current focused column.
+- `"first-of-workspace"`, the new column will be the first column in workspace.
+- `"last-of-workspace"`, the new column will be the last column in workspace.
+
+```kdl
+layout {
+    new-column-location "left-of-active"
 }
 ```
 


### PR DESCRIPTION
Hello,
Thank you for developing the Niri.

Apparently , a new window always spawn after the current active column; This PR intend to allow for the customization to spawn it before the active column. (and two more options)

(I'm new to niri and rust)