### PR TITLE
Support miette 7.4.0 without patching knuffel

### DIFF
--- a/niri-config/Cargo.toml
+++ b/niri-config/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 bitflags.workspace = true
 csscolorparser = "0.7.2"
 knuffel = "3.2.0"
-miette = { version = "5.10.0", features = ["fancy-no-backtrace"] }
+miette = { version = "7.4.0", features = ["fancy-no-backtrace"] }
 niri-ipc = { version = "25.5.1", path = "../niri-ipc" }
 regex = "1.11.1"
 smithay = { workspace = true, features = ["backend_libinput"] }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2546,13 +2546,18 @@ impl Config {
             .into_diagnostic()
             .with_context(|| format!("error reading {path:?}"))?;
 
-        let config = Self::parse(
-            path.file_name()
-                .and_then(OsStr::to_str)
-                .unwrap_or("config.kdl"),
-            &contents,
-        )
-        .context("error parsing")?;
+        let filename = path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .unwrap_or("config.kdl");
+
+        let config = match Self::parse(filename, &contents) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                return Err(miette::Report::msg(format!("error parsing: {e}")));
+            }
+        };
+
         debug!("loaded config from {path:?}");
         Ok(config)
     }


### PR DESCRIPTION
Knuffel seems to be unmaintained and depends on an older version of miette but niri-config is able to build against miette 7.4.0 with a small code tweak.