### PR TITLE
Add resize anim tests & fix cancelling resize anim causing jumps

### DIFF
--- a/niri-visual-tests/src/test_window.rs
+++ b/niri-visual-tests/src/test_window.rs
@@ -255,10 +255,6 @@ impl LayoutElement for TestWindow {
         &EMPTY
     }
 
-    fn animation_snapshot(&self) -> Option<&LayoutElementRenderSnapshot> {
-        None
-    }
-
     fn take_animation_snapshot(&mut self) -> Option<LayoutElementRenderSnapshot> {
         None
     }

--- a/src/backend/headless.rs
+++ b/src/backend/headless.rs
@@ -1,13 +1,16 @@
 //! Headless backend for tests.
 //!
 //! This can eventually grow into a more complete backend if needed, but for now it's missing some
-//! crucial parts like rendering.
+//! crucial parts like dmabufs.
 
 use std::mem;
 use std::sync::{Arc, Mutex};
 
+use anyhow::Context as _;
 use niri_config::OutputName;
 use smithay::backend::allocator::dmabuf::Dmabuf;
+use smithay::backend::egl::native::EGLSurfacelessDisplay;
+use smithay::backend::egl::{EGLContext, EGLDisplay};
 use smithay::backend::renderer::element::RenderElementStates;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::output::{Mode, Output, PhysicalProperties, Subpixel};
@@ -17,20 +20,43 @@ use smithay::wayland::presentation::Refresh;
 
 use super::{IpcOutputMap, OutputId, RenderResult};
 use crate::niri::{Niri, RedrawState};
