### PR TITLE
feat: WindowTitleChanged IPC event

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1385,6 +1385,13 @@ pub enum Event {
         /// The new urgency state of the window.
         urgent: bool,
     },
+    /// Window title changed.
+    WindowTitleChanged {
+        /// Id of the window.
+        id: u64,
+        /// The new title of the window.
+        title: String,
+    },
     /// The layout of one or more windows has changed.
     WindowLayoutsChanged {
         /// Pairs consisting of a window id and new layout information for the window.

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -201,6 +201,14 @@ impl EventStreamStatePart for WindowsState {
                     }
                 }
             }
+            Event::WindowTitleChanged { id, title } => {
+                for win in self.windows.values_mut() {
+                    if win.id == id {
+                        win.title = Some(title);
+                        break;
+                    }
+                }
+            }
             Event::WindowLayoutsChanged { changes } => {
                 for (id, update) in changes {
                     let win = self.windows.get_mut(&id);

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -716,6 +716,20 @@ impl XdgShellHandler for State {
 
     fn title_changed(&mut self, toplevel: ToplevelSurface) {
         self.update_window_rules(&toplevel);
+
+        // Send IPC event for window title change
+        if let Some((mapped, _)) = self
+            .niri
+            .layout
+            .find_window_and_output(toplevel.wl_surface())
+        {
+            let id = mapped.id().get();
+            let title = crate::utils::with_toplevel_role(&toplevel, |role| {
+                role.title.clone().unwrap_or_default()
+            });
+
+            self.ipc_window_title_changed(id, title);
+        }
     }
 
     fn parent_changed(&mut self, toplevel: ToplevelSurface) {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -447,6 +447,9 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                     Event::WindowUrgencyChanged { id, urgent } => {
                         println!("Window {id}: urgency changed to {urgent}");
                     }
+                    Event::WindowTitleChanged { id, title } => {
+                        println!("Window {id}: title changed to {title}");
+                    }
                     Event::WindowLayoutsChanged { changes } => {
                         println!("Window layouts changed: {changes:?}");
                     }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -773,4 +773,15 @@ impl State {
         state.apply(event.clone());
         server.send_event(event);
     }
+
+    pub fn ipc_window_title_changed(&mut self, id: u64, title: String) {
+        let Some(server) = &self.niri.ipc_server else {
+            return;
+        };
+        let mut state = server.event_stream_state.borrow_mut();
+
+        let event = Event::WindowTitleChanged { id, title };
+        state.windows.apply(event.clone());
+        server.send_event(event);
+    }
 }


### PR DESCRIPTION
Adds the IPC event `WindowTitleChanged` for when a window's title changes. Would resolve https://github.com/noctalia-dev/noctalia-shell/issues/128

<img width="2061" height="1112" alt="1755904640" src="https://github.com/user-attachments/assets/1f847ca9-3642-4417-b3b5-8f3f51c99a17" />
