### PR TITLE
Workspace switch overview shadow

### DIFF
--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -1570,7 +1570,11 @@ impl<W: LayoutElement> Monitor<W> {
 
         let scale = self.scale.fractional_scale();
         let zoom = self.overview_zoom();
-        let overview_clamped_progress = self.overview_progress.as_ref().map(|p| p.clamped_value());
+        let overview_clamped_progress = self
+            .workspace_switch
+            .is_some()
+            .then_some(1.0)
+            .or(self.overview_progress.as_ref().map(|p| p.clamped_value()));
 
         self.workspaces_with_render_geo()
             .flat_map(move |(ws, geo)| {

--- a/src/layout/shadow.rs
+++ b/src/layout/shadow.rs
@@ -8,6 +8,7 @@ use crate::render_helpers::shadow::ShadowRenderElement;
 
 #[derive(Debug)]
 pub struct Shadow {
+    shadow_geo: Rectangle<f64, Logical>,
     shader_rects: Vec<Rectangle<f64, Logical>>,
     shaders: Vec<ShadowRenderElement>,
     config: niri_config::Shadow,
@@ -16,6 +17,7 @@ pub struct Shadow {
 impl Shadow {
     pub fn new(config: niri_config::Shadow) -> Self {
         Self {
+            shadow_geo: Rectangle::zero(),
             shader_rects: Vec::new(),
             shaders: Vec::new(),
             config,
@@ -30,6 +32,11 @@ impl Shadow {
         for elem in &mut self.shaders {
             elem.damage_all();
         }
+    }
+
+    /// The most recently calulcated shadow geometry.
+    pub fn shadow_geometry(&self) -> Rectangle<f64, Logical> {
+        self.shadow_geo
     }
 
     pub fn update_render_elements(
@@ -83,6 +90,7 @@ impl Shadow {
         };
 
         let shader_geo = Rectangle::new(Point::from((-width, -width)), shader_size);
+        self.shadow_geo = shader_geo;
 
         // This is actually offset relative to shader_geo, this is handled below.
         let window_geo = Rectangle::new(Point::from((0., 0.)), win_size);

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1471,6 +1471,10 @@ impl<W: LayoutElement> Workspace<W> {
         (floating, scrolling)
     }
 
+    pub fn shadow_geometry(&self) -> Rectangle<f64, Logical> {
+        self.shadow.shadow_geometry()
+    }
+
     pub fn render_shadow<R: NiriRenderer>(
         &self,
         renderer: &mut R,


### PR DESCRIPTION
This enables rendering of workspace overview shadows while in a workspace switch. Best visible when `mod + middle mouse` dragging, or three finger drag gesture on a trackpad.

I also extended the rectangle that's checked when checking if a workspace's shadow should be drawn. Without this the shadow pops into view. This could be split into a separate PR if wanted though.