### PR TITLE
feat: `open-maximized-if-alone` window rule

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1423,6 +1423,8 @@ pub struct WindowRule {
     #[knuffel(child, unwrap(argument))]
     pub open_maximized: Option<bool>,
     #[knuffel(child, unwrap(argument))]
+    pub open_maximized_if_alone: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
     pub open_fullscreen: Option<bool>,
     #[knuffel(child, unwrap(argument))]
     pub open_floating: Option<bool>,
@@ -4249,6 +4251,7 @@ mod tests {
 
                 open-on-output "eDP-1"
                 open-maximized true
+                open-maximized-if-alone true
                 open-fullscreen false
                 open-floating false
                 open-focused true
@@ -5027,6 +5030,9 @@ mod tests {
                     ),
                     open_on_workspace: None,
                     open_maximized: Some(
+                        true,
+                    ),
+                    open_maximized_if_alone: Some(
                         true,
                     ),
                     open_fullscreen: Some(

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -917,7 +917,8 @@ impl State {
         let mut floating_width = None;
         let mut height = None;
         let mut floating_height = None;
-        let is_full_width = rules.open_maximized.unwrap_or(false);
+        let wants_full_width = rules.open_maximized.unwrap_or(false);
+        let wants_full_width_if_alone = rules.open_maximized_if_alone.unwrap_or(false);
         let is_floating = rules.compute_open_floating(toplevel);
 
         // Tell the surface the preferred size and bounds for its likely output.
@@ -930,7 +931,7 @@ impl State {
                     .or_else(|| self.niri.layout.active_workspace())
             });
 
-        if let Some(ws) = ws {
+        let is_full_width = if let Some(ws) = ws {
             // Set a fullscreen state based on window request and window rule.
             if (wants_fullscreen.is_some() && rules.open_fullscreen.is_none())
                 || rules.open_fullscreen == Some(true)
@@ -944,6 +945,9 @@ impl State {
             floating_width = ws.resolve_default_width(rules.default_width, true);
             height = ws.resolve_default_height(rules.default_height, false);
             floating_height = ws.resolve_default_height(rules.default_height, true);
+
+            let is_full_width =
+                wants_full_width || (wants_full_width_if_alone && !ws.has_windows());
 
             let configure_width = if is_floating {
                 floating_width
@@ -960,7 +964,11 @@ impl State {
                 is_floating,
                 &rules,
             );
-        }
+
+            is_full_width
+        } else {
+            wants_full_width
+        };
 
         // Set the tiled state for the initial configure.
         update_tiled_state(toplevel, config.prefer_no_csd, rules.tiled_state);

--- a/src/tests/window_opening.rs
+++ b/src/tests/window_opening.rs
@@ -415,6 +415,7 @@ fn target_size() {
     // * want fullscreen
     // * open-fullscreen
     // * open-maximized
+    // * open-maximized-if-alone
     // * open-floating
     // * default-column-width
     // * border
@@ -430,6 +431,7 @@ fn target_size() {
         WantFullscreen::AfterInitial(None),
     ];
     let open_maximized = [None, Some("true")];
+    let open_maximized_if_alone = [None, Some("true")];
     let open_floating = [None, Some("true")];
     let default_column_width = [
         None,
@@ -450,12 +452,14 @@ fn target_size() {
     for fs in open_fullscreen {
         for wfs in want_fullscreen {
             for om in open_maximized {
-                for of in open_floating {
-                    for dw in default_column_width {
-                        for dh in default_window_height {
-                            for b in border {
-                                for t in tabbed {
-                                    powerset.push((fs, wfs, om, of, dw, dh, b, t));
+                for omia in open_maximized_if_alone {
+                    for of in open_floating {
+                        for dw in default_column_width {
+                            for dh in default_window_height {
+                                for b in border {
+                                    for t in tabbed {
+                                        powerset.push((fs, wfs, om, omia, of, dw, dh, b, t));
+                                    }
                                 }
                             }
                         }
@@ -467,8 +471,8 @@ fn target_size() {
 
     powerset
         .into_par_iter()
-        .for_each(|(fs, wfs, om, of, dw, dh, b, t)| {
-            check_target_size(fs, wfs, om, of, dw, dh, b, t);
+        .for_each(|(fs, wfs, om, omia, of, dw, dh, b, t)| {
+            check_target_size(fs, wfs, om, omia, of, dw, dh, b, t);
         });
 }
 
@@ -477,6 +481,7 @@ fn check_target_size(
     open_fullscreen: Option<&str>,
     want_fullscreen: WantFullscreen,
     open_maximized: Option<&str>,
+    open_maximized_if_alone: Option<&str>,
     open_floating: Option<&str>,
     default_width: Option<DefaultSize>,
     default_height: Option<DefaultSize>,
@@ -504,6 +509,13 @@ window-rule {
 
         let x = if x == "true" { "T" } else { "F" };
         snapshot_suffix.push(format!("om{x}"));
+    }
+
+    if let Some(x) = open_maximized_if_alone {
+        writeln!(config, "    open-maximized-if-alone {x}").unwrap();
+
+        let x = if x == "true" { "T" } else { "F" };
+        snapshot_suffix.push(format!("omia{x}"));
     }
 
     if let Some(x) = open_floating {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -59,6 +59,9 @@ pub struct ResolvedWindowRules {
     /// Whether the window should open full-width.
     pub open_maximized: Option<bool>,
 
+    /// Whether the window should open full-width if alone on the workspace.
+    pub open_maximized_if_alone: Option<bool>,
+
     /// Whether the window should open fullscreen.
     pub open_fullscreen: Option<bool>,
 
@@ -178,6 +181,7 @@ impl ResolvedWindowRules {
             open_on_output: None,
             open_on_workspace: None,
             open_maximized: None,
+            open_maximized_if_alone: None,
             open_fullscreen: None,
             open_floating: None,
             open_focused: None,
@@ -296,6 +300,10 @@ impl ResolvedWindowRules {
 
                 if let Some(x) = rule.open_maximized {
                     resolved.open_maximized = Some(x);
+                }
+
+                if let Some(x) = rule.open_maximized_if_alone {
+                    resolved.open_maximized_if_alone = Some(x);
                 }
 
                 if let Some(x) = rule.open_fullscreen {


### PR DESCRIPTION
This PR adds a new `open-maximized-if-alone` window rule. 

As you can imagine It makes a window open maximized only if it's the only one on the workspace.
This was a feature I missed when I made the move from Hyprland and the only real mention I could find was here https://github.com/YaLTeR/niri/discussions/859, so I gave it a stab.

Set `open-maximized-if-alone = true`, and the window maximizes only if it's alone on the workspace. If other windows are around, it follows other rules or defaults as usual.

```kdl
window-rule {
    match app-id="zen$"
    match app-id="firefox$"
    
    open-maximized-if-alone true
}
```