+use crate::render_helpers::{resources, shaders};
 use crate::utils::{get_monotonic_time, logical_output};
 
 pub struct Headless {
+    renderer: Option<GlesRenderer>,
     ipc_outputs: Arc<Mutex<IpcOutputMap>>,
 }
 
 impl Headless {
     pub fn new() -> Self {
         Self {
+            renderer: None,
             ipc_outputs: Default::default(),
         }
     }
 
     pub fn init(&mut self, _niri: &mut Niri) {}
+
+    pub fn add_renderer(&mut self) -> anyhow::Result<()> {
+        if self.renderer.is_some() {
+            error!("add_renderer: renderer must not already exist");
+            return Ok(());
+        }
+
+        let mut renderer = unsafe {
+            let display =
+                EGLDisplay::new(EGLSurfacelessDisplay).context("error creating EGL display")?;
+            let context = EGLContext::new(&display).context("error creating EGL context")?;
+            GlesRenderer::new(context).context("error creating renderer")?
+        };
+
+        resources::init(&mut renderer);
+        shaders::init(&mut renderer);
+
+        self.renderer = Some(renderer);
+        Ok(())
+    }
 
     pub fn add_output(&mut self, niri: &mut Niri, n: u8, size: (u16, u16)) {
         let connector = format!("headless-{n}");
@@ -94,9 +120,9 @@ impl Headless {
 
     pub fn with_primary_renderer<T>(
         &mut self,
-        _f: impl FnOnce(&mut GlesRenderer) -> T,
+        f: impl FnOnce(&mut GlesRenderer) -> T,
     ) -> Option<T> {
-        None
+        self.renderer.as_mut().map(f)
     }
 
     pub fn render(&mut self, niri: &mut Niri, output: &Output) -> RenderResult {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -270,7 +270,6 @@ pub trait LayoutElement {
     /// Runs periodic clean-up tasks.
     fn refresh(&self);
 
-    fn animation_snapshot(&self) -> Option<&LayoutElementRenderSnapshot>;
     fn take_animation_snapshot(&mut self) -> Option<LayoutElementRenderSnapshot>;
 
     fn set_interactive_resize(&mut self, data: Option<InteractiveResizeData>);

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4041,14 +4041,12 @@ impl<W: LayoutElement> Column<W> {
             .find(|(_, tile)| tile.window().id() == window)
             .unwrap();
 
-        let height = f64::from(tile.window().size().h);
-        let offset = tile
-            .window()
-            .animation_snapshot()
-            .map_or(0., |from| from.size.h - height);
+        let prev_height = self.data[tile_idx].size.h;
 
         tile.update_window();
         self.data[tile_idx].update(tile);
+
+        let offset = prev_height - self.data[tile_idx].size.h;
 
         let is_tabbed = self.display_mode == ColumnDisplay::Tabbed;
 

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -244,10 +244,6 @@ impl LayoutElement for TestWindow {
         &EMPTY
     }
 
-    fn animation_snapshot(&self) -> Option<&LayoutElementRenderSnapshot> {
-        None
-    }
-
     fn take_animation_snapshot(&mut self) -> Option<LayoutElementRenderSnapshot> {
         None
     }

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -11,6 +11,8 @@ use smithay::utils::Rectangle;
 
 use super::*;
 
+mod animations;
+
 impl<W: LayoutElement> Default for Layout<W> {
     fn default() -> Self {
         Self::with_options(Clock::with_time(Duration::ZERO), Default::default())

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -614,6 +614,7 @@ enum Op {
         #[proptest(strategy = "arbitrary_msec_delta()")]
         msec_delta: i32,
     },
+    CompleteAnimations,
     MoveWorkspaceToOutput(#[proptest(strategy = "1..=5usize")] usize),
     ViewOffsetGestureBegin {
         #[proptest(strategy = "1..=5usize")]
@@ -1400,6 +1401,11 @@ impl Op {
                 }
                 layout.clock.set_unadjusted(now);
                 layout.advance_animations();
+            }
+            Op::CompleteAnimations => {
+                layout.clock.set_complete_instantly(true);
+                layout.advance_animations();
+                layout.clock.set_complete_instantly(false);
             }
             Op::MoveWorkspaceToOutput(id) => {
                 let name = format!("output{id}");

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -1479,24 +1479,24 @@ impl Op {
 }
 
 #[track_caller]
-fn check_ops(ops: &[Op]) -> Layout<TestWindow> {
-    let mut layout = Layout::default();
+fn check_ops_on_layout(layout: &mut Layout<TestWindow>, ops: &[Op]) {
     for op in ops {
-        op.apply(&mut layout);
+        op.apply(layout);
         layout.verify_invariants();
     }
+}
+
+#[track_caller]
+fn check_ops(ops: &[Op]) -> Layout<TestWindow> {
+    let mut layout = Layout::default();
+    check_ops_on_layout(&mut layout, ops);
     layout
 }
 
 #[track_caller]
 fn check_ops_with_options(options: Options, ops: &[Op]) -> Layout<TestWindow> {
     let mut layout = Layout::with_options(Clock::with_time(Duration::ZERO), options);
-
-    for op in ops {
-        op.apply(&mut layout);
-        layout.verify_invariants();
-    }
-
+    check_ops_on_layout(&mut layout, ops);
     layout
 }
 

--- a/src/layout/tests/animations.rs
+++ b/src/layout/tests/animations.rs
@@ -989,16 +989,14 @@ fn width_resize_and_cancel() {
     check_ops_on_layout(&mut layout, &ops);
 
     // Since the resize animation is cancelled, the width goes to the new value immediately. The X
-    // position doesn't jump, instead the animation is offset to preserve the current position.
-    //
-    // FIXME: this is not currently the case!
+    // position doesn't jump, instead the animation is restarted to preserve the current position.
     assert_snapshot!(format_tiles(&layout), @r"
     100 × 100 at x:  0 y:  0
-    200 × 200 at x:  5 y:  0
+    200 × 200 at x:105 y:  0
     ");
 
     // Advance to the end of the move animation.
-    Op::AdvanceAnimations { msec_delta: 950 }.apply(&mut layout);
+    Op::AdvanceAnimations { msec_delta: 1000 }.apply(&mut layout);
 
     // Final state.
     assert_snapshot!(format_tiles(&layout), @r"
@@ -1081,16 +1079,14 @@ fn width_resize_and_cancel_of_column_to_the_left() {
     check_ops_on_layout(&mut layout, &ops);
 
     // Since the resize animation is cancelled, the width goes to the new value immediately. The X
-    // position doesn't jump, instead the animation is offset to preserve the current position.
-    //
-    // FIXME: this is not currently the case!
+    // position doesn't jump, instead the animation is restarted to preserve the current position.
     assert_snapshot!(format_tiles(&layout), @r"
-    100 × 100 at x: 95 y:  0
+    100 × 100 at x: -5 y:  0
     200 × 200 at x:100 y:  0
     ");
 
     // Advance to the end of the move animation.
-    Op::AdvanceAnimations { msec_delta: 950 }.apply(&mut layout);
+    Op::AdvanceAnimations { msec_delta: 1000 }.apply(&mut layout);
 
     // Final state.
     assert_snapshot!(format_tiles(&layout), @r"

--- a/src/layout/tests/animations.rs
+++ b/src/layout/tests/animations.rs
@@ -1,0 +1,909 @@
+use std::fmt::Write as _;
+
+use insta::assert_snapshot;
+use niri_config::{AnimationCurve, AnimationKind, EasingParams};
+
+use super::*;
+
+fn format_tiles(layout: &Layout<TestWindow>) -> String {
+    let mut buf = String::new();
+    let ws = layout.active_workspace().unwrap();
+    let mut tiles: Vec<_> = ws.tiles_with_render_positions().collect();
+
+    // We sort by id since that gives us a consistent order (from first opened to last), but we
+    // don't print the id since it's nondeterministic (the id is a global counter across all
+    // running tests in the same binary).
+    tiles.sort_by_key(|(tile, _, _)| tile.window().id());
+    for (tile, pos, _visible) in tiles {
+        let Size { w, h, .. } = tile.animated_tile_size();
+        let Point { x, y, .. } = pos;
+        writeln!(&mut buf, "{w:>3.0} × {h:>3.0} at x:{x:>3.0} y:{y:>3.0}").unwrap();
+    }
+    buf
+}
+
+fn make_options() -> Options {
+    const LINEAR: AnimationKind = AnimationKind::Easing(EasingParams {
+        duration_ms: 1000,
+        curve: AnimationCurve::Linear,
+    });
+
+    let mut options = Options {
+        gaps: 0.0,
+        ..Options::default()
+    };
+    options.animations.window_resize.anim.kind = LINEAR;
+    options.animations.window_movement.0.kind = LINEAR;
+
+    options
+}
+
+fn set_up_two_in_column() -> Layout<TestWindow> {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+        Op::FocusColumnLeft,
+        Op::ConsumeWindowIntoColumn,
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        Op::SetForcedSize {
+            id: 2,
+            size: Some(Size::new(200, 200)),
+        },
+        Op::Communicate(1),
+        Op::Communicate(2),
+        Op::CompleteAnimations,
+    ];
+
+    check_ops_with_options(make_options(), &ops)
+}
+
+#[test]
+fn height_resize_animates_next_y() {
+    let mut layout = set_up_two_in_column();
+
+    let ops = [
+        // Issue a resize.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::AdjustFixed(-50),
+        },
+        // The top window shrinks in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 50)),
+        },
+        Op::Communicate(1),
+        Op::Communicate(2),
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // No time had passed yet, so we're at the initial state.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:100
+    ");
+
+    // Advance the time halfway.
+    Op::AdvanceAnimations { msec_delta: 500 }.apply(&mut layout);
+
+    // Top window is half-resized at 75 px tall, bottom window is at y=75 matching it.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 ×  75 at x:  0 y:  0
+    200 × 200 at x:  0 y: 75
+    ");
+
+    // Advance the time to completion.
+    Op::AdvanceAnimations { msec_delta: 500 }.apply(&mut layout);
+
+    // Final state at 50 px.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 ×  50 at x:  0 y:  0
+    200 × 200 at x:  0 y: 50
+    ");
+}
+
+#[test]
+fn clientside_height_change_doesnt_animate() {
+    let mut layout = set_up_two_in_column();
+
+    // The initial state.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:100
+    ");
+
+    let ops = [
+        // The top window shrinks by itself, without a niri-issued resize.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 50)),
+        },
+        // This does not start any animations.
+        Op::Communicate(1),
+        Op::Communicate(2),
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // No time had passed yet, but we are at the final state right away.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 ×  50 at x:  0 y:  0
+    200 × 200 at x:  0 y: 50
+    ");
+}
+
+#[test]
+fn height_resize_and_back() {
+    let mut layout = set_up_two_in_column();
+
+    // The initial state.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:100
+    ");
+
+    let ops = [
+        // Issue a resize.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(200),
+        },
+        // The top window grows in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 200)),
+        },
+        // This starts the resize animation.
+        Op::Communicate(1),
+        Op::Communicate(2),
+        // Advance the time halfway.
+        Op::AdvanceAnimations { msec_delta: 500 },
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // Top window is half-resized at 150 px tall, bottom window is at y=150 matching it.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 150 at x:  0 y:  0
+    200 × 200 at x:  0 y:150
+    ");
+
+    let ops = [
+        // Issue a resize back.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(100),
+        },
+        // The top window shrinks in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        // This starts a new resize animation.
+        Op::Communicate(1),
+        Op::Communicate(2),
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // No time had passed yet, and we expect no animation jumps, so this state matches the last.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 150 at x:  0 y:  0
+    200 × 200 at x:  0 y:150
+    ");
+
+    // Advance the time halfway.
+    Op::AdvanceAnimations { msec_delta: 500 }.apply(&mut layout);
+
+    // Halfway through at 125px.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 125 at x:  0 y:  0
+    200 × 200 at x:  0 y:125
+    ");
+
+    // Advance the time to completion.
+    Op::AdvanceAnimations { msec_delta: 500 }.apply(&mut layout);
+
+    // Final state back at 100px.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:100
+    ");
+}
+
+#[test]
+fn height_resize_and_cancel() {
+    let mut layout = set_up_two_in_column();
+
+    // The initial state.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:100
+    ");
+
+    let ops = [
+        // Issue a resize.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(200),
+        },
+        // The top window grows in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 200)),
+        },
+        // This starts the resize animation.
+        Op::Communicate(1),
+        Op::Communicate(2),
+        // Advance the time slightly.
+        Op::AdvanceAnimations { msec_delta: 50 },
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // Top window is half-resized at 105 px tall, bottom window is at y=105 matching it.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 105 at x:  0 y:  0
+    200 × 200 at x:  0 y:105
+    ");
+
+    let ops = [
+        // Issue a resize back.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(100),
+        },
+        // The top window shrinks in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        // This cancels the resize animation since the change of 5 px is less than the resize
+        // animation threshold.
+        Op::Communicate(1),
+        Op::Communicate(2),
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // Since the resize animation is cancelled, the height goes to the new value immediately, and
+    // the Y position should also go to 100 immediately, cancelling the movement.
+    //
+    // FIXME: right now, the Y position jumps to 5 and will continue animating to 100 from there
+    // because cancelling the resize anim doesn't cancel the induced Y movement.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:  5
+    ");
+}
+
+#[test]
+fn height_resize_and_back_during_another_y_anim() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+        Op::FocusColumnLeft,
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        Op::SetForcedSize {
+            id: 2,
+            size: Some(Size::new(200, 200)),
+        },
+        Op::Communicate(1),
+        Op::Communicate(2),
+        Op::CompleteAnimations,
+    ];
+    let mut layout = check_ops_with_options(make_options(), &ops);
+
+    // The initial state.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:100 y:  0
+    ");
+
+    // Consume second window into column, starting the X/Y move anim down.
+    Op::ConsumeWindowIntoColumn.apply(&mut layout);
+
+    // No time had passed, so no change in coordinates yet.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:100 y:  0
+    ");
+
+    // Advance the time halfway.
+    Op::AdvanceAnimations { msec_delta: 500 }.apply(&mut layout);
+
+    // Second window halfway to the bottom.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x: 50 y: 50
+    ");
+
+    let ops = [
+        // Issue a resize.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(200),
+        },
+        // The top window grows in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 200)),
+        },
+        // This starts the resize animation.
+        Op::Communicate(1),
+        Op::Communicate(2),
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // No time had passed, so no change in state yet.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x: 50 y: 50
+    ");
+
+    // Advance the time a bit.
+    Op::AdvanceAnimations { msec_delta: 200 }.apply(&mut layout);
+
+    // X changed by 20, but y changed by 30 since the Y movement from the resize compounds with the
+    // Y movement from consume-into-column.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 120 at x:  0 y:  0
+    200 × 200 at x: 30 y: 80
+    ");
+
+    let ops = [
+        // Issue a resize back.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(100),
+        },
+        // The top window shrinks in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        // This starts the resize animation.
+        Op::Communicate(1),
+        Op::Communicate(2),
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // No time had passed, so no change in state yet.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 120 at x:  0 y:  0
+    200 × 200 at x: 30 y: 80
+    ");
+
+    // Advance the time a bit. Both resize and consume movement are still ongoing.
+    Op::AdvanceAnimations { msec_delta: 200 }.apply(&mut layout);
+
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 116 at x:  0 y:  0
+    200 × 200 at x: 10 y: 84
+    ");
+
+    // Advance the time to complete the consume movement.
+    Op::AdvanceAnimations { msec_delta: 100 }.apply(&mut layout);
+
+    // The Y position is still lower than the height since the window started the resize-induced Y
+    // movement high up.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 114 at x:  0 y:  0
+    200 × 200 at x:  0 y: 86
+    ");
+
+    // Advance the time to complete the resize.
+    Op::AdvanceAnimations { msec_delta: 700 }.apply(&mut layout);
+
+    // Final state.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:100
+    ");
+}
+
+#[test]
+fn height_resize_and_cancel_during_another_y_anim() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+        Op::FocusColumnLeft,
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        Op::SetForcedSize {
+            id: 2,
+            size: Some(Size::new(200, 200)),
+        },
+        Op::Communicate(1),
+        Op::Communicate(2),
+        Op::CompleteAnimations,
+    ];
+    let mut layout = check_ops_with_options(make_options(), &ops);
+
+    // The initial state.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:100 y:  0
+    ");
+
+    // Consume second window into column, starting the X/Y move anim down.
+    Op::ConsumeWindowIntoColumn.apply(&mut layout);
+
+    // No time had passed, so no change in coordinates yet.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:100 y:  0
+    ");
+
+    // Advance the time halfway.
+    Op::AdvanceAnimations { msec_delta: 500 }.apply(&mut layout);
+
+    // Second window halfway to the bottom.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x: 50 y: 50
+    ");
+
+    let ops = [
+        // Issue a resize.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(200),
+        },
+        // The top window grows in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 200)),
+        },
+        // This starts the resize animation.
+        Op::Communicate(1),
+        Op::Communicate(2),
+        // Advance the time slightly.
+        Op::AdvanceAnimations { msec_delta: 50 },
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // X changed by 5, but y changed by 8 since the Y movement from the resize compounds with the Y
+    // movement from consume-into-column.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 105 at x:  0 y:  0
+    200 × 200 at x: 45 y: 58
+    ");
+
+    let ops = [
+        // Issue a resize back.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(100),
+        },
+        // The top window shrinks in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        // This cancels the resize animation since the change of 5 px is less than the resize
+        // animation threshold.
+        Op::Communicate(1),
+        Op::Communicate(2),
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // Since the resize anim was cancelled, second window's Y should jump a little to go back to
+    // its original trajectory.
+    //
+    // FIXME: right now, the Y position jumps and will continue to animate from there because
+    // cancelling the resize anim doesn't cancel the induced Y movement.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x: 45 y:-43
+    ");
+
+    // Advance the time to complete the consume movement.
+    Op::AdvanceAnimations { msec_delta: 450 }.apply(&mut layout);
+
+    // Final state. Y should be at 100 since the resize-induced Y anim was cancelled.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y: 25
+    ");
+}
+
+#[test]
+fn height_resize_before_another_y_anim_then_back() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+        Op::FocusColumnLeft,
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        Op::SetForcedSize {
+            id: 2,
+            size: Some(Size::new(200, 200)),
+        },
+        Op::Communicate(1),
+        Op::Communicate(2),
+        Op::CompleteAnimations,
+        // Issue a resize.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(200),
+        },
+        // The top window grows in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 200)),
+        },
+        // This starts the resize animation.
+        Op::Communicate(1),
+        Op::Communicate(2),
+        // Advance the time a bit.
+        Op::AdvanceAnimations { msec_delta: 200 },
+    ];
+    let mut layout = check_ops_with_options(make_options(), &ops);
+
+    // The resize is in progress.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 120 at x:  0 y:  0
+    200 × 200 at x:100 y:  0
+    ");
+
+    // Consume second window into column, starting the X/Y move anim down.
+    Op::ConsumeWindowIntoColumn.apply(&mut layout);
+
+    // No time had passed, so no change in coordinates yet.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 120 at x:  0 y:  0
+    200 × 200 at x:100 y:  0
+    ");
+
+    // Advance the time halfway.
+    Op::AdvanceAnimations { msec_delta: 600 }.apply(&mut layout);
+
+    // Second window halfway to the bottom. Since consume happened after the start of the first
+    // window's resize, the second window's Y is unaffected by it and is animating towards the
+    // final position right away.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 180 at x:  0 y:  0
+    200 × 200 at x: 40 y:120
+    ");
+
+    let ops = [
+        // Issue a resize back.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(100),
+        },
+        // The top window shrinks in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        // This starts the resize animation.
+        Op::Communicate(1),
+        Op::Communicate(2),
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // No time had passed, so no change in state yet.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 180 at x:  0 y:  0
+    200 × 200 at x: 40 y:120
+    ");
+
+    // Advance the time a bit. Both resize and consume movement are still ongoing.
+    Op::AdvanceAnimations { msec_delta: 200 }.apply(&mut layout);
+
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 164 at x:  0 y:  0
+    200 × 200 at x: 20 y:116
+    ");
+
+    // Advance the time to complete the consume movement.
+    Op::AdvanceAnimations { msec_delta: 200 }.apply(&mut layout);
+
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 148 at x:  0 y:  0
+    200 × 200 at x:  0 y:112
+    ");
+
+    // Advance the time to complete the resize.
+    Op::AdvanceAnimations { msec_delta: 600 }.apply(&mut layout);
+
+    // Final state.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:100
+    ");
+}
+
+#[test]
+fn height_resize_before_another_y_anim_then_cancel() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+        Op::FocusColumnLeft,
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        Op::SetForcedSize {
+            id: 2,
+            size: Some(Size::new(200, 200)),
+        },
+        Op::Communicate(1),
+        Op::Communicate(2),
+        Op::CompleteAnimations,
+        // Issue a resize.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(200),
+        },
+        // The top window grows in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 200)),
+        },
+        // This starts the resize animation.
+        Op::Communicate(1),
+        Op::Communicate(2),
+        // Advance the time a bit.
+        Op::AdvanceAnimations { msec_delta: 20 },
+    ];
+    let mut layout = check_ops_with_options(make_options(), &ops);
+
+    // The resize is in progress.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 102 at x:  0 y:  0
+    200 × 200 at x:100 y:  0
+    ");
+
+    // Consume second window into column, starting the X/Y move anim down.
+    Op::ConsumeWindowIntoColumn.apply(&mut layout);
+
+    // No time had passed, so no change in coordinates yet.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 102 at x:  0 y:  0
+    200 × 200 at x:100 y:  0
+    ");
+
+    // Advance the time a little.
+    Op::AdvanceAnimations { msec_delta: 20 }.apply(&mut layout);
+
+    // Second window on its way to the bottom.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 104 at x:  0 y:  0
+    200 × 200 at x: 98 y:  4
+    ");
+
+    let ops = [
+        // Issue a resize back.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(100),
+        },
+        // The top window shrinks in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        // This cancels the resize animation since the change of 4 px is less than the resize
+        // animation threshold.
+        Op::Communicate(1),
+        Op::Communicate(2),
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // This should cause the second window's trajectory to readjust to the new final position at
+    // 100px. Ideally without big jumps because even though the first window's actual size changed
+    // from 200 px to 100 px, the cancelled resize only shifted it from 104 px to 100 px.
+    //
+    // FIXME: currently causes a 100 px jump due to the change in the actual window size.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x: 98 y:-96
+    ");
+
+    // Advance the time to complete the consume movement.
+    Op::AdvanceAnimations { msec_delta: 980 }.apply(&mut layout);
+
+    // Final state.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:100
+    ");
+}
+
+#[test]
+fn clientside_height_change_during_another_y_anim() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+        Op::FocusColumnLeft,
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        Op::SetForcedSize {
+            id: 2,
+            size: Some(Size::new(200, 200)),
+        },
+        Op::Communicate(1),
+        Op::Communicate(2),
+        Op::CompleteAnimations,
+        Op::ConsumeWindowIntoColumn,
+        // Clear the animate next configure flag.
+        Op::Communicate(1),
+        Op::Communicate(2),
+        // Advance the time a bit.
+        Op::AdvanceAnimations { msec_delta: 200 },
+    ];
+    let mut layout = check_ops_with_options(make_options(), &ops);
+
+    // Second window on its way to the bottom.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x: 80 y: 20
+    ");
+
+    let ops = [
+        // The top window suddenly grows.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 200)),
+        },
+        Op::Communicate(1),
+        Op::Communicate(2),
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // This should cause the second window's trajectory to readjust to the new final position at
+    // 200px. Ideally without big jumps.
+    //
+    // FIXME: currently causes a 100 px jump due to the change in the window size.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 200 at x:  0 y:  0
+    200 × 200 at x: 80 y:120
+    ");
+
+    // Advance the time to complete the consume movement.
+    Op::AdvanceAnimations { msec_delta: 800 }.apply(&mut layout);
+
+    // Final state.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 200 at x:  0 y:  0
+    200 × 200 at x:  0 y:200
+    ");
+}
+
+#[test]
+fn height_resize_cancel_with_stationary_second_window() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+        Op::FocusColumnLeft,
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        Op::SetForcedSize {
+            id: 2,
+            size: Some(Size::new(200, 200)),
+        },
+        Op::Communicate(1),
+        Op::Communicate(2),
+        Op::CompleteAnimations,
+        // Issue a resize.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(200),
+        },
+        // The top window grows in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 200)),
+        },
+        // This starts the resize animation.
+        Op::Communicate(1),
+        Op::Communicate(2),
+        // Advance the time a bit.
+        Op::AdvanceAnimations { msec_delta: 20 },
+    ];
+    let mut options = make_options();
+    // Window movement will happen instantly.
+    options.animations.window_movement.0.off = true;
+    let mut layout = check_ops_with_options(options, &ops);
+
+    // The resize is in progress.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 102 at x:  0 y:  0
+    200 × 200 at x:100 y:  0
+    ");
+
+    // Consume second window into column, starting the X/Y move anim down.
+    Op::ConsumeWindowIntoColumn.apply(&mut layout);
+
+    // No time had passed, so no change in coordinates yet.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 102 at x:  0 y:  0
+    200 × 200 at x:100 y:  0
+    ");
+
+    // Advance the time a little.
+    Op::AdvanceAnimations { msec_delta: 20 }.apply(&mut layout);
+
+    // The window movement anim is off, so the second window is already at the bottom. Since
+    // consume started after the resize, the second window is unaffected by the resize-induced Y
+    // movement, and sits at the final position at 200 px.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 104 at x:  0 y:  0
+    200 × 200 at x:  0 y:200
+    ");
+
+    let ops = [
+        // Issue a resize back.
+        Op::SetWindowHeight {
+            id: None,
+            change: SizeChange::SetFixed(100),
+        },
+        // The top window shrinks in response, the bottom remains as is.
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::new(100, 100)),
+        },
+        // This cancels the resize animation since the change of 4 px is less than the resize
+        // animation threshold.
+        Op::Communicate(1),
+        Op::Communicate(2),
+    ];
+    check_ops_on_layout(&mut layout, &ops);
+
+    // This causes the second window to jump down, which is correct because it hadn't been in an
+    // animation, and as far as it's concerned, this is the same case as a window just deciding to
+    // do a clientside resize on its own, which is not animated.
+    //
+    // Since the resize is also cancelled, this is the final state.
+    assert_snapshot!(format_tiles(&layout), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:100
+    ");
+}

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -485,6 +485,17 @@ impl<W: LayoutElement> Tile<W> {
         });
     }
 
