### PR TITLE
Add the `LoadConfigFile` action

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1924,6 +1924,8 @@ pub enum Action {
     SetWindowUrgent(u64),
     #[knuffel(skip)]
     UnsetWindowUrgent(u64),
+    #[knuffel(skip)]
+    LoadConfigFile,
 }
 
 impl From<niri_ipc::Action> for Action {
@@ -2199,6 +2201,7 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::ToggleWindowUrgent { id } => Self::ToggleWindowUrgent(id),
             niri_ipc::Action::SetWindowUrgent { id } => Self::SetWindowUrgent(id),
             niri_ipc::Action::UnsetWindowUrgent { id } => Self::UnsetWindowUrgent(id),
+            niri_ipc::Action::LoadConfigFile {} => Self::LoadConfigFile,
         }
     }
 }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -841,6 +841,9 @@ pub enum Action {
         id: u64,
     },
     /// Reload the config file.
+    ///
+    /// Can be useful for scripts changing the config file, to avoid waiting the small duration for
+    /// niri's config file watcher to notice the changes.
     LoadConfigFile {},
 }
 

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -840,6 +840,8 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(long))]
         id: u64,
     },
+    /// Reload the config file.
+    LoadConfigFile {},
 }
 
 /// Change in window or column size.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2113,6 +2113,11 @@ impl State {
                 }
                 self.niri.queue_redraw_all();
             }
+            Action::LoadConfigFile => {
+                if let Some(watcher) = &self.niri.config_file_watcher {
+                    watcher.load_config();
+                }
+            }
         }
     }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -164,6 +164,7 @@ use crate::ui::screen_transition::{self, ScreenTransition};
 use crate::ui::screenshot_ui::{OutputScreenshot, ScreenshotUi, ScreenshotUiRenderElement};
 use crate::utils::scale::{closest_representable_scale, guess_monitor_scale};
 use crate::utils::spawning::{CHILD_DISPLAY, CHILD_ENV};
+use crate::utils::watcher::Watcher;
 use crate::utils::xwayland::satellite::Satellite;
 use crate::utils::{
     center, center_f64, expand_home, get_monotonic_time, ipc_transform_to_smithay, is_mapped,
@@ -189,6 +190,8 @@ pub struct Niri {
     /// reloading the config from disk to determine if the output configuration should be reloaded
     /// (and transient changes dropped).
     pub config_file_output_config: niri_config::Outputs,
+
+    pub config_file_watcher: Option<Watcher>,
 
     pub event_loop: LoopHandle<'static, State>,
     pub scheduler: Scheduler<()>,
@@ -2528,6 +2531,7 @@ impl Niri {
         let mut niri = Self {
             config,
             config_file_output_config,
+            config_file_watcher: None,
 
             event_loop,
             scheduler,


### PR DESCRIPTION
The new action forces config file reloading, allowing to reduce lag between file updates and receiving visual feedback from the compositor.