### PR TITLE
nix: add `cargo-insta` to devShells

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -204,6 +204,7 @@
                   ];
                 }
               ))
+              pkgs.cargo-insta
             ];
 
             nativeBuildInputs = [


### PR DESCRIPTION
Add `cargo-insta` to Nix dev shell.

`cargo-insta` is used to apply diff in snapshot test managed by `insta`.