### PR TITLE
Feature: Add auto-confirm option to screenshot ui

### DIFF
--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -382,6 +382,15 @@ binds {
 }
 ```
 
+<sup>Since: next release</sup> You can make it so that a screenshot is taken as soon as a rectangular area is selected (without needing to press Enter) with the `auto-confirm=true` property:
+
+```kdl
+binds {
+    // Take the screenshot as soon as the user releases the mouse
+    Print { screenshot auto-confirm=true; }
+}
+```
+
 #### `toggle-keyboard-shortcuts-inhibit`
 
 <sup>Since: 25.02</sup>

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -106,7 +106,10 @@ pub enum Action {
     CancelScreenshot,
     #[knuffel(skip)]
     ScreenshotTogglePointer,
-    Screenshot(#[knuffel(property(name = "show-pointer"), default = true)] bool),
+    Screenshot(
+        #[knuffel(property(name = "show-pointer"), default = true)] bool,
+        #[knuffel(property(name = "auto-confirm"), default = false)] bool,
+    ),
     ScreenshotScreen(
         #[knuffel(property(name = "write-to-disk"), default = true)] bool,
         #[knuffel(property(name = "show-pointer"), default = true)] bool,
@@ -349,7 +352,7 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::Spawn { command } => Self::Spawn(command),
             niri_ipc::Action::SpawnSh { command } => Self::SpawnSh(command),
             niri_ipc::Action::DoScreenTransition { delay_ms } => Self::DoScreenTransition(delay_ms),
-            niri_ipc::Action::Screenshot { show_pointer } => Self::Screenshot(show_pointer),
+            niri_ipc::Action::Screenshot { show_pointer, auto_confirm } => Self::Screenshot(show_pointer, auto_confirm),
             niri_ipc::Action::ScreenshotScreen {
                 write_to_disk,
                 show_pointer,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -220,6 +220,10 @@ pub enum Action {
         ///  Whether to show the mouse pointer by default in the screenshot UI.
         #[cfg_attr(feature = "clap", arg(short = 'p', long, action = clap::ArgAction::Set, default_value_t = true))]
         show_pointer: bool,
+
+        /// Whether to wait for the user pressing enter before confirming the screenshot
+        #[cfg_attr(feature = "clap", arg(short = 'p', long, action = clap::ArgAction::Set, default_value_t = false))]
+        auto_confirm: bool,
     },
     /// Screenshot the focused screen.
     ScreenshotScreen {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -636,8 +636,8 @@ impl State {
                 self.niri.screenshot_ui.toggle_pointer();
                 self.niri.queue_redraw_all();
             }
-            Action::Screenshot(show_cursor) => {
-                self.open_screenshot_ui(show_cursor);
+            Action::Screenshot(show_cursor, auto_confirm) => {
+                self.open_screenshot_ui(show_cursor, auto_confirm);
             }
             Action::ScreenshotWindow(write_to_disk) => {
                 let focus = self.niri.layout.focus_with_output();

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1808,7 +1808,7 @@ impl State {
         self.niri.output_management_state.notify_changes(new_config);
     }
 
-    pub fn open_screenshot_ui(&mut self, show_pointer: bool) {
+    pub fn open_screenshot_ui(&mut self, show_pointer: bool, auto_confirm: bool) {
         if self.niri.is_locked() || self.niri.screenshot_ui.is_open() {
             return;
         }
@@ -1843,7 +1843,7 @@ impl State {
         self.backend.with_primary_renderer(|renderer| {
             self.niri
                 .screenshot_ui
-                .open(renderer, screenshots, default_output, show_pointer)
+                .open(renderer, screenshots, default_output, show_pointer, auto_confirm)
         });
 
         self.niri

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -263,7 +263,7 @@ fn collect_actions(config: &Config) -> Vec<&Action> {
     // Screenshot is not as important, can omit if not bound.
     if let Some(bind) = binds
         .iter()
-        .find(|bind| matches!(bind.action, Action::Screenshot(_)))
+        .find(|bind| matches!(bind.action, Action::Screenshot(..)))
     {
         actions.push(&bind.action);
     }
@@ -479,7 +479,7 @@ fn action_name(action: &Action) -> String {
             String::from("Switch Focus Between Floating and Tiling")
         }
         Action::ToggleOverview => String::from("Open the Overview"),
-        Action::Screenshot(_) => String::from("Take a Screenshot"),
+        Action::Screenshot(..) => String::from("Take a Screenshot"),
         Action::Spawn(args) => format!(
             "Spawn <span face='monospace' bgcolor='#000000'>{}</span>",
             args.first().unwrap_or(&String::new())

--- a/src/ui/screenshot_ui.rs
+++ b/src/ui/screenshot_ui.rs
@@ -60,6 +60,7 @@ pub enum ScreenshotUi {
         output_data: HashMap<Output, OutputData>,
         button: Button,
         show_pointer: bool,
+        auto_confirm: bool,
         open_anim: Animation,
         clock: Clock,
         config: Rc<RefCell<Config>>,
@@ -141,6 +142,7 @@ impl ScreenshotUi {
         screenshots: HashMap<Output, [OutputScreenshot; 3]>,
         default_output: Output,
         show_pointer: bool,
+        auto_confirm: bool,
     ) -> bool {
         if screenshots.is_empty() {
             return false;
@@ -232,6 +234,7 @@ impl ScreenshotUi {
             output_data,
             button: Button::Up,
             show_pointer,
+            auto_confirm,
             open_anim,
             clock: clock.clone(),
             config: config.clone(),
@@ -923,11 +926,14 @@ impl ScreenshotUi {
             output_data,
             button,
             show_pointer,
+            auto_confirm,
             ..
         } = self
         else {
             return None;
         };
+
+        let auto_confirm = *auto_confirm;
 
         let Button::Down {
             touch_slot,
@@ -993,7 +999,7 @@ impl ScreenshotUi {
 
         self.update_buffers();
 
-        Some(false)
+        Some(auto_confirm)
     }
 }
 


### PR DESCRIPTION
add an option to auto-confirm screenshots using the screenshot ui - i.e. - immediately take a screenshot once the user makes a selection without waiting for the user to confirm/press Enter