### PR TITLE
flake: skip tests that require a valid EGL display

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,8 +118,7 @@
           checkFlags = [
             # These tests require the ability to access a "valid EGL Display", but that won't work
             # inside the Nix sandbox
-            "--skip=tests::animations::clientside_height_change_doesnt_animate"
-            "--skip=tests::animations::height_resize_animates_next_y"
+            "--skip=tests::animations
           ];
 
           postInstall =

--- a/flake.nix
+++ b/flake.nix
@@ -118,7 +118,7 @@
           checkFlags = [
             # These tests require the ability to access a "valid EGL Display", but that won't work
             # inside the Nix sandbox
-            "--skip=tests::animations
+            "--skip=tests::animations"
           ];
 
           postInstall =

--- a/flake.nix
+++ b/flake.nix
@@ -115,6 +115,13 @@
             export XDG_RUNTIME_DIR="$(mktemp -d)"
           '';
 
+          checkFlags = [
+            # These tests require the ability to access a "valid EGL Display", but that won't work
+            # inside the Nix sandbox
+            "--skip=tests::animations::clientside_height_change_doesnt_animate"
+            "--skip=tests::animations::height_resize_animates_next_y"
+          ];
+
           postInstall =
             ''
               installShellCompletion --cmd niri \


### PR DESCRIPTION
Otherwise:

    niri> failures:
    niri>
    niri> ---- tests::animations::clientside_height_change_doesnt_animate stdout ----
    niri>
    niri> thread 'tests::animations::clientside_height_change_doesnt_animate' panicked at src/tests/animations.rs:87:54:
    niri> called `Result::unwrap()` on an `Err` value: error creating EGL display
    niri>
    niri> Caused by:
    niri>     Unable to obtain a valid EGL Display.
    niri> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    niri>
    niri> ---- tests::animations::height_resize_animates_next_y stdout ----
    niri>
    niri> thread 'tests::animations::height_resize_animates_next_y' panicked at src/tests/animations.rs:87:54:
    niri> called `Result::unwrap()` on an `Err` value: error creating EGL display
    niri>
    niri> Caused by:
    niri>     Unable to obtain a valid EGL Display.
    niri>
    niri>
    niri> failures:
    niri>     tests::animations::clientside_height_change_doesnt_animate
    niri>     tests::animations::height_resize_animates_next_y
    niri>
    niri> test result: FAILED. 147 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.45s

---

Closes https://github.com/YaLTeR/niri/issues/2245.