+    pub fn offset_move_y_anim_current(&mut self, offset: f64) {
+        if let Some(move_) = self.move_y_animation.as_mut() {
+            // If the anim is almost done, there's little point trying to offset it; we can let
+            // things jump. If it turns out like a bad idea, we could restart the anim intead.
+            let value = move_.anim.value();
+            if value > 0.001 {
+                move_.from += offset / value;
+            }
+        }
+    }
+
     pub fn stop_move_animations(&mut self) {
         self.move_x_animation = None;
         self.move_y_animation = None;

--- a/src/tests/animations.rs
+++ b/src/tests/animations.rs
@@ -1,0 +1,195 @@
+use std::fmt::Write as _;
+use std::time::Duration;
+
+use insta::assert_snapshot;
+use niri_config::{AnimationCurve, AnimationKind, Config, EasingParams, FloatOrInt};
+use niri_ipc::SizeChange;
+use smithay::utils::{Point, Size};
+use wayland_client::protocol::wl_surface::WlSurface;
+
+use super::client::ClientId;
+use super::*;
+use crate::niri::Niri;
+
+fn format_tiles(niri: &Niri) -> String {
+    let mut buf = String::new();
+    let ws = niri.layout.active_workspace().unwrap();
+    let mut tiles: Vec<_> = ws.tiles_with_render_positions().collect();
+
+    // We sort by id since that gives us a consistent order (from first opened to last), but we
+    // don't print the id since it's nondeterministic (the id is a global counter across all
+    // running tests in the same binary).
+    tiles.sort_by_key(|(tile, _, _)| tile.window().id().get());
+    for (tile, pos, _visible) in tiles {
+        let Size { w, h, .. } = tile.animated_tile_size();
+        let Point { x, y, .. } = pos;
+        writeln!(&mut buf, "{w:>3.0} × {h:>3.0} at x:{x:>3.0} y:{y:>3.0}").unwrap();
+    }
+    buf
+}
+
+fn create_window(f: &mut Fixture, id: ClientId, w: u16, h: u16) -> WlSurface {
+    let window = f.client(id).create_window();
+    let surface = window.surface.clone();
+    window.commit();
+    f.roundtrip(id);
+
+    let window = f.client(id).window(&surface);
+    window.attach_new_buffer();
+    window.set_size(w, h);
+    window.ack_last_and_commit();
+    f.roundtrip(id);
+
+    surface
+}
+
+fn complete_animations(niri: &mut Niri) {
+    niri.clock.set_complete_instantly(true);
+    niri.advance_animations();
+    niri.clock.set_complete_instantly(false);
+}
+
+fn set_time(niri: &mut Niri, time: Duration) {
+    // This is a bit involved because we're dealing with an AdjustableClock that maintains its own
+    // internal current_time.
+
+    // First, reset current_time to zero by matching unadjusted time to it (at rate 0.0), then
+    // setting unadjusted time to zero at rate 1.0 (causing current_time to also go to zero).
+    let now = niri.clock.now();
+    niri.clock.set_unadjusted(now);
+    let _ = niri.clock.now();
+    niri.clock.set_unadjusted(Duration::ZERO);
+    niri.clock.set_rate(1.0);
+    let _ = niri.clock.now();
+
+    // Now, set the desired time at rate 1.0.
+    niri.clock.set_unadjusted(time);
+    let _ = niri.clock.now();
+
+    // Freeze the clock so that clear() inside the niri loop callback followed by some get()
+    // doesn't replace it with the monotonic time.
+    niri.clock.set_rate(0.0);
+}
+
+// Sets up a fixture with linear animations, a renderer, and an output.
+fn set_up() -> Fixture {
+    const LINEAR: AnimationKind = AnimationKind::Easing(EasingParams {
+        duration_ms: 1000,
+        curve: AnimationCurve::Linear,
+    });
+
+    let mut config = Config::default();
+    config.layout.gaps = FloatOrInt(0.0);
+    config.animations.window_resize.anim.kind = LINEAR;
+    config.animations.window_movement.0.kind = LINEAR;
+
+    let mut f = Fixture::with_config(config);
+    f.niri_state().backend.headless().add_renderer().unwrap();
+    f.add_output(1, (1920, 1080));
+
+    f
+}
+
+fn set_up_two_in_column() -> (Fixture, ClientId, WlSurface, WlSurface) {
+    let mut f = set_up();
+
+    let id = f.add_client();
+
+    let surface1 = create_window(&mut f, id, 100, 100);
+    let surface2 = create_window(&mut f, id, 200, 200);
+    f.double_roundtrip(id);
+
+    let _ = f.client(id).window(&surface1).recent_configures();
+    let _ = f.client(id).window(&surface2).recent_configures();
+
+    // Consume into one column.
+    f.niri().layout.focus_left();
+    f.niri().layout.consume_into_column();
+    f.double_roundtrip(id);
+
+    // Commit for the column consume.
+    let window = f.client(id).window(&surface1);
+    window.ack_last_and_commit();
+
+    let window = f.client(id).window(&surface2);
+    window.ack_last_and_commit();
+
+    f.double_roundtrip(id);
+
+    set_time(f.niri(), Duration::ZERO);
+    complete_animations(f.niri());
+
+    (f, id, surface1, surface2)
+}
+
+#[test]
+fn height_resize_animates_next_y() {
+    let (mut f, id, surface1, surface2) = set_up_two_in_column();
+
+    // Issue a resize.
+    f.niri()
+        .layout
+        .set_window_height(None, SizeChange::AdjustFixed(-50));
+    f.double_roundtrip(id);
+
+    // The top window shrinks in response, the bottom remains as is.
+    let window = f.client(id).window(&surface1);
+    window.set_size(100, 50);
+    window.ack_last_and_commit();
+    let window = f.client(id).window(&surface2);
+    window.ack_last_and_commit();
+
+    // This starts the resize animation for the top window and the Y move for the bottom.
+    f.roundtrip(id);
+
+    // No time had passed yet, so we're at the initial state.
+    assert_snapshot!(format_tiles(f.niri()), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:100
+    ");
+
+    // Advance the time halfway.
+    set_time(f.niri(), Duration::from_millis(500));
+    f.niri().advance_animations();
+
+    // Top window is half-resized at 75 px tall, bottom window is at y=75 matching it.
+    assert_snapshot!(format_tiles(f.niri()), @r"
+    100 ×  75 at x:  0 y:  0
+    200 × 200 at x:  0 y: 75
+    ");
+
+    // Advance the time to completion.
+    set_time(f.niri(), Duration::from_millis(1000));
+    f.niri().advance_animations();
+
+    // Final state at 50 px.
+    assert_snapshot!(format_tiles(f.niri()), @r"
+    100 ×  50 at x:  0 y:  0
+    200 × 200 at x:  0 y: 50
+    ");
+}
+
+#[test]
+fn clientside_height_change_doesnt_animate() {
+    let (mut f, id, surface1, _surface2) = set_up_two_in_column();
+
+    // The initial state.
+    assert_snapshot!(format_tiles(f.niri()), @r"
+    100 × 100 at x:  0 y:  0
+    200 × 200 at x:  0 y:100
+    ");
+
+    // The top window shrinks by itself, without a niri-issued resize.
+    let window = f.client(id).window(&surface1);
+    window.set_size(100, 50);
+    window.commit();
+
+    // This does not start any animations.
+    f.roundtrip(id);
+
+    // No time had passed yet, but we are at the final state right away.
+    assert_snapshot!(format_tiles(f.niri()), @r"
+    100 ×  50 at x:  0 y:  0
+    200 × 200 at x:  0 y: 50
+    ");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod client;
 mod fixture;
 mod server;
 
+mod animations;
 mod floating;
 mod fullscreen;
 mod layer_shell;

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -1174,10 +1174,6 @@ impl LayoutElement for Mapped {
         &self.rules
     }
 
-    fn animation_snapshot(&self) -> Option<&LayoutElementRenderSnapshot> {
-        self.animation_snapshot.as_ref()
-    }
-
     fn take_animation_snapshot(&mut self) -> Option<LayoutElementRenderSnapshot> {
         self.animation_snapshot.take()
     }


### PR DESCRIPTION
This fixes Mod Plus and Mod Minus in quick succession causing the adjacent columns to jump. Similarly, Mod Shift Plus and Minus in quick succession causing tiles below to jump.

~~There's one case left to fix: continuously-resizing windows cause column X anims to never settle because I currently made them restart instead of offset. Need to figure that out.~~