### PR TITLE
configure section permalinks

### DIFF
--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -43,6 +43,8 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.keys
+  - toc:
+      permalink: '#'
 plugins:
   - search
 hooks:


### PR DESCRIPTION
i think this fixes https://github.com/YaLTeR/niri/discussions/2266

though, it's not consistent with github's permalinks that show up on the left side of a title.
this one shows up on the right side of the header.

it's visible when hovering over a title. it is always visible when the url matches the slug

<img width="291" height="236" alt="image" src="https://github.com/user-attachments/assets/51cc06e5-565e-4137-87a3-82aa4ca4eb45" />
