### PR TITLE
Asynchronously wait for frame completion in PipeWire

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2331,8 +2331,6 @@ pub struct DebugConfig {
     #[knuffel(child)]
     pub wait_for_frame_completion_before_queueing: bool,
     #[knuffel(child)]
-    pub wait_for_frame_completion_in_pipewire: bool,
-    #[knuffel(child)]
     pub enable_overlay_planes: bool,
     #[knuffel(child)]
     pub disable_cursor_plane: bool,
@@ -5327,7 +5325,6 @@ mod tests {
                 preview_render: None,
                 dbus_interfaces_in_non_session_instances: false,
                 wait_for_frame_completion_before_queueing: false,
-                wait_for_frame_completion_in_pipewire: false,
                 enable_overlay_planes: false,
                 disable_cursor_plane: false,
                 disable_direct_scanout: false,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -5002,7 +5002,7 @@ impl Niri {
 
         let mut casts = mem::take(&mut self.casts);
         for cast in &mut casts {
-            if !cast.is_active.get() {
+            if !cast.is_active() {
                 continue;
             }
 
@@ -5058,7 +5058,7 @@ impl Niri {
 
         let mut casts = mem::take(&mut self.casts);
         for cast in &mut casts {
-            if !cast.is_active.get() {
+            if !cast.is_active() {
                 continue;
             }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2029,7 +2029,8 @@ impl State {
                 let pw = if let Some(pw) = &self.niri.pipewire {
                     pw
                 } else {
-                    match PipeWire::new(&self.niri.event_loop, self.niri.pw_to_niri.clone()) {
+                    match PipeWire::new(self.niri.event_loop.clone(), self.niri.pw_to_niri.clone())
+                    {
                         Ok(pipewire) => self.niri.pipewire.insert(pipewire),
                         Err(err) => {
                             warn!(
@@ -5019,7 +5020,7 @@ impl Niri {
                 }
             }
 
-            if cast.check_time_and_schedule(&self.event_loop, output, target_presentation_time) {
+            if cast.check_time_and_schedule(output, target_presentation_time) {
                 continue;
             }
 
@@ -5085,7 +5086,7 @@ impl Niri {
                 }
             }
 
-            if cast.check_time_and_schedule(&self.event_loop, output, target_presentation_time) {
+            if cast.check_time_and_schedule(output, target_presentation_time) {
                 continue;
             }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1881,12 +1881,8 @@ impl State {
 
         match &cast.target {
             CastTarget::Nothing => {
-                let config = self.niri.config.borrow();
-                let wait_for_sync = config.debug.wait_for_frame_completion_in_pipewire;
-                drop(config);
-
                 self.backend.with_primary_renderer(|renderer| {
-                    if cast.dequeue_buffer_and_clear(renderer, wait_for_sync) {
+                    if cast.dequeue_buffer_and_clear(renderer) {
                         cast.last_frame_time = get_monotonic_time();
                     }
                 });
@@ -1926,10 +1922,6 @@ impl State {
                     }
                 }
 
-                let config = self.niri.config.borrow();
-                let wait_for_sync = config.debug.wait_for_frame_completion_in_pipewire;
-                drop(config);
-
                 self.backend.with_primary_renderer(|renderer| {
                     // FIXME: pointer.
                     let elements = mapped
@@ -1937,13 +1929,7 @@ impl State {
                         .rev()
                         .collect::<Vec<_>>();
 
-                    if cast.dequeue_buffer_and_render(
-                        renderer,
-                        &elements,
-                        bbox.size,
-                        scale,
-                        wait_for_sync,
-                    ) {
+                    if cast.dequeue_buffer_and_render(renderer, &elements, bbox.size, scale) {
                         cast.last_frame_time = get_monotonic_time();
                     }
                 });
@@ -4994,10 +4980,6 @@ impl Niri {
 
         let scale = Scale::from(output.current_scale().fractional_scale());
 
-        let config = self.config.borrow();
-        let wait_for_sync = config.debug.wait_for_frame_completion_in_pipewire;
-        drop(config);
-
         let mut elements = None;
         let mut casts_to_stop = vec![];
 
@@ -5029,7 +5011,7 @@ impl Niri {
                 self.render(renderer, output, true, RenderTarget::Screencast)
             });
 
-            if cast.dequeue_buffer_and_render(renderer, elements, size, scale, wait_for_sync) {
+            if cast.dequeue_buffer_and_render(renderer, elements, size, scale) {
                 cast.last_frame_time = target_presentation_time;
             }
         }
@@ -5050,10 +5032,6 @@ impl Niri {
         let _span = tracy_client::span!("Niri::render_windows_for_screen_cast");
 
         let scale = Scale::from(output.current_scale().fractional_scale());
-
-        let config = self.config.borrow();
-        let wait_for_sync = config.debug.wait_for_frame_completion_in_pipewire;
-        drop(config);
 
         let mut casts_to_stop = vec![];
 
@@ -5093,8 +5071,7 @@ impl Niri {
             // FIXME: pointer.
             let elements: Vec<_> = mapped.render_for_screen_cast(renderer, scale).collect();
 
-            if cast.dequeue_buffer_and_render(renderer, &elements, bbox.size, scale, wait_for_sync)
-            {
+            if cast.dequeue_buffer_and_render(renderer, &elements, bbox.size, scale) {
                 cast.last_frame_time = target_presentation_time;
             }
         }

--- a/src/pw_utils.rs
+++ b/src/pw_utils.rs
@@ -85,7 +85,7 @@ pub struct Cast {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
-pub enum CastState {
+enum CastState {
     ResizePending {
         pending_size: Size<u32, Physical>,
     },

--- a/src/pw_utils.rs
+++ b/src/pw_utils.rs
@@ -600,6 +600,10 @@ impl PipeWire {
                             assert!((*spa_data).type_ & (1 << DataType::DmaBuf.as_raw()) > 0);
 
                             (*spa_data).type_ = DataType::DmaBuf.as_raw();
+                            // With DMA-BUFs, consumers should ignore the maxsize field, and
+                            // producers are allowed to set it to 0.
+                            //
+                            // https://docs.pipewire.org/page_dma_buf.html
                             (*spa_data).maxsize = 1;
                             (*spa_data).fd = fd.as_raw_fd() as i64;
                             (*spa_data).flags = SPA_DATA_FLAG_READWRITE;
@@ -880,6 +884,13 @@ impl Cast {
             zip(buffer.datas_mut(), zip(dmabuf.strides(), dmabuf.offsets()))
         {
             let chunk = data.chunk_mut();
+            // With DMA-BUFs, consumers should ignore the size field, and producers are allowed to
+            // set it to 0.
+            //
+            // https://docs.pipewire.org/page_dma_buf.html
+            //
+            // However, OBS checks for size != 0 as a workaround for old compositor versions,
+            // so we set it to 1.
             *chunk.size_mut() = 1;
             *chunk.stride_mut() = stride as i32;
             *chunk.offset_mut() = offset;
@@ -931,6 +942,13 @@ impl Cast {
             zip(buffer.datas_mut(), zip(dmabuf.strides(), dmabuf.offsets()))
         {
             let chunk = data.chunk_mut();
+            // With DMA-BUFs, consumers should ignore the size field, and producers are allowed to
+            // set it to 0.
+            //
+            // https://docs.pipewire.org/page_dma_buf.html
+            //
+            // However, OBS checks for size != 0 as a workaround for old compositor versions,
+            // so we set it to 1.
             *chunk.size_mut() = 1;
             *chunk.stride_mut() = stride as i32;
             *chunk.offset_mut() = offset;

--- a/wiki/Configuration:-Debug-Options.md
+++ b/wiki/Configuration:-Debug-Options.md
@@ -21,7 +21,6 @@ debug {
     force-pipewire-invalid-modifier
     dbus-interfaces-in-non-session-instances
     wait-for-frame-completion-before-queueing
-    wait-for-frame-completion-in-pipewire
     emulate-zero-presentation-time
     disable-resize-throttling
     disable-transactions
@@ -152,22 +151,6 @@ Useful for diagnosing certain synchronization and performance problems.
 ```kdl
 debug {
     wait-for-frame-completion-before-queueing
-}
-```
-
-### `wait-for-frame-completion-in-pipewire`
-
-<sup>Since: 25.05</sup>
-
-Wait until every screencast frame is done rendering before handing it over to PipeWire.
-
-Sometimes helps on NVIDIA to prevent glitched frames when screencasting.
-
-This debug flag will eventually be removed once we handle this properly (via explicit sync in PipeWire).
-
-```kdl
-debug {
-    wait-for-frame-completion-in-pipewire
 }
 ```
 

--- a/wiki/Nvidia.md
+++ b/wiki/Nvidia.md
@@ -42,9 +42,11 @@ The fix shipped in the driver at the time of writing uses a value of 0, while th
 
 ### Screencast flickering fix
 
+<sup>Until: next release</sup>
+
 If you have screencast glitches or flickering on NVIDIA, set this in the niri config:
 
-```kdl
+```kdl,must-fail
 debug {
     wait-for-frame-completion-in-pipewire
 }


### PR DESCRIPTION
Along with a bunch of refactors in preparation for PW explicit sync.

In theory, fixes #1432 (the issue therein).

Needs testing from NVIDIA users who experience the screencast flickering issue.