### PR TITLE
feat: add niri-uwsm.desktop

### DIFF
--- a/resources/niri-uwsm.desktop
+++ b/resources/niri-uwsm.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Niri (uwsm-managed)
+Comment=A scrollable-tiling Wayland compositor
+Exec=uwsm start -- niri.desktop
+TryExec=uwsm
+Type=Application
+DesktopNames=niri


### PR DESCRIPTION
adds a desktop entry for [uwsm](https://github.com/Vladimir-csp/uwsm).

if the user wants to use uwsm and a display or login manager, it's required to add this by hand, which is inconvenient. the entry requires root privileges for the creation and editing, and in the environment like nixos it's required to be done manually via a derivation or uwsm options in the configuration.

i think uwsm is pretty widely used at this point, so adding at least a desktop entry for the convenience would be great. the addition was approved from the uwsm author's side in this [comment](https://github.com/Vladimir-csp/uwsm/pull/162#issuecomment-3221185858).

`TryExec` directive should hide the entry if uwsm is not installed, so it wouldn't clutter display/login managers in the case of uwsm absence.

the issue is this entry needs to be installed to the system by the package manager. so in case of this PR's merge approval, something like a notice for packagers in the next release would be great.