### PR TITLE
niri-ipc: Add window is_fullscreen and is_windowed_fullscreen

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1155,6 +1155,10 @@ pub struct Window {
     pub is_floating: bool,
     /// Whether this window requests your attention.
     pub is_urgent: bool,
+    /// Whether this window is fullscreen
+    pub is_fullscreen: bool,
+    /// Whether this window is windowed fullscreen
+    pub is_windowed_fullscreen: bool,
     /// Position- and size-related properties of the window.
     pub layout: WindowLayout,
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -33,6 +33,7 @@ use smithay::wayland::shell::wlr_layer::{KeyboardInteractivity, Layer};
 use crate::backend::IpcOutputMap;
 use crate::input::pick_window_grab::PickWindowGrab;
 use crate::layout::workspace::WorkspaceId;
+use crate::layout::LayoutElement;
 use crate::niri::State;
 use crate::utils::{version, with_toplevel_role};
 use crate::window::Mapped;
@@ -491,6 +492,8 @@ fn make_ipc_window(
         workspace_id: workspace_id.map(|id| id.get()),
         is_focused: mapped.is_focused(),
         is_floating: mapped.is_floating(),
+        is_fullscreen: mapped.is_fullscreen(),
+        is_windowed_fullscreen: mapped.is_windowed_fullscreen(),
         is_urgent: mapped.is_urgent(),
         layout,
     })


### PR DESCRIPTION
I'm trying to determine if a window is fullscreen using the IPC, but this information is not currently exposed. I've worked around it by:

1. Getting the workspace of the window
2. Getting the output the workspace is on
3. Comparing the size of the window to the logical dimensions of the output

This is rather awkward :sweat_smile:  and I think the fullscreen information should be exposed by the window.