### PR TITLE
niri-config: add support for include directives and merging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,6 +2425,7 @@ dependencies = [
  "smithay",
  "tracing",
  "tracy-client",
+ "xshell",
 ]
 
 [[package]]
@@ -2441,7 +2442,6 @@ dependencies = [
 name = "niri-macros"
 version = "25.8.0"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.106",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,6 +2419,7 @@ dependencies = [
  "knuffel",
  "miette",
  "niri-ipc",
+ "niri-macros",
  "pretty_assertions",
  "regex",
  "smithay",
@@ -2434,6 +2435,15 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "niri-macros"
+version = "25.8.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0.143"
 tracing = { version = "0.1.41", features = ["max_level_trace", "release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracy-client = { version = "0.18.2", default-features = false }
+xshell = "0.2.7"
 
 [workspace.dependencies.smithay]
 # version = "0.4.1"
@@ -123,7 +124,7 @@ proptest = "1.7.0"
 proptest-derive = { version = "0.6.0", features = ["boxed_union"] }
 rayon = "1.11.0"
 wayland-client = "0.31.11"
-xshell = "0.2.7"
+xshell.workspace = true
 
 [features]
 default = ["dbus", "systemd", "xdp-gnome-screencast"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "niri-config",
     "niri-ipc",
+    "niri-macros",
     "niri-visual-tests",
 ]
 

--- a/docs/wiki/Configuration:-Introduction.md
+++ b/docs/wiki/Configuration:-Introduction.md
@@ -78,32 +78,19 @@ input {
 
 #### Sections
 
-Most sections cannot be repeated. For example:
+Most sections that are repeated will be merged top-down in a where where "last one wins":
 
 ```kdl
-// This is valid: every section appears once.
 input {
-    keyboard {
-        // ...
-    }
-
     touchpad {
-        // ...
-    }
-}
-```
-
-```kdl,must-fail
-// This is NOT valid: input section appears twice.
-input {
-    keyboard {
-        // ...
+        scroll-factor 0.3
     }
 }
 
+// Scroll factor becomes 0.75, the previous value 0.3 is overridden
 input {
     touchpad {
-        // ...
+        scroll-factor 0.75
     }
 }
 ```

--- a/docs/wiki/Configuration:-Introduction.md
+++ b/docs/wiki/Configuration:-Introduction.md
@@ -78,7 +78,7 @@ input {
 
 #### Sections
 
-Most sections that are repeated will be merged top-down in a where where "last one wins":
+Most sections that are repeated will be merged top-down so that the "last one wins":
 
 ```kdl
 input {
@@ -92,6 +92,19 @@ input {
     touchpad {
         scroll-factor 0.75
     }
+}
+```
+
+Some configurations are not mergeable, for example environment:
+
+```kdl,must-fail
+// This is NOT valid: environment cannot appear twice
+environment {
+    DISPLAY ":0"
+}
+
+environment {
+    DISPLAY: "1"
 }
 ```
 

--- a/docs/wiki/Configuration:-Modularization.md
+++ b/docs/wiki/Configuration:-Modularization.md
@@ -1,0 +1,185 @@
+### Modularization
+
+<sup>Since: next release</sup>
+
+You can use `include` directives to resolve configuration from multiple files.
+
+```kdl
+// gestures.kdl
+gestures {
+    dnd-edge-view-scroll {
+        trigger-width 30
+        delay-ms 100
+        max-speed 1500
+    }
+
+    dnd-edge-workspace-switch {
+        trigger-height 50
+        delay-ms 100
+        max-speed 1500
+    }
+
+    hot-corners {
+        // off
+    }
+}
+```
+
+```kdl
+// binds.kdl
+binds {
+    Mod+Left { focus-column-left; }
+    Super+Alt+L { spawn "swaylock"; }
+}
+```
+
+```kdl
+// layout.kdl
+layout {
+    gaps 16
+}
+```
+
+```kdl
+// config.kdl
+include "layout.kdl"
+
+layer-rule {
+    match namespace="waybar"
+    match at-startup=true
+
+    // Properties that apply continuously.
+    opacity 0.5
+}
+
+include "gestures.kdl"
+include "binds.kdl"
+```
+
+This will result in a final effective configuration of:
+
+```kdl
+layout {
+    gaps 16
+}
+
+
+layer-rule {
+    match namespace="waybar"
+    match at-startup=true
+
+    // Properties that apply continuously.
+    opacity 0.5
+}
+
+gestures {
+    dnd-edge-view-scroll {
+        trigger-width 30
+        delay-ms 100
+        max-speed 1500
+    }
+
+    dnd-edge-workspace-switch {
+        trigger-height 50
+        delay-ms 100
+        max-speed 1500
+    }
+
+    hot-corners {
+        // off
+    }
+}
+
+binds {
+    Mod+Left { focus-column-left; }
+    Super+Alt+L { spawn "swaylock"; }
+}
+```
+
+Notice how includes are resolved relative to the position in which they appear.
+
+### Duplication and Merging
+
+Named sections can appear more than once.
+
+```kdl,must-fail
+// Any section with a name can appear more than once, but the names must be unique.
+workspace "browser" {
+    open-on-outtput "DP-1"
+}
+
+workspace "development" {
+    open-on-output "DP-2"
+}
+
+// It is INVALID to have multiple workspaces named "development"
+workspace "development" {
+    open-on-output "DP-1"
+}
+```
+
+Some sections will be merged when appearing more than once, with a "last one wins" strategy
+
+```kdl
+layout {
+    gaps 16
+    background-color "#003300"
+
+    focus-ring {
+        width 4
+        active-color "#7fc8ff"
+        inactive-color "#505050"
+        urgent-color "#9b0000"
+    }
+}
+
+layout {
+    gaps 5
+
+    focus-ring {
+        active-color "#505050"
+    }
+}
+```
+
+This would result the resolved configuration:
+```kdl
+layout {
+    gaps 5
+    background-color "#003300"
+
+    focus-ring {
+        width 4
+        active-color "#505050"
+        inactive-color "#505050"
+        urgent-color "#9b0000"
+    }
+}
+```
+
+Some sections can appear more than once, but will not be merged:
+
+```kdl
+// Window rules are not merged
+window-rule {
+    open-maximized true
+}
+
+window-rule {
+    match app-id="Alacritty"
+    open-maximized false
+}
+```
+
+Some sections cannot appear more than once and will fail validation:
+
+```kdl,must-fail
+// Environment can only be defined once
+environment {
+    DISPLAY: ":1"
+}
+
+environment {
+    DISPLAY: ":0"
+}
+```

--- a/niri-config/Cargo.toml
+++ b/niri-config/Cargo.toml
@@ -12,6 +12,7 @@ bitflags.workspace = true
 csscolorparser = "0.7.2"
 knuffel = "3.2.0"
 miette = { version = "5.10.0", features = ["fancy-no-backtrace"] }
+niri-macros = { version = "25.8.0", path = "../niri-macros" }
 niri-ipc = { version = "25.8.0", path = "../niri-ipc" }
 regex = "1.11.2"
 smithay = { workspace = true, features = ["backend_libinput"] }

--- a/niri-config/Cargo.toml
+++ b/niri-config/Cargo.toml
@@ -22,3 +22,4 @@ tracy-client.workspace = true
 [dev-dependencies]
 insta.workspace = true
 pretty_assertions = "1.4.1"
+xshell.workspace = true

--- a/niri-config/src/animations.rs
+++ b/niri-config/src/animations.rs
@@ -817,7 +817,7 @@ mod tests {
     #[test]
     fn test_animations_maybesset_slowdown() {
         let mut base = Animations::default();
-        assert_eq!(*base.slowdown, FloatOrInt(1.0));
+        assert_eq!(*base.slowdown.value(), FloatOrInt(1.0));
         assert!(!base.slowdown.is_set());
 
         let overlay = Animations {
@@ -826,7 +826,7 @@ mod tests {
         };
 
         base.merge_with(&overlay);
-        assert_eq!(*base.slowdown, FloatOrInt(2.0));
+        assert_eq!(*base.slowdown.value(), FloatOrInt(2.0));
         assert!(base.slowdown.is_set());
 
         let overlay_unset = Animations {
@@ -835,7 +835,7 @@ mod tests {
         };
 
         base.merge_with(&overlay_unset);
-        assert_eq!(*base.slowdown, FloatOrInt(2.0));
+        assert_eq!(*base.slowdown.value(), FloatOrInt(2.0));
         assert!(base.slowdown.is_set());
     }
 }

--- a/niri-config/src/animations.rs
+++ b/niri-config/src/animations.rs
@@ -821,7 +821,7 @@ mod tests {
         assert!(!base.slowdown.is_set());
 
         let overlay = Animations {
-            slowdown: MaybeSet::new(FloatOrInt(2.0)),
+            slowdown: FloatOrInt(2.0).into(),
             ..Default::default()
         };
 

--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use knuffel::errors::DecodeError;
 use miette::{miette, IntoDiagnostic as _};
+use niri_macros::Mergeable;
 use smithay::backend::renderer::Color32F;
 
 use crate::FloatOrInt;
@@ -11,7 +12,7 @@ pub const DEFAULT_BACKGROUND_COLOR: Color = Color::from_array_unpremul([0.25, 0.
 pub const DEFAULT_BACKDROP_COLOR: Color = Color::from_array_unpremul([0.15, 0.15, 0.15, 1.]);
 
 /// RGB color in [0, 1] with unpremultiplied alpha.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Mergeable)]
 pub struct Color {
     pub r: f32,
     pub g: f32,
@@ -76,7 +77,7 @@ impl MulAssign<f32> for Color {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct Gradient {
     #[knuffel(property, str)]
     pub from: Color,
@@ -102,20 +103,20 @@ impl From<Color> for Gradient {
     }
 }
 
-#[derive(knuffel::DecodeScalar, Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(knuffel::DecodeScalar, Debug, Default, Clone, Copy, PartialEq, Eq, Mergeable)]
 pub enum GradientRelativeTo {
     #[default]
     Window,
     WorkspaceView,
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct GradientInterpolation {
     pub color_space: GradientColorSpace,
     pub hue_interpolation: HueInterpolation,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Mergeable)]
 pub enum GradientColorSpace {
     #[default]
     Srgb,
@@ -124,7 +125,7 @@ pub enum GradientColorSpace {
     Oklch,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Mergeable)]
 pub enum HueInterpolation {
     #[default]
     Shorter,
@@ -133,7 +134,7 @@ pub enum HueInterpolation {
     Decreasing,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Mergeable)]
 pub struct CornerRadius {
     pub top_left: f32,
     pub top_right: f32,
@@ -221,7 +222,7 @@ impl CornerRadius {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct FocusRing {
     #[knuffel(child)]
     pub off: bool,
@@ -256,7 +257,7 @@ impl Default for FocusRing {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct Border {
     #[knuffel(child)]
     pub off: bool,
@@ -321,7 +322,7 @@ impl From<FocusRing> for Border {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct Shadow {
     #[knuffel(child)]
     pub on: bool,
@@ -356,7 +357,7 @@ impl Default for Shadow {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct ShadowOffset {
     #[knuffel(property, default)]
     pub x: FloatOrInt<-65535, 65535>,
@@ -364,7 +365,7 @@ pub struct ShadowOffset {
     pub y: FloatOrInt<-65535, 65535>,
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct WorkspaceShadow {
     #[knuffel(child)]
     pub off: bool,
@@ -407,7 +408,7 @@ impl From<WorkspaceShadow> for Shadow {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct TabIndicator {
     #[knuffel(child)]
     pub off: bool,
@@ -465,13 +466,13 @@ impl Default for TabIndicator {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct TabIndicatorLength {
     #[knuffel(property)]
     pub total_proportion: Option<f64>,
 }
 
-#[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub enum TabIndicatorPosition {
     Left,
     Right,
@@ -479,7 +480,7 @@ pub enum TabIndicatorPosition {
     Bottom,
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct InsertHint {
     #[knuffel(child)]
     pub off: bool,
@@ -499,17 +500,19 @@ impl Default for InsertHint {
     }
 }
 
-#[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq, Mergeable)]
 pub enum BlockOutFrom {
     Screencast,
     ScreenCapture,
 }
 
-#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Mergeable)]
 pub struct BorderRule {
     #[knuffel(child)]
+    #[mergeable(mutex)]
     pub off: bool,
     #[knuffel(child)]
+    #[mergeable(mutex)]
     pub on: bool,
     #[knuffel(child, unwrap(argument))]
     pub width: Option<FloatOrInt<0, 65535>>,
@@ -527,11 +530,13 @@ pub struct BorderRule {
     pub urgent_gradient: Option<Gradient>,
 }
 
-#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Mergeable)]
 pub struct ShadowRule {
     #[knuffel(child)]
+    #[mergeable(mutex)]
     pub off: bool,
     #[knuffel(child)]
+    #[mergeable(mutex)]
     pub on: bool,
     #[knuffel(child)]
     pub offset: Option<ShadowOffset>,
@@ -547,7 +552,7 @@ pub struct ShadowRule {
     pub inactive_color: Option<Color>,
 }
 
-#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Mergeable)]
 pub struct TabIndicatorRule {
     #[knuffel(child)]
     pub active_color: Option<Color>,
@@ -564,40 +569,6 @@ pub struct TabIndicatorRule {
 }
 
 impl BorderRule {
-    pub fn merge_with(&mut self, other: &Self) {
-        if other.off {
-            self.off = true;
-            self.on = false;
-        }
-
-        if other.on {
-            self.off = false;
-            self.on = true;
-        }
-
-        if let Some(x) = other.width {
-            self.width = Some(x);
-        }
-        if let Some(x) = other.active_color {
-            self.active_color = Some(x);
-        }
-        if let Some(x) = other.inactive_color {
-            self.inactive_color = Some(x);
-        }
-        if let Some(x) = other.urgent_color {
-            self.urgent_color = Some(x);
-        }
-        if let Some(x) = other.active_gradient {
-            self.active_gradient = Some(x);
-        }
-        if let Some(x) = other.inactive_gradient {
-            self.inactive_gradient = Some(x);
-        }
-        if let Some(x) = other.urgent_gradient {
-            self.urgent_gradient = Some(x);
-        }
-    }
-
     pub fn resolve_against(&self, mut config: Border) -> Border {
         config.off |= self.off;
         if self.on {
@@ -634,37 +605,6 @@ impl BorderRule {
 }
 
 impl ShadowRule {
-    pub fn merge_with(&mut self, other: &Self) {
-        if other.off {
-            self.off = true;
-            self.on = false;
-        }
-
-        if other.on {
-            self.off = false;
-            self.on = true;
-        }
-
-        if let Some(x) = other.offset {
-            self.offset = Some(x);
-        }
-        if let Some(x) = other.softness {
-            self.softness = Some(x);
-        }
-        if let Some(x) = other.spread {
-            self.spread = Some(x);
-        }
-        if let Some(x) = other.draw_behind_window {
-            self.draw_behind_window = Some(x);
-        }
-        if let Some(x) = other.color {
-            self.color = Some(x);
-        }
-        if let Some(x) = other.inactive_color {
-            self.inactive_color = Some(x);
-        }
-    }
-
     pub fn resolve_against(&self, mut config: Shadow) -> Shadow {
         config.on |= self.on;
         if self.off {
@@ -691,29 +631,6 @@ impl ShadowRule {
         }
 
         config
-    }
-}
-
-impl TabIndicatorRule {
-    pub fn merge_with(&mut self, other: &Self) {
-        if let Some(x) = other.active_color {
-            self.active_color = Some(x);
-        }
-        if let Some(x) = other.inactive_color {
-            self.inactive_color = Some(x);
-        }
-        if let Some(x) = other.urgent_color {
-            self.urgent_color = Some(x);
-        }
-        if let Some(x) = other.active_gradient {
-            self.active_gradient = Some(x);
-        }
-        if let Some(x) = other.inactive_gradient {
-            self.inactive_gradient = Some(x);
-        }
-        if let Some(x) = other.urgent_gradient {
-            self.urgent_gradient = Some(x);
-        }
     }
 }
 
@@ -1006,6 +923,7 @@ mod tests {
     use insta::assert_snapshot;
 
     use super::*;
+    use crate::mergeable::Mergeable;
 
     #[test]
     fn parse_gradient_interpolation() {

--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -6,7 +6,7 @@ use miette::{miette, IntoDiagnostic as _};
 use niri_macros::Mergeable;
 use smithay::backend::renderer::Color32F;
 
-use crate::FloatOrInt;
+use crate::{BoolFlag, FloatOrInt, MaybeSet};
 
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::from_array_unpremul([0.25, 0.25, 0.25, 1.]);
 pub const DEFAULT_BACKDROP_COLOR: Color = Color::from_array_unpremul([0.15, 0.15, 0.15, 1.]);
@@ -224,16 +224,16 @@ impl CornerRadius {
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct FocusRing {
-    #[knuffel(child)]
-    pub off: bool,
-    #[knuffel(child, unwrap(argument), default = Self::default().width)]
-    pub width: FloatOrInt<0, 65535>,
-    #[knuffel(child, default = Self::default().active_color)]
-    pub active_color: Color,
-    #[knuffel(child, default = Self::default().inactive_color)]
-    pub inactive_color: Color,
-    #[knuffel(child, default = Self::default().urgent_color)]
-    pub urgent_color: Color,
+    #[knuffel(child, default)]
+    pub off: BoolFlag,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(4.)))]
+    pub width: MaybeSet<FloatOrInt<0, 65535>>,
+    #[knuffel(child, default = MaybeSet::unset(Color::from_rgba8_unpremul(127, 200, 255, 255)))]
+    pub active_color: MaybeSet<Color>,
+    #[knuffel(child, default = MaybeSet::unset(Color::from_rgba8_unpremul(80, 80, 80, 255)))]
+    pub inactive_color: MaybeSet<Color>,
+    #[knuffel(child, default = MaybeSet::unset(Color::from_rgba8_unpremul(255, 180, 171, 255)))]
+    pub urgent_color: MaybeSet<Color>,
     #[knuffel(child)]
     pub active_gradient: Option<Gradient>,
     #[knuffel(child)]
@@ -245,11 +245,11 @@ pub struct FocusRing {
 impl Default for FocusRing {
     fn default() -> Self {
         Self {
-            off: false,
-            width: FloatOrInt(4.),
-            active_color: Color::from_rgba8_unpremul(127, 200, 255, 255),
-            inactive_color: Color::from_rgba8_unpremul(80, 80, 80, 255),
-            urgent_color: Color::from_rgba8_unpremul(155, 0, 0, 255),
+            off: false.into(),
+            width: FloatOrInt(4.).into(),
+            active_color: Color::from_rgba8_unpremul(127, 200, 255, 255).into(),
+            inactive_color: Color::from_rgba8_unpremul(80, 80, 80, 255).into(),
+            urgent_color: Color::from_rgba8_unpremul(155, 0, 0, 255).into(),
             active_gradient: None,
             inactive_gradient: None,
             urgent_gradient: None,
@@ -257,18 +257,36 @@ impl Default for FocusRing {
     }
 }
 
+impl FocusRing {
+    pub fn resolved_width(&self) -> FloatOrInt<0, 65535> {
+        *self.width.value()
+    }
+
+    pub fn resolved_active_color(&self) -> Color {
+        *self.active_color.value()
+    }
+
+    pub fn resolved_inactive_color(&self) -> Color {
+        *self.inactive_color.value()
+    }
+
+    pub fn resolved_urgent_color(&self) -> Color {
+        *self.urgent_color.value()
+    }
+}
+
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct Border {
-    #[knuffel(child)]
-    pub off: bool,
-    #[knuffel(child, unwrap(argument), default = Self::default().width)]
-    pub width: FloatOrInt<0, 65535>,
-    #[knuffel(child, default = Self::default().active_color)]
-    pub active_color: Color,
-    #[knuffel(child, default = Self::default().inactive_color)]
-    pub inactive_color: Color,
-    #[knuffel(child, default = Self::default().urgent_color)]
-    pub urgent_color: Color,
+    #[knuffel(child, default)]
+    pub off: BoolFlag,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(4.)))]
+    pub width: MaybeSet<FloatOrInt<0, 65535>>,
+    #[knuffel(child, default = MaybeSet::unset(Color::from_rgba8_unpremul(255, 200, 127, 255)))]
+    pub active_color: MaybeSet<Color>,
+    #[knuffel(child, default = MaybeSet::unset(Color::from_rgba8_unpremul(80, 80, 80, 255)))]
+    pub inactive_color: MaybeSet<Color>,
+    #[knuffel(child, default = MaybeSet::unset(Color::from_rgba8_unpremul(155, 0, 0, 255)))]
+    pub urgent_color: MaybeSet<Color>,
     #[knuffel(child)]
     pub active_gradient: Option<Gradient>,
     #[knuffel(child)]
@@ -280,15 +298,33 @@ pub struct Border {
 impl Default for Border {
     fn default() -> Self {
         Self {
-            off: true,
-            width: FloatOrInt(4.),
-            active_color: Color::from_rgba8_unpremul(255, 200, 127, 255),
-            inactive_color: Color::from_rgba8_unpremul(80, 80, 80, 255),
-            urgent_color: Color::from_rgba8_unpremul(155, 0, 0, 255),
+            off: true.into(),
+            width: FloatOrInt(4.).into(),
+            active_color: Color::from_rgba8_unpremul(255, 200, 127, 255).into(),
+            inactive_color: Color::from_rgba8_unpremul(80, 80, 80, 255).into(),
+            urgent_color: Color::from_rgba8_unpremul(155, 0, 0, 255).into(),
             active_gradient: None,
             inactive_gradient: None,
             urgent_gradient: None,
         }
+    }
+}
+
+impl Border {
+    pub fn resolved_width(&self) -> FloatOrInt<0, 65535> {
+        *self.width.value()
+    }
+
+    pub fn resolved_active_color(&self) -> Color {
+        *self.active_color.value()
+    }
+
+    pub fn resolved_inactive_color(&self) -> Color {
+        *self.inactive_color.value()
+    }
+
+    pub fn resolved_urgent_color(&self) -> Color {
+        *self.urgent_color.value()
     }
 }
 
@@ -324,18 +360,18 @@ impl From<FocusRing> for Border {
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct Shadow {
-    #[knuffel(child)]
-    pub on: bool,
-    #[knuffel(child, default = Self::default().offset)]
-    pub offset: ShadowOffset,
-    #[knuffel(child, unwrap(argument), default = Self::default().softness)]
-    pub softness: FloatOrInt<0, 1024>,
-    #[knuffel(child, unwrap(argument), default = Self::default().spread)]
-    pub spread: FloatOrInt<-1024, 1024>,
-    #[knuffel(child, unwrap(argument), default = Self::default().draw_behind_window)]
-    pub draw_behind_window: bool,
-    #[knuffel(child, default = Self::default().color)]
-    pub color: Color,
+    #[knuffel(child, default)]
+    pub on: BoolFlag,
+    #[knuffel(child, default = MaybeSet::unset(ShadowOffset::default()))]
+    pub offset: MaybeSet<ShadowOffset>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(30.)))]
+    pub softness: MaybeSet<FloatOrInt<0, 1024>>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(5.)))]
+    pub spread: MaybeSet<FloatOrInt<-1024, 1024>>,
+    #[knuffel(child, unwrap(argument), default)]
+    pub draw_behind_window: BoolFlag,
+    #[knuffel(child, default = MaybeSet::unset(Color::from_rgba8_unpremul(0, 0, 0, 68)))]
+    pub color: MaybeSet<Color>,
     #[knuffel(child)]
     pub inactive_color: Option<Color>,
 }
@@ -343,21 +379,40 @@ pub struct Shadow {
 impl Default for Shadow {
     fn default() -> Self {
         Self {
-            on: false,
+            on: false.into(),
             offset: ShadowOffset {
                 x: FloatOrInt(0.),
                 y: FloatOrInt(5.),
-            },
-            softness: FloatOrInt(30.),
-            spread: FloatOrInt(5.),
-            draw_behind_window: false,
-            color: Color::from_rgba8_unpremul(0, 0, 0, 0x70),
+            }
+            .into(),
+            softness: FloatOrInt(30.).into(),
+            spread: FloatOrInt(5.).into(),
+            draw_behind_window: false.into(),
+            color: Color::from_rgba8_unpremul(0, 0, 0, 0x70).into(),
             inactive_color: None,
         }
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
+impl Shadow {
+    pub fn resolved_offset(&self) -> ShadowOffset {
+        *self.offset.value()
+    }
+
+    pub fn resolved_softness(&self) -> FloatOrInt<0, 1024> {
+        *self.softness.value()
+    }
+
+    pub fn resolved_spread(&self) -> FloatOrInt<-1024, 1024> {
+        *self.spread.value()
+    }
+
+    pub fn resolved_color(&self) -> Color {
+        *self.color.value()
+    }
+}
+
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable, Default)]
 pub struct ShadowOffset {
     #[knuffel(property, default)]
     pub x: FloatOrInt<-65535, 65535>,
@@ -397,12 +452,12 @@ impl Default for WorkspaceShadow {
 impl From<WorkspaceShadow> for Shadow {
     fn from(value: WorkspaceShadow) -> Self {
         Self {
-            on: !value.off,
-            offset: value.offset,
-            softness: value.softness,
-            spread: value.spread,
-            draw_behind_window: false,
-            color: value.color,
+            on: BoolFlag::from(!value.off),
+            offset: value.offset.into(),
+            softness: value.softness.into(),
+            spread: value.spread.into(),
+            draw_behind_window: false.into(),
+            color: value.color.into(),
             inactive_color: None,
         }
     }
@@ -410,24 +465,24 @@ impl From<WorkspaceShadow> for Shadow {
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct TabIndicator {
-    #[knuffel(child)]
-    pub off: bool,
-    #[knuffel(child)]
-    pub hide_when_single_tab: bool,
-    #[knuffel(child)]
-    pub place_within_column: bool,
-    #[knuffel(child, unwrap(argument), default = Self::default().gap)]
-    pub gap: FloatOrInt<-65535, 65535>,
-    #[knuffel(child, unwrap(argument), default = Self::default().width)]
-    pub width: FloatOrInt<0, 65535>,
-    #[knuffel(child, default = Self::default().length)]
-    pub length: TabIndicatorLength,
-    #[knuffel(child, unwrap(argument), default = Self::default().position)]
-    pub position: TabIndicatorPosition,
-    #[knuffel(child, unwrap(argument), default = Self::default().gaps_between_tabs)]
-    pub gaps_between_tabs: FloatOrInt<0, 65535>,
-    #[knuffel(child, unwrap(argument), default = Self::default().corner_radius)]
-    pub corner_radius: FloatOrInt<0, 65535>,
+    #[knuffel(child, default)]
+    pub off: BoolFlag,
+    #[knuffel(child, default)]
+    pub hide_when_single_tab: BoolFlag,
+    #[knuffel(child, default)]
+    pub place_within_column: BoolFlag,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(0.)))]
+    pub gap: MaybeSet<FloatOrInt<-65535, 65535>>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(3.)))]
+    pub width: MaybeSet<FloatOrInt<0, 65535>>,
+    #[knuffel(child, default = MaybeSet::unset(TabIndicatorLength::default()))]
+    pub length: MaybeSet<TabIndicatorLength>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(TabIndicatorPosition::Left))]
+    pub position: MaybeSet<TabIndicatorPosition>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(0.)))]
+    pub gaps_between_tabs: MaybeSet<FloatOrInt<0, 65535>>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(0.)))]
+    pub corner_radius: MaybeSet<FloatOrInt<0, 65535>>,
     #[knuffel(child)]
     pub active_color: Option<Color>,
     #[knuffel(child)]
@@ -445,17 +500,18 @@ pub struct TabIndicator {
 impl Default for TabIndicator {
     fn default() -> Self {
         Self {
-            off: false,
-            hide_when_single_tab: false,
-            place_within_column: false,
-            gap: FloatOrInt(5.),
-            width: FloatOrInt(4.),
+            off: false.into(),
+            hide_when_single_tab: false.into(),
+            place_within_column: false.into(),
+            gap: FloatOrInt(5.).into(),
+            width: FloatOrInt(4.).into(),
             length: TabIndicatorLength {
                 total_proportion: Some(0.5),
-            },
-            position: TabIndicatorPosition::Left,
-            gaps_between_tabs: FloatOrInt(0.),
-            corner_radius: FloatOrInt(0.),
+            }
+            .into(),
+            position: TabIndicatorPosition::Left.into(),
+            gaps_between_tabs: FloatOrInt(0.).into(),
+            corner_radius: FloatOrInt(0.).into(),
             active_color: None,
             inactive_color: None,
             urgent_color: None,
@@ -466,7 +522,33 @@ impl Default for TabIndicator {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
+impl TabIndicator {
+    pub fn resolved_gap(&self) -> FloatOrInt<-65535, 65535> {
+        *self.gap.value()
+    }
+
+    pub fn resolved_width(&self) -> FloatOrInt<0, 65535> {
+        *self.width.value()
+    }
+
+    pub fn resolved_length(&self) -> TabIndicatorLength {
+        *self.length.value()
+    }
+
+    pub fn resolved_position(&self) -> TabIndicatorPosition {
+        *self.position.value()
+    }
+
+    pub fn resolved_gaps_between_tabs(&self) -> FloatOrInt<0, 65535> {
+        *self.gaps_between_tabs.value()
+    }
+
+    pub fn resolved_corner_radius(&self) -> FloatOrInt<0, 65535> {
+        *self.corner_radius.value()
+    }
+}
+
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable, Default)]
 pub struct TabIndicatorLength {
     #[knuffel(property)]
     pub total_proportion: Option<f64>,
@@ -482,10 +564,10 @@ pub enum TabIndicatorPosition {
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct InsertHint {
-    #[knuffel(child)]
-    pub off: bool,
-    #[knuffel(child, default = Self::default().color)]
-    pub color: Color,
+    #[knuffel(child, default)]
+    pub off: BoolFlag,
+    #[knuffel(child, default = MaybeSet::unset(Color::from_rgba8_unpremul(127, 200, 255, 128)))]
+    pub color: MaybeSet<Color>,
     #[knuffel(child)]
     pub gradient: Option<Gradient>,
 }
@@ -493,10 +575,16 @@ pub struct InsertHint {
 impl Default for InsertHint {
     fn default() -> Self {
         Self {
-            off: false,
-            color: Color::from_rgba8_unpremul(127, 200, 255, 128),
+            off: false.into(),
+            color: Color::from_rgba8_unpremul(127, 200, 255, 128).into(),
             gradient: None,
         }
+    }
+}
+
+impl InsertHint {
+    pub fn resolved_color(&self) -> Color {
+        *self.color.value()
     }
 }
 
@@ -570,24 +658,24 @@ pub struct TabIndicatorRule {
 
 impl BorderRule {
     pub fn resolve_against(&self, mut config: Border) -> Border {
-        config.off |= self.off;
+        *config.off.0.value_mut() |= self.off;
         if self.on {
-            config.off = false;
+            config.off = false.into();
         }
 
         if let Some(x) = self.width {
-            config.width = x;
+            config.width = x.into();
         }
         if let Some(x) = self.active_color {
-            config.active_color = x;
+            config.active_color = x.into();
             config.active_gradient = None;
         }
         if let Some(x) = self.inactive_color {
-            config.inactive_color = x;
+            config.inactive_color = x.into();
             config.inactive_gradient = None;
         }
         if let Some(x) = self.urgent_color {
-            config.urgent_color = x;
+            config.urgent_color = x.into();
             config.urgent_gradient = None;
         }
         if let Some(x) = self.active_gradient {
@@ -608,23 +696,23 @@ impl ShadowRule {
     pub fn resolve_against(&self, mut config: Shadow) -> Shadow {
         config.on |= self.on;
         if self.off {
-            config.on = false;
+            config.on = false.into();
         }
 
         if let Some(x) = self.offset {
-            config.offset = x;
+            config.offset = x.into();
         }
         if let Some(x) = self.softness {
-            config.softness = x;
+            config.softness = x.into();
         }
         if let Some(x) = self.spread {
-            config.spread = x;
+            config.spread = x.into();
         }
         if let Some(x) = self.draw_behind_window {
-            config.draw_behind_window = x;
+            config.draw_behind_window = x.into();
         }
         if let Some(x) = self.color {
-            config.color = x;
+            config.color = x.into();
         }
         if let Some(x) = self.inactive_color {
             config.inactive_color = Some(x);
@@ -1026,11 +1114,11 @@ mod tests {
             }
 
             let config = Border {
-                off: config == "off",
+                off: BoolFlag::from(config == "off"),
                 ..Default::default()
             };
 
-            if resolved.resolve_against(config).off {
+            if *resolved.resolve_against(config).off {
                 "off"
             } else {
                 "on"

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -12,10 +12,31 @@ use smithay::input::keyboard::keysyms::KEY_NoSymbol;
 use smithay::input::keyboard::xkb::{keysym_from_name, KEYSYM_CASE_INSENSITIVE};
 use smithay::input::keyboard::Keysym;
 
+use crate::mergeable::Mergeable;
 use crate::utils::expect_only_children;
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct Binds(pub Vec<Bind>);
+
+impl Mergeable for Binds {
+    fn merge_with(&mut self, other: &Self) {
+        let mut key_positions: std::collections::HashMap<Key, usize> =
+            std::collections::HashMap::new();
+
+        for (i, bind) in self.0.iter().enumerate() {
+            key_positions.insert(bind.key, i);
+        }
+
+        for bind in &other.0 {
+            if let Some(&existing_pos) = key_positions.get(&bind.key) {
+                self.0[existing_pos] = bind.clone();
+            } else {
+                key_positions.insert(bind.key, self.0.len());
+                self.0.push(bind.clone());
+            }
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Bind {

--- a/niri-config/src/debug.rs
+++ b/niri-config/src/debug.rs
@@ -57,7 +57,7 @@ mod tests {
     use niri_macros::Mergeable;
 
     use super::*;
-    use crate::{MaybeSet, Mergeable};
+    use crate::Mergeable;
 
     #[test]
     fn test_debug_regular_bool_merging() {
@@ -93,7 +93,7 @@ mod tests {
         assert!(!*base.flag_c);
 
         let overlay = MultiFlags {
-            flag_a: BoolFlag(MaybeSet::new(true)),
+            flag_a: true.into(),
             ..Default::default()
         };
 
@@ -104,7 +104,7 @@ mod tests {
         assert!(!*base.flag_c);
 
         let overlay2 = MultiFlags {
-            flag_b: BoolFlag(MaybeSet::new(true)),
+            flag_b: true.into(),
             ..Default::default()
         };
 
@@ -117,10 +117,10 @@ mod tests {
     #[test]
     fn test_debug_mutex_with_regular_fields() {
         let mut base = Debug::default();
-        base.dbus_interfaces_in_non_session_instances = BoolFlag(MaybeSet::new(true));
+        base.dbus_interfaces_in_non_session_instances = true.into();
 
         let overlay = Debug {
-            wait_for_frame_completion_before_queueing: BoolFlag(MaybeSet::new(true)),
+            wait_for_frame_completion_before_queueing: true.into(),
             render_drm_device: Some("/dev/dri/renderD128".into()),
             ..Default::default()
         };

--- a/niri-config/src/debug.rs
+++ b/niri-config/src/debug.rs
@@ -1,49 +1,172 @@
 use std::path::PathBuf;
 
-#[derive(knuffel::Decode, Debug, Default, PartialEq)]
+use niri_macros::Mergeable;
+
+use crate::maybe_set::BoolFlag;
+
+#[derive(knuffel::Decode, Debug, Default, PartialEq, Clone, Mergeable)]
 pub struct Debug {
     #[knuffel(child, unwrap(argument))]
     pub preview_render: Option<PreviewRender>,
-    #[knuffel(child)]
-    pub dbus_interfaces_in_non_session_instances: bool,
-    #[knuffel(child)]
-    pub wait_for_frame_completion_before_queueing: bool,
-    #[knuffel(child)]
-    pub enable_overlay_planes: bool,
-    #[knuffel(child)]
-    pub disable_cursor_plane: bool,
-    #[knuffel(child)]
-    pub disable_direct_scanout: bool,
-    #[knuffel(child)]
-    pub keep_max_bpc_unchanged: bool,
-    #[knuffel(child)]
-    pub restrict_primary_scanout_to_matching_format: bool,
+    #[knuffel(child, default)]
+    pub dbus_interfaces_in_non_session_instances: BoolFlag,
+    #[knuffel(child, default)]
+    pub wait_for_frame_completion_before_queueing: BoolFlag,
+    #[knuffel(child, default)]
+    pub enable_overlay_planes: BoolFlag,
+    #[knuffel(child, default)]
+    pub disable_cursor_plane: BoolFlag,
+    #[knuffel(child, default)]
+    pub disable_direct_scanout: BoolFlag,
+    #[knuffel(child, default)]
+    pub keep_max_bpc_unchanged: BoolFlag,
+    #[knuffel(child, default)]
+    pub restrict_primary_scanout_to_matching_format: BoolFlag,
     #[knuffel(child, unwrap(argument))]
     pub render_drm_device: Option<PathBuf>,
-    #[knuffel(child)]
-    pub force_pipewire_invalid_modifier: bool,
-    #[knuffel(child)]
-    pub emulate_zero_presentation_time: bool,
-    #[knuffel(child)]
-    pub disable_resize_throttling: bool,
-    #[knuffel(child)]
-    pub disable_transactions: bool,
-    #[knuffel(child)]
-    pub keep_laptop_panel_on_when_lid_is_closed: bool,
-    #[knuffel(child)]
-    pub disable_monitor_names: bool,
-    #[knuffel(child)]
-    pub strict_new_window_focus_policy: bool,
-    #[knuffel(child)]
-    pub honor_xdg_activation_with_invalid_serial: bool,
-    #[knuffel(child)]
-    pub deactivate_unfocused_windows: bool,
-    #[knuffel(child)]
-    pub skip_cursor_only_updates_during_vrr: bool,
+    #[knuffel(child, default)]
+    pub force_pipewire_invalid_modifier: BoolFlag,
+    #[knuffel(child, default)]
+    pub emulate_zero_presentation_time: BoolFlag,
+    #[knuffel(child, default)]
+    pub disable_resize_throttling: BoolFlag,
+    #[knuffel(child, default)]
+    pub disable_transactions: BoolFlag,
+    #[knuffel(child, default)]
+    pub keep_laptop_panel_on_when_lid_is_closed: BoolFlag,
+    #[knuffel(child, default)]
+    pub disable_monitor_names: BoolFlag,
+    #[knuffel(child, default)]
+    pub strict_new_window_focus_policy: BoolFlag,
+    #[knuffel(child, default)]
+    pub honor_xdg_activation_with_invalid_serial: BoolFlag,
+    #[knuffel(child, default)]
+    pub deactivate_unfocused_windows: BoolFlag,
+    #[knuffel(child, default)]
+    pub skip_cursor_only_updates_during_vrr: BoolFlag,
 }
 
-#[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq, Mergeable)]
 pub enum PreviewRender {
     Screencast,
     ScreenCapture,
+}
+
+#[cfg(test)]
+mod tests {
+    use niri_macros::Mergeable;
+
+    use super::*;
+    use crate::{MaybeSet, Mergeable};
+
+    #[test]
+    fn test_debug_regular_bool_merging() {
+        #[derive(Debug, PartialEq, Clone, Default, Mergeable)]
+        struct SingleFlag {
+            pub test_flag: bool,
+        }
+
+        let mut base = SingleFlag::default();
+        assert!(!base.test_flag);
+
+        let overlay = SingleFlag { test_flag: true };
+        base.merge_with(&overlay);
+        assert!(base.test_flag);
+
+        let overlay2 = SingleFlag { test_flag: false };
+        base.merge_with(&overlay2);
+        assert!(!base.test_flag);
+    }
+
+    #[test]
+    fn test_debug_mutex_behavior_with_multiple_bool_flags() {
+        #[derive(Debug, PartialEq, Clone, Default, Mergeable)]
+        struct MultiFlags {
+            pub flag_a: BoolFlag,
+            pub flag_b: BoolFlag,
+            pub flag_c: BoolFlag,
+        }
+
+        let mut base = MultiFlags::default();
+        assert!(!*base.flag_a);
+        assert!(!*base.flag_b);
+        assert!(!*base.flag_c);
+
+        let overlay = MultiFlags {
+            flag_a: BoolFlag(MaybeSet::new(true)),
+            ..Default::default()
+        };
+
+        base.merge_with(&overlay);
+        assert!(base.flag_a.0.is_set());
+        assert!(*base.flag_a);
+        assert!(!*base.flag_b);
+        assert!(!*base.flag_c);
+
+        let overlay2 = MultiFlags {
+            flag_b: BoolFlag(MaybeSet::new(true)),
+            ..Default::default()
+        };
+
+        base.merge_with(&overlay2);
+        assert!(*base.flag_a);
+        assert!(*base.flag_b);
+        assert!(!*base.flag_c);
+    }
+
+    #[test]
+    fn test_debug_mutex_with_regular_fields() {
+        let mut base = Debug::default();
+        base.dbus_interfaces_in_non_session_instances = BoolFlag(MaybeSet::new(true));
+
+        let overlay = Debug {
+            wait_for_frame_completion_before_queueing: BoolFlag(MaybeSet::new(true)),
+            render_drm_device: Some("/dev/dri/renderD128".into()),
+            ..Default::default()
+        };
+
+        base.merge_with(&overlay);
+
+        assert!(*base.dbus_interfaces_in_non_session_instances);
+        assert!(*base.wait_for_frame_completion_before_queueing);
+        assert_eq!(
+            base.render_drm_device.as_deref(),
+            Some("/dev/dri/renderD128".as_ref())
+        );
+    }
+
+    #[test]
+    fn test_mutex_behavior_with_regular_bools() {
+        #[derive(Debug, PartialEq, Clone, Default, Mergeable)]
+        struct MultiBools {
+            pub option_a: bool,
+            pub option_b: bool,
+            pub option_c: bool,
+        }
+
+        let mut base = MultiBools::default();
+        assert!(!base.option_a);
+        assert!(!base.option_b);
+        assert!(!base.option_c);
+
+        let overlay = MultiBools {
+            option_a: true,
+            ..Default::default()
+        };
+
+        base.merge_with(&overlay);
+        assert!(base.option_a);
+        assert!(!base.option_b);
+        assert!(!base.option_c);
+
+        let overlay2 = MultiBools {
+            option_b: true,
+            ..Default::default()
+        };
+
+        base.merge_with(&overlay2);
+        assert!(!base.option_a);
+        assert!(base.option_b);
+        assert!(!base.option_c);
+    }
 }

--- a/niri-config/src/gestures.rs
+++ b/niri-config/src/gestures.rs
@@ -1,6 +1,6 @@
 use niri_macros::Mergeable;
 
-use crate::FloatOrInt;
+use crate::{FloatOrInt, MaybeSet};
 
 #[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Mergeable)]
 pub struct Gestures {
@@ -14,41 +14,69 @@ pub struct Gestures {
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct DndEdgeViewScroll {
-    #[knuffel(child, unwrap(argument), default = Self::default().trigger_width)]
-    pub trigger_width: FloatOrInt<0, 65535>,
-    #[knuffel(child, unwrap(argument), default = Self::default().delay_ms)]
-    pub delay_ms: u16,
-    #[knuffel(child, unwrap(argument), default = Self::default().max_speed)]
-    pub max_speed: FloatOrInt<0, 1_000_000>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(30.)))]
+    pub trigger_width: MaybeSet<FloatOrInt<0, 65535>>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(100))]
+    pub delay_ms: MaybeSet<u16>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(1500.)))]
+    pub max_speed: MaybeSet<FloatOrInt<0, 1_000_000>>,
 }
 
 impl Default for DndEdgeViewScroll {
     fn default() -> Self {
         Self {
-            trigger_width: FloatOrInt(30.), // Taken from GTK 4.
-            delay_ms: 100,
-            max_speed: FloatOrInt(1500.),
+            trigger_width: FloatOrInt(30.).into(), // Taken from GTK 4.
+            delay_ms: 100.into(),
+            max_speed: FloatOrInt(1500.).into(),
         }
+    }
+}
+
+impl DndEdgeViewScroll {
+    pub fn resolved_trigger_width(&self) -> FloatOrInt<0, 65535> {
+        *self.trigger_width.value()
+    }
+
+    pub fn resolved_delay_ms(&self) -> u16 {
+        *self.delay_ms.value()
+    }
+
+    pub fn resolved_max_speed(&self) -> FloatOrInt<0, 1_000_000> {
+        *self.max_speed.value()
     }
 }
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct DndEdgeWorkspaceSwitch {
-    #[knuffel(child, unwrap(argument), default = Self::default().trigger_height)]
-    pub trigger_height: FloatOrInt<0, 65535>,
-    #[knuffel(child, unwrap(argument), default = Self::default().delay_ms)]
-    pub delay_ms: u16,
-    #[knuffel(child, unwrap(argument), default = Self::default().max_speed)]
-    pub max_speed: FloatOrInt<0, 1_000_000>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(50.)))]
+    pub trigger_height: MaybeSet<FloatOrInt<0, 65535>>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(100))]
+    pub delay_ms: MaybeSet<u16>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(1500.)))]
+    pub max_speed: MaybeSet<FloatOrInt<0, 1_000_000>>,
 }
 
 impl Default for DndEdgeWorkspaceSwitch {
     fn default() -> Self {
         Self {
-            trigger_height: FloatOrInt(50.),
-            delay_ms: 100,
-            max_speed: FloatOrInt(1500.),
+            trigger_height: FloatOrInt(50.).into(),
+            delay_ms: 100.into(),
+            max_speed: FloatOrInt(1500.).into(),
         }
+    }
+}
+
+impl DndEdgeWorkspaceSwitch {
+    pub fn resolved_trigger_height(&self) -> FloatOrInt<0, 65535> {
+        *self.trigger_height.value()
+    }
+
+    pub fn resolved_delay_ms(&self) -> u16 {
+        *self.delay_ms.value()
+    }
+
+    pub fn resolved_max_speed(&self) -> FloatOrInt<0, 1_000_000> {
+        *self.max_speed.value()
     }
 }
 

--- a/niri-config/src/gestures.rs
+++ b/niri-config/src/gestures.rs
@@ -1,6 +1,8 @@
+use niri_macros::Mergeable;
+
 use crate::FloatOrInt;
 
-#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Mergeable)]
 pub struct Gestures {
     #[knuffel(child, default)]
     pub dnd_edge_view_scroll: DndEdgeViewScroll,
@@ -10,7 +12,7 @@ pub struct Gestures {
     pub hot_corners: HotCorners,
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct DndEdgeViewScroll {
     #[knuffel(child, unwrap(argument), default = Self::default().trigger_width)]
     pub trigger_width: FloatOrInt<0, 65535>,
@@ -30,7 +32,7 @@ impl Default for DndEdgeViewScroll {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct DndEdgeWorkspaceSwitch {
     #[knuffel(child, unwrap(argument), default = Self::default().trigger_height)]
     pub trigger_height: FloatOrInt<0, 65535>,
@@ -50,7 +52,7 @@ impl Default for DndEdgeWorkspaceSwitch {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Mergeable)]
 pub struct HotCorners {
     #[knuffel(child)]
     pub off: bool,

--- a/niri-config/src/include.rs
+++ b/niri-config/src/include.rs
@@ -1,0 +1,572 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use miette::{Context as _, IntoDiagnostic as _};
+
+#[derive(Debug, Clone)]
+pub struct IncludeResult {
+    pub content: String, // The fully resolved configuration content
+    pub included_files: Vec<PathBuf>,
+}
+
+pub fn resolve_includes(main_path: &Path) -> miette::Result<IncludeResult> {
+    let mut included_files = Vec::new();
+    let mut inclusion_stack = Vec::new();
+    let mut visited = HashSet::new();
+
+    let content = resolve_includes_recursive(
+        main_path,
+        &mut included_files,
+        &mut inclusion_stack,
+        &mut visited,
+    )?;
+
+    Ok(IncludeResult {
+        content,
+        included_files,
+    })
+}
+
+fn resolve_includes_recursive(
+    path: &Path,
+    included_files: &mut Vec<PathBuf>,
+    inclusion_stack: &mut Vec<PathBuf>,
+    visited: &mut HashSet<PathBuf>,
+) -> miette::Result<String> {
+    let canonical_path = path
+        .canonicalize()
+        .into_diagnostic()
+        .with_context(|| format!("failed to canonicalize path {path:?}"))?;
+
+    // Check for circular dependencies
+    if inclusion_stack.contains(&canonical_path) {
+        let cycle_start = inclusion_stack
+            .iter()
+            .position(|p| p == &canonical_path)
+            .unwrap();
+        let cycle: Vec<_> = inclusion_stack[cycle_start..]
+            .iter()
+            .chain(std::iter::once(&canonical_path))
+            .map(|p| p.display().to_string())
+            .collect();
+
+        return Err(miette::miette!(
+            "circular dependency detected: {}",
+            cycle.join(" -> ")
+        ));
+    }
+
+    if !visited.insert(canonical_path.clone()) {
+        // Already processed this file, return empty content to avoid duplicates
+        return Ok(String::new());
+    }
+
+    inclusion_stack.push(canonical_path.clone());
+    included_files.push(canonical_path.clone());
+
+    let content = fs::read_to_string(&canonical_path)
+        .into_diagnostic()
+        .with_context(|| format!("error reading {canonical_path:?}"))?;
+
+    let mut result = String::new();
+    let current_dir = canonical_path
+        .parent()
+        .ok_or_else(|| miette::miette!("config file has no parent directory"))?;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Check for include directive
+        if trimmed.starts_with("include") {
+            if let Some(include_path) = parse_include_directive(trimmed)? {
+                let resolved_path = resolve_include_path(&include_path, current_dir)?;
+                let included_content = resolve_includes_recursive(
+                    &resolved_path,
+                    included_files,
+                    inclusion_stack,
+                    visited,
+                )?;
+
+                if !included_content.is_empty() {
+                    if !result.is_empty() && !result.ends_with('\n') {
+                        result.push('\n');
+                    }
+                    result.push_str(&included_content);
+                    if !included_content.ends_with('\n') {
+                        result.push('\n');
+                    }
+                }
+            }
+        } else {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+
+    inclusion_stack.pop();
+    Ok(result)
+}
+
+fn parse_include_directive(line: &str) -> miette::Result<Option<String>> {
+    let trimmed = line.trim();
+
+    // Match: include "path/to/file.kdl"
+    if let Some(rest) = trimmed.strip_prefix("include") {
+        let rest = rest.trim();
+
+        // Extract quoted string
+        if rest.starts_with('"') && rest.ends_with('"') && rest.len() >= 2 {
+            let path = &rest[1..rest.len() - 1];
+            if path.is_empty() {
+                return Err(miette::miette!("include directive has empty path: {line}"));
+            }
+            return Ok(Some(path.to_string()));
+        } else {
+            return Err(miette::miette!(
+                "include directive must have quoted path: {line}"
+            ));
+        }
+    }
+
+    Ok(None)
+}
+
+fn resolve_include_path(include_path: &str, current_dir: &Path) -> miette::Result<PathBuf> {
+    let path = Path::new(include_path);
+
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+
+    let resolved = current_dir.join(path);
+
+    if !resolved.exists() {
+        return Err(miette::miette!(
+            "included file not found: {resolved:?} (from {include_path:?})"
+        ));
+    }
+
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs as unix_fs;
+
+    use xshell::Shell;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_include_directive() {
+        assert_eq!(
+            parse_include_directive("include \"config.kdl\"").unwrap(),
+            Some("config.kdl".to_string())
+        );
+
+        assert_eq!(
+            parse_include_directive("  include \"path/to/file.kdl\"  ").unwrap(),
+            Some("path/to/file.kdl".to_string())
+        );
+
+        assert_eq!(parse_include_directive("layout { gaps 10 }").unwrap(), None);
+
+        assert!(parse_include_directive("include").is_err());
+        assert!(parse_include_directive("include \"\"").is_err());
+        assert!(parse_include_directive("include unquoted").is_err());
+    }
+
+    #[test]
+    fn test_nested_includes_two_levels() {
+        let sh = Shell::new().unwrap();
+        let temp_dir = sh.create_temp_dir().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create level2.kdl
+        let level2_content = r#"
+layout {
+    gaps 20
+}
+"#;
+        fs::write(temp_path.join("level2.kdl"), level2_content).unwrap();
+
+        // Create level1.kdl that includes level2.kdl
+        let level1_content = r#"
+include "level2.kdl"
+input {
+    keyboard {
+        repeat-rate 30
+    }
+}
+"#;
+        fs::write(temp_path.join("level1.kdl"), level1_content).unwrap();
+
+        // Create main.kdl that includes level1.kdl
+        let main_content = r#"
+include "level1.kdl"
+output "eDP-1" {
+    scale 2
+}
+"#;
+        fs::write(temp_path.join("main.kdl"), main_content).unwrap();
+
+        let result = resolve_includes(&temp_path.join("main.kdl")).unwrap();
+
+        // Should include content from all three files
+        assert!(result.content.contains("scale 2"));
+        assert!(result.content.contains("repeat-rate 30"));
+        assert!(result.content.contains("gaps 20"));
+
+        // Should track all processed files (main + 2 includes)
+        assert_eq!(result.included_files.len(), 3);
+        assert!(result
+            .included_files
+            .iter()
+            .any(|p| p.file_name().unwrap() == "main.kdl"));
+        assert!(result
+            .included_files
+            .iter()
+            .any(|p| p.file_name().unwrap() == "level1.kdl"));
+        assert!(result
+            .included_files
+            .iter()
+            .any(|p| p.file_name().unwrap() == "level2.kdl"));
+    }
+
+    #[test]
+    fn test_nested_includes_three_levels() {
+        let sh = Shell::new().unwrap();
+        let temp_dir = sh.create_temp_dir().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create level3.kdl (deepest level)
+        let level3_content = r#"
+animations {
+    slowdown 2.0
+}
+"#;
+        fs::write(temp_path.join("level3.kdl"), level3_content).unwrap();
+
+        // Create level2.kdl that includes level3.kdl
+        let level2_content = r#"
+include "level3.kdl"
+layout {
+    gaps 15
+}
+"#;
+        fs::write(temp_path.join("level2.kdl"), level2_content).unwrap();
+
+        // Create level1.kdl that includes level2.kdl
+        let level1_content = r#"
+include "level2.kdl"
+input {
+    mouse {
+        accel-speed 0.5
+    }
+}
+"#;
+        fs::write(temp_path.join("level1.kdl"), level1_content).unwrap();
+
+        // Create main.kdl that includes level1.kdl
+        let main_content = r#"
+include "level1.kdl"
+binds {
+    Mod+Q { close-window; }
+}
+"#;
+        fs::write(temp_path.join("main.kdl"), main_content).unwrap();
+
+        let result = resolve_includes(&temp_path.join("main.kdl")).unwrap();
+
+        // Should include content from all four files
+        assert!(result.content.contains("close-window"));
+        assert!(result.content.contains("accel-speed 0.5"));
+        assert!(result.content.contains("gaps 15"));
+        assert!(result.content.contains("slowdown 2.0"));
+
+        // Should track all processed files (main + 3 includes)
+        assert_eq!(result.included_files.len(), 4);
+        assert!(result
+            .included_files
+            .iter()
+            .any(|p| p.file_name().unwrap() == "main.kdl"));
+        assert!(result
+            .included_files
+            .iter()
+            .any(|p| p.file_name().unwrap() == "level1.kdl"));
+        assert!(result
+            .included_files
+            .iter()
+            .any(|p| p.file_name().unwrap() == "level2.kdl"));
+        assert!(result
+            .included_files
+            .iter()
+            .any(|p| p.file_name().unwrap() == "level3.kdl"));
+    }
+
+    #[test]
+    fn test_include_cycle_detection() {
+        let sh = Shell::new().unwrap();
+        let temp_dir = sh.create_temp_dir().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create a.kdl that includes b.kdl
+        let a_content = r#"
+include "b.kdl"
+layout { gaps 10 }
+"#;
+        fs::write(temp_path.join("a.kdl"), a_content).unwrap();
+
+        // Create b.kdl that includes c.kdl
+        let b_content = r#"
+include "c.kdl"
+input { keyboard { repeat-rate 25 } }
+"#;
+        fs::write(temp_path.join("b.kdl"), b_content).unwrap();
+
+        // Create c.kdl that includes a.kdl (creating a cycle)
+        let c_content = r#"
+include "a.kdl"
+binds { Mod+Q { quit; } }
+"#;
+        fs::write(temp_path.join("c.kdl"), c_content).unwrap();
+
+        let result = resolve_includes(&temp_path.join("a.kdl"));
+
+        assert!(result.is_err());
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(err_msg.contains("circular dependency"));
+        assert!(
+            err_msg.contains("a.kdl") || err_msg.contains("b.kdl") || err_msg.contains("c.kdl")
+        );
+    }
+
+    #[test]
+    fn test_direct_self_include_cycle() {
+        let sh = Shell::new().unwrap();
+        let temp_dir = sh.create_temp_dir().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create a file that includes itself
+        let self_include_content = r#"
+include "self_include.kdl"
+layout { gaps 5 }
+"#;
+        fs::write(temp_path.join("self_include.kdl"), self_include_content).unwrap();
+
+        let result = resolve_includes(&temp_path.join("self_include.kdl"));
+
+        assert!(result.is_err());
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(err_msg.contains("circular dependency"));
+    }
+
+    #[test]
+    fn test_relative_paths_from_nested_includes() {
+        let sh = Shell::new().unwrap();
+        let temp_dir = sh.create_temp_dir().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create subdirectory structure
+        let subdir = temp_path.join("configs");
+        fs::create_dir(&subdir).unwrap();
+        let deep_subdir = subdir.join("deep");
+        fs::create_dir(&deep_subdir).unwrap();
+
+        // Create deep/shared.kdl
+        let shared_content = r#"
+animations {
+    slowdown 1.5
+}
+"#;
+        fs::write(deep_subdir.join("shared.kdl"), shared_content).unwrap();
+
+        // Create configs/layout.kdl that includes ../configs/deep/shared.kdl using relative path
+        let layout_content = r#"
+include "deep/shared.kdl"
+layout {
+    gaps 8
+}
+"#;
+        fs::write(subdir.join("layout.kdl"), layout_content).unwrap();
+
+        // Create main.kdl that includes configs/layout.kdl
+        let main_content = r#"
+include "configs/layout.kdl"
+input {
+    keyboard {
+        repeat-delay 500
+    }
+}
+"#;
+        fs::write(temp_path.join("main.kdl"), main_content).unwrap();
+
+        let result = resolve_includes(&temp_path.join("main.kdl")).unwrap();
+
+        // Should resolve all relative paths correctly
+        assert!(result.content.contains("repeat-delay 500"));
+        assert!(result.content.contains("gaps 8"));
+        assert!(result.content.contains("slowdown 1.5"));
+
+        assert_eq!(result.included_files.len(), 3);
+    }
+
+    #[test]
+    fn test_symlinked_includes() {
+        let sh = Shell::new().unwrap();
+        let temp_dir = sh.create_temp_dir().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create the actual config file
+        let actual_config_content = r#"
+layout {
+    gaps 12
+}
+"#;
+        let actual_file = temp_path.join("actual_config.kdl");
+        fs::write(&actual_file, actual_config_content).unwrap();
+
+        // Create a symlink to the actual file
+        let symlink_file = temp_path.join("symlink_config.kdl");
+        unix_fs::symlink(&actual_file, &symlink_file).unwrap();
+
+        // Create main config that includes the symlink
+        let main_content = r#"
+include "symlink_config.kdl"
+input {
+    touchpad {
+        tap
+    }
+}
+"#;
+        fs::write(temp_path.join("main.kdl"), main_content).unwrap();
+
+        let result = resolve_includes(&temp_path.join("main.kdl")).unwrap();
+
+        // Should resolve symlink and include content
+        assert!(result.content.contains("tap"));
+        assert!(result.content.contains("gaps 12"));
+
+        // Should track both main file and the canonical path (not the symlink path)
+        assert_eq!(result.included_files.len(), 2);
+        // Should include both main.kdl and actual_config.kdl (canonical path)
+        assert!(result
+            .included_files
+            .iter()
+            .any(|p| p.file_name().unwrap() == "main.kdl"));
+        assert!(result
+            .included_files
+            .iter()
+            .any(|p| p.file_name().unwrap() == "actual_config.kdl"));
+    }
+
+    #[test]
+    fn test_missing_included_file_error() {
+        let sh = Shell::new().unwrap();
+        let temp_dir = sh.create_temp_dir().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create a config that includes a non-existent file
+        let main_content = r#"
+include "nonexistent.kdl"
+layout {
+    gaps 10
+}
+"#;
+        fs::write(temp_path.join("main.kdl"), main_content).unwrap();
+
+        let result = resolve_includes(&temp_path.join("main.kdl"));
+
+        assert!(result.is_err());
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(err_msg.contains("nonexistent.kdl"));
+        // Should be a clear error about file not found
+        assert!(
+            err_msg.to_lowercase().contains("no such file")
+                || err_msg.to_lowercase().contains("not found")
+                || err_msg.to_lowercase().contains("failed to canonicalize")
+        );
+    }
+
+    #[test]
+    fn test_mixed_success_one_missing_file() {
+        let sh = Shell::new().unwrap();
+        let temp_dir = sh.create_temp_dir().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create a valid included file
+        let valid_content = r#"
+input {
+    keyboard {
+        repeat-rate 30
+    }
+}
+"#;
+        fs::write(temp_path.join("valid.kdl"), valid_content).unwrap();
+
+        // Create main config that includes one valid and one missing file
+        let main_content = r#"
+include "valid.kdl"
+include "missing.kdl"
+layout {
+    gaps 15
+}
+"#;
+        fs::write(temp_path.join("main.kdl"), main_content).unwrap();
+
+        let result = resolve_includes(&temp_path.join("main.kdl"));
+
+        assert!(result.is_err());
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(err_msg.contains("missing.kdl"));
+
+        // Should provide informative error about which file is missing
+        assert!(
+            err_msg.to_lowercase().contains("no such file")
+                || err_msg.to_lowercase().contains("not found")
+                || err_msg.to_lowercase().contains("failed to canonicalize")
+        );
+    }
+
+    #[test]
+    fn test_nested_missing_file_error() {
+        let sh = Shell::new().unwrap();
+        let temp_dir = sh.create_temp_dir().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create level1.kdl that tries to include a missing file
+        let level1_content = r#"
+include "missing_deep.kdl"
+layout {
+    gaps 25
+}
+"#;
+        fs::write(temp_path.join("level1.kdl"), level1_content).unwrap();
+
+        // Create main.kdl that includes level1.kdl
+        let main_content = r#"
+include "level1.kdl"
+input {
+    mouse {
+        accel-speed 0.3
+    }
+}
+"#;
+        fs::write(temp_path.join("main.kdl"), main_content).unwrap();
+
+        let result = resolve_includes(&temp_path.join("main.kdl"));
+
+        assert!(result.is_err());
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(err_msg.contains("missing_deep.kdl"));
+
+        // The error should mention the missing file
+        assert!(
+            err_msg.to_lowercase().contains("no such file")
+                || err_msg.to_lowercase().contains("not found")
+                || err_msg.to_lowercase().contains("failed to canonicalize")
+        );
+    }
+}

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use miette::miette;
+use niri_macros::Mergeable;
 use smithay::input::keyboard::XkbConfig;
 use smithay::reexports::input;
 
@@ -8,7 +9,7 @@ use crate::binds::Modifiers;
 use crate::utils::Percent;
 use crate::FloatOrInt;
 
-#[derive(knuffel::Decode, Debug, Default, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, PartialEq, Clone, Mergeable)]
 pub struct Input {
     #[knuffel(child, default)]
     pub keyboard: Keyboard,
@@ -38,7 +39,7 @@ pub struct Input {
     pub mod_key_nested: Option<ModKey>,
 }
 
-#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq, Clone, Mergeable)]
 pub struct Keyboard {
     #[knuffel(child, default)]
     pub xkb: Xkb,
@@ -65,7 +66,7 @@ impl Default for Keyboard {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Default, PartialEq, Eq, Clone)]
+#[derive(knuffel::Decode, Debug, Default, PartialEq, Eq, Clone, Mergeable)]
 pub struct Xkb {
     #[knuffel(child, unwrap(argument), default)]
     pub rules: String,
@@ -93,7 +94,7 @@ impl Xkb {
     }
 }
 
-#[derive(knuffel::DecodeScalar, Debug, Default, PartialEq, Eq)]
+#[derive(knuffel::DecodeScalar, Debug, Default, PartialEq, Eq, Clone, Mergeable)]
 pub enum TrackLayout {
     /// The layout change is global.
     #[default]
@@ -102,7 +103,7 @@ pub enum TrackLayout {
     Window,
 }
 
-#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Mergeable)]
 pub struct ScrollFactor {
     #[knuffel(argument)]
     pub base: Option<FloatOrInt<0, 100>>,
@@ -121,7 +122,7 @@ impl ScrollFactor {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Default, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, PartialEq, Clone, Mergeable)]
 pub struct Touchpad {
     #[knuffel(child)]
     pub off: bool,
@@ -161,7 +162,7 @@ pub struct Touchpad {
     pub scroll_factor: Option<ScrollFactor>,
 }
 
-#[derive(knuffel::Decode, Debug, Default, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, PartialEq, Clone, Mergeable)]
 pub struct Mouse {
     #[knuffel(child)]
     pub off: bool,
@@ -185,7 +186,7 @@ pub struct Mouse {
     pub scroll_factor: Option<ScrollFactor>,
 }
 
-#[derive(knuffel::Decode, Debug, Default, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, PartialEq, Clone, Mergeable)]
 pub struct Trackpoint {
     #[knuffel(child)]
     pub off: bool,
@@ -207,7 +208,7 @@ pub struct Trackpoint {
     pub middle_emulation: bool,
 }
 
-#[derive(knuffel::Decode, Debug, Default, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, PartialEq, Clone, Mergeable)]
 pub struct Trackball {
     #[knuffel(child)]
     pub off: bool,
@@ -229,7 +230,7 @@ pub struct Trackball {
     pub middle_emulation: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Mergeable)]
 pub enum ClickMethod {
     Clickfinger,
     ButtonAreas,
@@ -244,7 +245,7 @@ impl From<ClickMethod> for input::ClickMethod {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Mergeable)]
 pub enum AccelProfile {
     Adaptive,
     Flat,
@@ -259,7 +260,7 @@ impl From<AccelProfile> for input::AccelProfile {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Mergeable)]
 pub enum ScrollMethod {
     NoScroll,
     TwoFinger,
@@ -278,7 +279,7 @@ impl From<ScrollMethod> for input::ScrollMethod {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Mergeable)]
 pub enum TapButtonMap {
     LeftRightMiddle,
     LeftMiddleRight,
@@ -293,7 +294,7 @@ impl From<TapButtonMap> for input::TapButtonMap {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Default, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, PartialEq, Clone, Mergeable)]
 pub struct Tablet {
     #[knuffel(child)]
     pub off: bool,
@@ -305,7 +306,7 @@ pub struct Tablet {
     pub left_handed: bool,
 }
 
-#[derive(knuffel::Decode, Debug, Default, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, PartialEq, Clone, Mergeable)]
 pub struct Touch {
     #[knuffel(child)]
     pub off: bool,
@@ -313,19 +314,19 @@ pub struct Touch {
     pub map_to_output: Option<String>,
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct FocusFollowsMouse {
     #[knuffel(property, str)]
     pub max_scroll_amount: Option<Percent>,
 }
 
-#[derive(knuffel::Decode, Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq, Clone, Copy, Mergeable)]
 pub struct WarpMouseToFocus {
     #[knuffel(property, str)]
     pub mode: Option<WarpMouseToFocusMode>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Mergeable)]
 pub enum WarpMouseToFocusMode {
     CenterXy,
     CenterXyAlways,
@@ -345,7 +346,7 @@ impl FromStr for WarpMouseToFocusMode {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Mergeable)]
 pub enum ModKey {
     Ctrl,
     Shift,

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -7,7 +7,7 @@ use smithay::reexports::input;
 
 use crate::binds::Modifiers;
 use crate::utils::Percent;
-use crate::FloatOrInt;
+use crate::{FloatOrInt, MaybeSet};
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq, Clone, Mergeable)]
 pub struct Input {
@@ -44,10 +44,10 @@ pub struct Keyboard {
     #[knuffel(child, default)]
     pub xkb: Xkb,
     // The defaults were chosen to match wlroots and sway.
-    #[knuffel(child, unwrap(argument), default = Self::default().repeat_delay)]
-    pub repeat_delay: u16,
-    #[knuffel(child, unwrap(argument), default = Self::default().repeat_rate)]
-    pub repeat_rate: u8,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(600))]
+    pub repeat_delay: MaybeSet<u16>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(25))]
+    pub repeat_rate: MaybeSet<u8>,
     #[knuffel(child, unwrap(argument), default)]
     pub track_layout: TrackLayout,
     #[knuffel(child)]
@@ -58,11 +58,21 @@ impl Default for Keyboard {
     fn default() -> Self {
         Self {
             xkb: Default::default(),
-            repeat_delay: 600,
-            repeat_rate: 25,
+            repeat_delay: 600.into(),
+            repeat_rate: 25.into(),
             track_layout: Default::default(),
             numlock: Default::default(),
         }
+    }
+}
+
+impl Keyboard {
+    pub fn resolved_repeat_delay(&self) -> u16 {
+        *self.repeat_delay.value()
+    }
+
+    pub fn resolved_repeat_rate(&self) -> u8 {
+        *self.repeat_rate.value()
     }
 }
 

--- a/niri-config/src/layer_rule.rs
+++ b/niri-config/src/layer_rule.rs
@@ -1,7 +1,9 @@
+use niri_macros::Mergeable;
+
 use crate::appearance::{BlockOutFrom, CornerRadius, ShadowRule};
 use crate::utils::RegexEq;
 
-#[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, Clone, PartialEq, Mergeable)]
 pub struct LayerRule {
     #[knuffel(children(name = "match"))]
     pub matches: Vec<Match>,
@@ -22,7 +24,7 @@ pub struct LayerRule {
     pub baba_is_float: Option<bool>,
 }
 
-#[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, Clone, PartialEq, Mergeable)]
 pub struct Match {
     #[knuffel(property, str)]
     pub namespace: Option<RegexEq>,

--- a/niri-config/src/layout.rs
+++ b/niri-config/src/layout.rs
@@ -6,7 +6,7 @@ use crate::appearance::{
     Border, FocusRing, InsertHint, Shadow, TabIndicator, DEFAULT_BACKGROUND_COLOR,
 };
 use crate::utils::expect_only_children;
-use crate::{Color, FloatOrInt};
+use crate::{Color, FloatOrInt, MaybeSet};
 
 #[derive(knuffel::Decode, Debug, Clone, PartialEq, Mergeable)]
 pub struct Layout {
@@ -34,12 +34,12 @@ pub struct Layout {
     pub empty_workspace_above_first: bool,
     #[knuffel(child, unwrap(argument, str), default = Self::default().default_column_display)]
     pub default_column_display: ColumnDisplay,
-    #[knuffel(child, unwrap(argument), default = Self::default().gaps)]
-    pub gaps: FloatOrInt<0, 65535>,
+    #[knuffel(child, unwrap(argument), default = MaybeSet::unset(FloatOrInt(16.)))]
+    pub gaps: MaybeSet<FloatOrInt<0, 65535>>,
     #[knuffel(child, default)]
     pub struts: Struts,
-    #[knuffel(child, default = DEFAULT_BACKGROUND_COLOR)]
-    pub background_color: Color,
+    #[knuffel(child, default = MaybeSet::unset(DEFAULT_BACKGROUND_COLOR))]
+    pub background_color: MaybeSet<Color>,
 }
 
 impl Default for Layout {
@@ -56,10 +56,10 @@ impl Default for Layout {
             always_center_single_column: false,
             empty_workspace_above_first: false,
             default_column_display: ColumnDisplay::Normal,
-            gaps: FloatOrInt(16.),
+            gaps: FloatOrInt(16.).into(),
             struts: Default::default(),
             preset_window_heights: Default::default(),
-            background_color: DEFAULT_BACKGROUND_COLOR,
+            background_color: DEFAULT_BACKGROUND_COLOR.into(),
         }
     }
 }

--- a/niri-config/src/layout.rs
+++ b/niri-config/src/layout.rs
@@ -1,5 +1,6 @@
 use knuffel::errors::DecodeError;
 use niri_ipc::{ColumnDisplay, SizeChange};
+use niri_macros::Mergeable;
 
 use crate::appearance::{
     Border, FocusRing, InsertHint, Shadow, TabIndicator, DEFAULT_BACKGROUND_COLOR,
@@ -7,7 +8,7 @@ use crate::appearance::{
 use crate::utils::expect_only_children;
 use crate::{Color, FloatOrInt};
 
-#[derive(knuffel::Decode, Debug, Clone, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, PartialEq, Mergeable)]
 pub struct Layout {
     #[knuffel(child, default)]
     pub focus_ring: FocusRing,
@@ -63,7 +64,7 @@ impl Default for Layout {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Mergeable)]
 pub enum PresetSize {
     Proportion(#[knuffel(argument)] f64),
     Fixed(#[knuffel(argument)] i32),
@@ -78,10 +79,10 @@ impl From<PresetSize> for SizeChange {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Mergeable)]
 pub struct DefaultPresetSize(pub Option<PresetSize>);
 
-#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Mergeable)]
 pub struct Struts {
     #[knuffel(child, unwrap(argument), default)]
     pub left: FloatOrInt<-65535, 65535>,
@@ -93,7 +94,7 @@ pub struct Struts {
     pub bottom: FloatOrInt<-65535, 65535>,
 }
 
-#[derive(knuffel::DecodeScalar, Debug, Default, PartialEq, Eq, Clone, Copy)]
+#[derive(knuffel::DecodeScalar, Debug, Default, PartialEq, Eq, Clone, Copy, Mergeable)]
 pub enum CenterFocusedColumn {
     /// Focusing a column will not center the column.
     #[default]

--- a/niri-config/src/maybe_set.rs
+++ b/niri-config/src/maybe_set.rs
@@ -1,0 +1,406 @@
+use std::ops::{Deref, DerefMut};
+
+use knuffel::errors::DecodeError;
+
+use crate::mergeable::Mergeable;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MaybeSet<T> {
+    value: T,
+    is_set: bool,
+}
+
+impl<T> MaybeSet<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            value,
+            is_set: true,
+        }
+    }
+
+    pub fn unset(value: T) -> Self {
+        Self {
+            value,
+            is_set: false,
+        }
+    }
+
+    pub fn is_set(&self) -> bool {
+        self.is_set
+    }
+
+    pub fn get(&self) -> &T {
+        &self.value
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    pub fn value_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+
+    pub fn into_value(self) -> T {
+        self.value
+    }
+
+    pub fn set(&mut self, value: T) {
+        self.value = value;
+        self.is_set = true;
+    }
+
+    pub fn unset_self(&mut self) {
+        self.is_set = false;
+    }
+}
+
+impl<T: Default> Default for MaybeSet<T> {
+    fn default() -> Self {
+        Self::unset(T::default())
+    }
+}
+
+impl<T> Deref for MaybeSet<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for MaybeSet<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl<T> From<T> for MaybeSet<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<MaybeSet<u16>> for u64 {
+    fn from(maybe_set: MaybeSet<u16>) -> Self {
+        u64::from(maybe_set.value)
+    }
+}
+
+impl<T: Copy> Copy for MaybeSet<T> {}
+
+impl<T: Clone> Mergeable for MaybeSet<T> {
+    fn merge_with(&mut self, other: &Self) {
+        if other.is_set {
+            self.value = other.value.clone();
+            self.is_set = true;
+        }
+    }
+}
+
+impl<S, T> knuffel::Decode<S> for MaybeSet<T>
+where
+    S: knuffel::traits::ErrorSpan,
+    T: knuffel::Decode<S>,
+{
+    fn decode_node(
+        node: &knuffel::ast::SpannedNode<S>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        T::decode_node(node, ctx).map(Self::new)
+    }
+}
+
+/// Wrapper for boolean flags that marks bare flags as true
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BoolFlag(pub MaybeSet<bool>);
+
+impl Default for BoolFlag {
+    fn default() -> Self {
+        Self(MaybeSet::unset(false))
+    }
+}
+
+impl std::ops::Deref for BoolFlag {
+    type Target = bool;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+impl Mergeable for BoolFlag {
+    fn merge_with(&mut self, other: &Self) {
+        self.0.merge_with(&other.0);
+    }
+}
+
+impl<S> knuffel::Decode<S> for BoolFlag
+where
+    S: knuffel::traits::ErrorSpan,
+{
+    fn decode_node(
+        node: &knuffel::ast::SpannedNode<S>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        knuffel::decode::check_flag_node(node, ctx);
+        Ok(Self(MaybeSet::new(true)))
+    }
+}
+
+impl<S, T> knuffel::DecodeScalar<S> for MaybeSet<T>
+where
+    S: knuffel::traits::ErrorSpan,
+    T: knuffel::DecodeScalar<S>,
+{
+    fn type_check(
+        type_name: &Option<knuffel::span::Spanned<knuffel::ast::TypeName, S>>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) {
+        T::type_check(type_name, ctx);
+    }
+
+    fn raw_decode(
+        val: &knuffel::span::Spanned<knuffel::ast::Literal, S>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        T::raw_decode(val, ctx).map(Self::new)
+    }
+
+    fn decode(
+        val: &knuffel::ast::Value<S>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        T::decode(val, ctx).map(Self::new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_creates_set_value() {
+        let maybe_set = MaybeSet::new(42);
+        assert_eq!(*maybe_set, 42);
+        assert!(maybe_set.is_set());
+        assert_eq!(maybe_set.value(), &42);
+        assert_eq!(maybe_set.into_value(), 42);
+    }
+
+    #[test]
+    fn unset_creates_unset_value() {
+        let maybe_set = MaybeSet::unset(42);
+        assert_eq!(*maybe_set, 42);
+        assert!(!maybe_set.is_set());
+        assert_eq!(maybe_set.value(), &42);
+    }
+
+    #[test]
+    fn default_is_unset() {
+        let maybe_set: MaybeSet<i32> = MaybeSet::default();
+        assert_eq!(*maybe_set, 0);
+        assert!(!maybe_set.is_set());
+    }
+
+    #[test]
+    fn from_creates_set_value() {
+        let maybe_set: MaybeSet<i32> = 42.into();
+        assert_eq!(*maybe_set, 42);
+        assert!(maybe_set.is_set());
+    }
+
+    #[test]
+    fn deref_works() {
+        let maybe_set = MaybeSet::new(String::from("test"));
+        assert_eq!(maybe_set.len(), 4);
+        assert_eq!(&*maybe_set, "test");
+    }
+
+    #[test]
+    fn value_mut_works() {
+        let mut maybe_set = MaybeSet::new(42);
+        *maybe_set.value_mut() = 100;
+        assert_eq!(*maybe_set, 100);
+        assert!(maybe_set.is_set());
+    }
+
+    #[test]
+    fn set_marks_as_set() {
+        let mut maybe_set = MaybeSet::unset(0);
+        assert!(!maybe_set.is_set());
+
+        maybe_set.set(42);
+        assert_eq!(*maybe_set, 42);
+        assert!(maybe_set.is_set());
+    }
+
+    #[test]
+    fn unset_self_marks_as_unset() {
+        let mut maybe_set = MaybeSet::new(42);
+        assert!(maybe_set.is_set());
+
+        maybe_set.unset_self();
+        assert_eq!(*maybe_set, 42);
+        assert!(!maybe_set.is_set());
+    }
+
+    #[test]
+    fn equality_works() {
+        let set1 = MaybeSet::new(42);
+        let set2 = MaybeSet::new(42);
+        let unset1 = MaybeSet::unset(42);
+        let unset2 = MaybeSet::unset(42);
+
+        assert_eq!(set1, set2);
+        assert_eq!(unset1, unset2);
+        assert_ne!(set1, unset1);
+    }
+
+    #[test]
+    fn clone_works() {
+        let original = MaybeSet::new(String::from("test"));
+        let cloned = original.clone();
+
+        assert_eq!(original, cloned);
+        assert!(cloned.is_set());
+        assert_eq!(*cloned, "test");
+    }
+
+    #[test]
+    fn get_methods_work() {
+        let maybe_set = MaybeSet::new(42);
+        assert_eq!(maybe_set.get(), &42);
+        assert_eq!(maybe_set.into_inner(), 42);
+    }
+
+    #[test]
+    fn get_mut_methods_work() {
+        let mut maybe_set = MaybeSet::new(42);
+        *maybe_set.get_mut() = 100;
+        assert_eq!(*maybe_set, 100);
+        assert!(maybe_set.is_set());
+    }
+
+    #[test]
+    fn deref_mut_works() {
+        let mut maybe_set = MaybeSet::new(String::from("test"));
+        maybe_set.push_str("ing");
+        assert_eq!(&*maybe_set, "testing");
+        assert!(maybe_set.is_set());
+    }
+
+    #[test]
+    fn mergeable_only_merges_when_set() {
+        let mut base = MaybeSet::new(100);
+        let overlay_unset = MaybeSet::unset(200);
+        let overlay_set = MaybeSet::new(300);
+
+        // Merging unset value should not change base
+        base.merge_with(&overlay_unset);
+        assert_eq!(*base, 100);
+        assert!(base.is_set());
+
+        // Merging set value should update base
+        base.merge_with(&overlay_set);
+        assert_eq!(*base, 300);
+        assert!(base.is_set());
+    }
+
+    #[test]
+    fn mergeable_can_set_unset_value() {
+        let mut base = MaybeSet::unset(100);
+        let overlay = MaybeSet::new(200);
+
+        base.merge_with(&overlay);
+        assert_eq!(*base, 200);
+        assert!(base.is_set());
+    }
+
+    #[test]
+    fn mergeable_with_struct_preserves_explicitly_set_values() {
+        use niri_macros::Mergeable as MergeableDerive;
+
+        #[derive(Debug, PartialEq, Clone, MergeableDerive)]
+        struct TestStruct {
+            duration: MaybeSet<u32>,
+            name: MaybeSet<String>,
+        }
+
+        impl Default for TestStruct {
+            fn default() -> Self {
+                Self {
+                    duration: MaybeSet::unset(200),
+                    name: MaybeSet::unset("default".to_string()),
+                }
+            }
+        }
+
+        // Start with defaults (all unset)
+        let mut base = TestStruct::default();
+        assert!(!base.duration.is_set());
+        assert!(!base.name.is_set());
+        assert_eq!(*base.duration, 200);
+        assert_eq!(*base.name, "default");
+
+        // First config sets duration explicitly
+        let overlay1 = TestStruct {
+            duration: MaybeSet::new(500),
+            name: MaybeSet::unset("default".to_string()),
+        };
+
+        base.merge_with(&overlay1);
+        assert!(base.duration.is_set());
+        assert!(!base.name.is_set());
+        assert_eq!(*base.duration, 500);
+        assert_eq!(*base.name, "default");
+
+        // Second config sets name explicitly but NOT duration
+        let overlay2 = TestStruct {
+            duration: MaybeSet::unset(999),
+            name: MaybeSet::new("custom".to_string()),
+        };
+
+        base.merge_with(&overlay2);
+        // Duration should stay 500 (previously set, new config didn't override)
+        assert!(base.duration.is_set());
+        assert_eq!(*base.duration, 500);
+
+        // Name should be updated to custom
+        assert!(base.name.is_set());
+        assert_eq!(*base.name, "custom");
+    }
+
+    #[test]
+    fn mergeable_with_struct_can_override_set_values() {
+        use niri_macros::Mergeable as MergeableDerive;
+
+        #[derive(Debug, PartialEq, Clone, MergeableDerive)]
+        struct TestStruct {
+            duration: MaybeSet<u32>,
+            name: MaybeSet<String>,
+        }
+
+        let mut base = TestStruct {
+            duration: MaybeSet::new(500),
+            name: MaybeSet::new("base".to_string()),
+        };
+
+        let overlay = TestStruct {
+            duration: MaybeSet::new(1000),
+            name: MaybeSet::unset("ignored".to_string()),
+        };
+
+        base.merge_with(&overlay);
+        assert_eq!(*base.duration, 1000); // Overridden
+        assert_eq!(*base.name, "base"); // Preserved
+    }
+}

--- a/niri-config/src/mergeable.rs
+++ b/niri-config/src/mergeable.rs
@@ -1,0 +1,222 @@
+pub trait Mergeable: Clone {
+    fn merge_with(&mut self, other: &Self);
+}
+
+impl<T: Mergeable + Clone> Mergeable for Option<T> {
+    fn merge_with(&mut self, other: &Self) {
+        match (self, other) {
+            (Some(s), Some(o)) => s.merge_with(o),
+            (s @ None, Some(o)) => *s = Some(o.clone()),
+            _ => {}
+        }
+    }
+}
+
+impl<T: Clone> Mergeable for Vec<T> {
+    fn merge_with(&mut self, other: &Self) {
+        self.extend_from_slice(other);
+    }
+}
+
+impl Mergeable for bool {
+    fn merge_with(&mut self, other: &Self) {
+        *self = *other;
+    }
+}
+
+impl Mergeable for String {
+    fn merge_with(&mut self, other: &Self) {
+        self.clone_from(other);
+    }
+}
+
+impl Mergeable for u16 {
+    fn merge_with(&mut self, other: &Self) {
+        *self = *other;
+    }
+}
+
+impl Mergeable for u32 {
+    fn merge_with(&mut self, other: &Self) {
+        *self = *other;
+    }
+}
+
+impl Mergeable for i16 {
+    fn merge_with(&mut self, other: &Self) {
+        *self = *other;
+    }
+}
+
+impl Mergeable for i32 {
+    fn merge_with(&mut self, other: &Self) {
+        *self = *other;
+    }
+}
+
+impl Mergeable for f32 {
+    fn merge_with(&mut self, other: &Self) {
+        *self = *other;
+    }
+}
+
+impl Mergeable for f64 {
+    fn merge_with(&mut self, other: &Self) {
+        *self = *other;
+    }
+}
+
+impl Mergeable for u8 {
+    fn merge_with(&mut self, other: &Self) {
+        *self = *other;
+    }
+}
+
+impl Mergeable for std::path::PathBuf {
+    fn merge_with(&mut self, other: &Self) {
+        self.clone_from(other);
+    }
+}
+
+impl Mergeable for crate::utils::Percent {
+    fn merge_with(&mut self, other: &Self) {
+        self.0 = other.0;
+    }
+}
+
+impl Mergeable for crate::utils::RegexEq {
+    fn merge_with(&mut self, other: &Self) {
+        self.0 = other.0.clone();
+    }
+}
+
+impl Mergeable for niri_ipc::ColumnDisplay {
+    fn merge_with(&mut self, other: &Self) {
+        *self = *other;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use niri_macros::Mergeable;
+
+    use super::*;
+
+    #[test]
+    fn test_vec_mergeable() {
+        let mut base = vec![1, 2, 3];
+        let overlay = vec![4, 5];
+
+        base.merge_with(&overlay);
+        assert_eq!(base, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_option_mergeable() {
+        let mut base: Option<i32> = None;
+        let overlay: Option<i32> = Some(42);
+
+        base.merge_with(&overlay);
+        assert_eq!(base, Some(42));
+
+        let mut base = Some(10);
+        let overlay = Some(20);
+
+        base.merge_with(&overlay);
+        assert_eq!(base, Some(20));
+
+        let mut base = Some(10);
+        let overlay = None;
+
+        base.merge_with(&overlay);
+        assert_eq!(base, Some(10));
+    }
+
+    #[test]
+    fn test_basic_types_mergeable() {
+        let mut base = false;
+        let overlay = true;
+        base.merge_with(&overlay);
+        assert_eq!(base, true);
+
+        let mut base = 10u32;
+        let overlay = 20u32;
+        base.merge_with(&overlay);
+        assert_eq!(base, 20);
+
+        let mut base = String::from("hello");
+        let overlay = String::from("world");
+        base.merge_with(&overlay);
+        assert_eq!(base, "world");
+    }
+
+    #[test]
+    fn test_nested_option_mergeable() {
+        #[derive(Debug, PartialEq, Clone, Default, Mergeable)]
+        struct TestStruct {
+            value: i32,
+        }
+
+        let mut base: Option<TestStruct> = None;
+        let overlay: Option<TestStruct> = Some(TestStruct { value: 42 });
+
+        base.merge_with(&overlay);
+        assert_eq!(base, Some(TestStruct { value: 42 }));
+
+        let mut base = Some(TestStruct { value: 10 });
+        let overlay = Some(TestStruct { value: 20 });
+
+        base.merge_with(&overlay);
+        assert_eq!(base, Some(TestStruct { value: 20 }));
+    }
+
+    #[test]
+    fn test_complex_nested_merging() {
+        #[derive(Debug, PartialEq, Clone, Default, Mergeable)]
+        struct InnerStruct {
+            name: String,
+            values: Vec<i32>,
+            maybe_flag: Option<bool>,
+        }
+
+        #[derive(Debug, PartialEq, Clone, Default, Mergeable)]
+        struct OuterStruct {
+            inner: InnerStruct,
+            optional_inner: Option<InnerStruct>,
+        }
+
+        let mut base = OuterStruct {
+            inner: InnerStruct {
+                name: "base".to_string(),
+                values: vec![1, 2],
+                maybe_flag: None,
+            },
+            optional_inner: None,
+        };
+
+        let overlay = OuterStruct {
+            inner: InnerStruct {
+                name: "overlay".to_string(),
+                values: vec![3, 4],
+                maybe_flag: Some(true),
+            },
+            optional_inner: Some(InnerStruct {
+                name: "optional".to_string(),
+                values: vec![5, 6],
+                maybe_flag: Some(false),
+            }),
+        };
+
+        base.merge_with(&overlay);
+
+        assert_eq!(base.inner.name, "overlay");
+        assert_eq!(base.inner.values, vec![1, 2, 3, 4]);
+        assert_eq!(base.inner.maybe_flag, Some(true));
+
+        assert!(base.optional_inner.is_some());
+        let optional = base.optional_inner.unwrap();
+        assert_eq!(optional.name, "optional");
+        assert_eq!(optional.values, vec![5, 6]);
+        assert_eq!(optional.maybe_flag, Some(false));
+    }
+}

--- a/niri-config/src/utils.rs
+++ b/niri-config/src/utils.rs
@@ -4,12 +4,20 @@ use knuffel::errors::DecodeError;
 use miette::miette;
 use regex::Regex;
 
+use crate::mergeable::Mergeable;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Percent(pub f64);
 
 // MIN and MAX generics are only used during parsing to check the value.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct FloatOrInt<const MIN: i32, const MAX: i32>(pub f64);
+
+impl<const MIN: i32, const MAX: i32> Mergeable for FloatOrInt<MIN, MAX> {
+    fn merge_with(&mut self, other: &Self) {
+        self.0 = other.0;
+    }
+}
 
 /// `Regex` that implements `PartialEq` by its string form.
 #[derive(Debug, Clone)]

--- a/niri-config/tests/wiki-parses.rs
+++ b/niri-config/tests/wiki-parses.rs
@@ -84,6 +84,11 @@ fn wiki_docs_parses() {
         must_fail,
     } in code_blocks
     {
+        // Skip code blocks that contain include directives since they require file resolution
+        if code.trim_start().starts_with("include ") || code.contains("\ninclude ") {
+            continue;
+        }
+
         if let Err(error) = niri_config::Config::parse(&filename, &code) {
             if !must_fail {
                 errors.push(format!(

--- a/niri-macros/Cargo.toml
+++ b/niri-macros/Cargo.toml
@@ -13,4 +13,3 @@ proc-macro = true
 [dependencies]
 syn = "2.0"
 quote = "1.0"
-proc-macro2 = "1.0"

--- a/niri-macros/Cargo.toml
+++ b/niri-macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "niri-macros"
+version.workspace = true
+description = "Procedural macros for niri"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2.0"
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/niri-macros/src/lib.rs
+++ b/niri-macros/src/lib.rs
@@ -1,0 +1,147 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields, Ident};
+
+#[proc_macro_derive(Mergeable, attributes(mergeable))]
+pub fn derive_mergeable(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let merge_body = match &input.data {
+        Data::Struct(data) => {
+            match &data.fields {
+                Fields::Named(fields) => {
+                    // Find all mutex fields
+                    let mutex_fields: Vec<&Ident> = fields
+                        .named
+                        .iter()
+                        .filter_map(|f| {
+                            let is_mutex = f.attrs.iter().any(|attr| {
+                                if attr.path().is_ident("mergeable") {
+                                    // Parse the attribute contents
+                                    let mut is_mutex_attr = false;
+                                    let _ = attr.parse_nested_meta(|meta| {
+                                        if meta.path.is_ident("mutex") {
+                                            is_mutex_attr = true;
+                                        }
+                                        Ok(())
+                                    });
+                                    return is_mutex_attr;
+                                }
+                                false
+                            });
+
+                            if is_mutex {
+                                f.ident.as_ref()
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+
+                    // Generate merge code for each field
+                    let field_merges = fields.named.iter().map(|f| {
+                        let field_name = &f.ident;
+                        let field_name_ref = field_name.as_ref().unwrap();
+
+                        // Check if this field is marked as mutex
+                        let is_mutex_field = mutex_fields.contains(&field_name_ref);
+
+                        if is_mutex_field {
+                            // Check if this field is a BoolFlag or plain bool
+                            let field_type = &f.ty;
+                            let is_bool_flag = match field_type {
+                                syn::Type::Path(type_path) => type_path
+                                    .path
+                                    .segments
+                                    .last()
+                                    .map(|seg| seg.ident == "BoolFlag")
+                                    .unwrap_or(false),
+                                _ => false,
+                            };
+
+                            let is_bool = match field_type {
+                                syn::Type::Path(type_path) => type_path
+                                    .path
+                                    .segments
+                                    .last()
+                                    .map(|seg| seg.ident == "bool")
+                                    .unwrap_or(false),
+                                _ => false,
+                            };
+
+                            if is_bool_flag {
+                                quote! {
+                                    self.#field_name.merge_with(&other.#field_name);
+                                }
+                            } else if is_bool {
+                                if mutex_fields.len() == 1 {
+                                    quote! {
+                                        self.#field_name = other.#field_name;
+                                    }
+                                } else {
+                                    let other_mutex_fields = mutex_fields
+                                        .iter()
+                                        .filter(|&&other_field| other_field != field_name_ref)
+                                        .map(|&other_field| {
+                                            quote! {
+                                                self.#other_field = false;
+                                            }
+                                        });
+
+                                    quote! {
+                                        if other.#field_name {
+                                            self.#field_name = true;
+                                            #(#other_mutex_fields)*
+                                        }
+                                    }
+                                }
+                            } else {
+                                return quote! {
+                                    compile_error!(concat!("#[mergeable(mutex)] can only be used on bool or BoolFlag fields, but field '", stringify!(#field_name), "' has a different type"));
+                                };
+                            }
+                        } else {
+                            quote! {
+                                self.#field_name.merge_with(&other.#field_name);
+                            }
+                        }
+                    });
+
+                    quote! {
+                        #(#field_merges)*
+                    }
+                }
+                Fields::Unnamed(fields) => {
+                    let field_merges = (0..fields.unnamed.len()).map(|i| {
+                        let idx = syn::Index::from(i);
+                        quote! {
+                            self.#idx.merge_with(&other.#idx);
+                        }
+                    });
+                    quote! {
+                        #(#field_merges)*
+                    }
+                }
+                Fields::Unit => quote! {},
+            }
+        }
+        Data::Enum(_) => {
+            quote! {
+                *self = other.clone();
+            }
+        }
+        Data::Union(_) => panic!("Unions are not supported for Mergeable derive"),
+    };
+
+    let expanded = quote! {
+        impl #impl_generics crate::mergeable::Mergeable for #name #ty_generics #where_clause {
+            fn merge_with(&mut self, other: &Self) {
+                #merge_body
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/niri-visual-tests/src/cases/gradient_area.rs
+++ b/niri-visual-tests/src/cases/gradient_area.rs
@@ -19,11 +19,11 @@ pub struct GradientArea {
 impl GradientArea {
     pub fn new(_args: Args) -> Self {
         let border = FocusRing::new(niri_config::FocusRing {
-            off: false,
-            width: FloatOrInt(1.),
-            active_color: Color::from_rgba8_unpremul(255, 255, 255, 128),
-            inactive_color: Color::default(),
-            urgent_color: Color::default(),
+            off: false.into(),
+            width: FloatOrInt(1.).into(),
+            active_color: Color::from_rgba8_unpremul(255, 255, 255, 128).into(),
+            inactive_color: Color::default().into(),
+            urgent_color: Color::default().into(),
             active_gradient: None,
             inactive_gradient: None,
             urgent_gradient: None,

--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -53,15 +53,15 @@ impl Layout {
 
         let options = Options {
             focus_ring: niri_config::FocusRing {
-                off: true,
+                off: true.into(),
                 ..Default::default()
             },
             border: niri_config::Border {
-                off: false,
-                width: FloatOrInt(4.),
-                active_color: Color::from_rgba8_unpremul(255, 163, 72, 255),
-                inactive_color: Color::from_rgba8_unpremul(50, 50, 50, 255),
-                urgent_color: Color::from_rgba8_unpremul(155, 0, 0, 255),
+                off: false.into(),
+                width: FloatOrInt(4.).into(),
+                active_color: Color::from_rgba8_unpremul(255, 163, 72, 255).into(),
+                inactive_color: Color::from_rgba8_unpremul(50, 50, 50, 255).into(),
+                urgent_color: Color::from_rgba8_unpremul(155, 0, 0, 255).into(),
                 active_gradient: None,
                 inactive_gradient: None,
                 urgent_gradient: None,

--- a/niri-visual-tests/src/cases/tile.rs
+++ b/niri-visual-tests/src/cases/tile.rs
@@ -59,13 +59,13 @@ impl Tile {
 
         let options = Options {
             focus_ring: niri_config::FocusRing {
-                off: true,
+                off: true.into(),
                 ..Default::default()
             },
             border: niri_config::Border {
-                off: false,
-                width: FloatOrInt(32.),
-                active_color: Color::from_rgba8_unpremul(255, 163, 72, 255),
+                off: false.into(),
+                width: FloatOrInt(32.).into(),
+                active_color: Color::from_rgba8_unpremul(255, 163, 72, 255).into(),
                 ..Default::default()
             },
             ..Default::default()

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -206,7 +206,7 @@ impl Winit {
 
         let rv;
         if let Some(damage) = res.damage {
-            if self
+            if *self
                 .config
                 .borrow()
                 .debug

--- a/src/dbus/freedesktop_a11y.rs
+++ b/src/dbus/freedesktop_a11y.rs
@@ -450,7 +450,8 @@ impl State {
         });
 
         let config = self.niri.config.borrow();
-        let repeat_delay = Duration::from_millis(u64::from(config.input.keyboard.repeat_delay));
+        let repeat_delay =
+            Duration::from_millis(u64::from(config.input.keyboard.resolved_repeat_delay()));
         let released = state == KeyState::Released;
 
         let Some(monitor) = &self.niri.a11y_keyboard_monitor else {

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -63,7 +63,7 @@ impl DBusServers {
             dbus.conn_service_channel = try_start(service_channel);
         }
 
-        if is_session_instance || config.debug.dbus_interfaces_in_non_session_instances {
+        if is_session_instance || *config.debug.dbus_interfaces_in_non_session_instances {
             let (to_niri, from_display_config) = calloop::channel::channel();
             let display_config = DisplayConfig::new(to_niri, backend.ipc_outputs());
             niri.event_loop

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -144,7 +144,7 @@ impl CompositorHandler for State {
                             ActivateWindow::Yes
                         } else {
                             let config = self.niri.config.borrow();
-                            if config.debug.strict_new_window_focus_policy {
+                            if *config.debug.strict_new_window_focus_policy {
                                 ActivateWindow::No
                             } else {
                                 ActivateWindow::Smart

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -765,7 +765,7 @@ impl XdgActivationHandler for State {
         // notification daemon, but alas they ignore it. Maybe in the future the clients are fixed,
         // and we can remove this debug flag.
         let config = self.niri.config.borrow();
-        if config.debug.honor_xdg_activation_with_invalid_serial {
+        if *config.debug.honor_xdg_activation_with_invalid_serial {
             return true;
         }
 

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -1275,7 +1275,7 @@ pub fn add_mapped_toplevel_pre_commit_hook(toplevel: &ToplevelSurface) -> HookId
             if let Some(transaction) = mapped.take_pending_transaction(serial) {
                 // Transaction can be already completed if it ran past the deadline.
                 let disable = state.niri.config.borrow().debug.disable_transactions;
-                if !transaction.is_completed() && !disable {
+                if !transaction.is_completed() && !*disable {
                     // Register the deadline even if this is the last pending, since dmabuf
                     // rendering can still run over the deadline.
                     transaction.register_deadline_timer(&state.niri.event_loop);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -470,14 +470,15 @@ impl State {
         let config = self.niri.config.borrow();
         let config = &config.input.keyboard;
 
-        let repeat_rate = config.repeat_rate;
+        let repeat_rate = config.resolved_repeat_rate();
         if repeat_rate == 0 {
             return;
         }
         let repeat_duration = Duration::from_secs_f64(1. / f64::from(repeat_rate));
 
-        let repeat_timer =
-            Timer::from_duration(Duration::from_millis(u64::from(config.repeat_delay)));
+        let repeat_timer = Timer::from_duration(Duration::from_millis(u64::from(
+            config.resolved_repeat_delay(),
+        )));
 
         let token = self
             .niri

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -60,7 +60,7 @@ impl MappedLayer {
     ) -> Self {
         let mut shadow_config = config.layout.shadow;
         // Shadows for layer surfaces need to be explicitly enabled.
-        shadow_config.on = false;
+        shadow_config.on = false.into();
         let shadow_config = rules.shadow.resolve_against(shadow_config);
 
         Self {
@@ -77,7 +77,7 @@ impl MappedLayer {
     pub fn update_config(&mut self, config: &Config) {
         let mut shadow_config = config.layout.shadow;
         // Shadows for layer surfaces need to be explicitly enabled.
-        shadow_config.on = false;
+        shadow_config.on = false.into();
         let shadow_config = self.rules.shadow.resolve_against(shadow_config);
         self.shadow.update_config(shadow_config);
     }

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -1,5 +1,5 @@
 use niri_config::layer_rule::{LayerRule, Match};
-use niri_config::{BlockOutFrom, CornerRadius, ShadowRule};
+use niri_config::{BlockOutFrom, CornerRadius, Mergeable, ShadowRule};
 use smithay::desktop::LayerSurface;
 
 pub mod mapped;

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1226,7 +1226,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
                 let size = match resolve_preset_size(size, working_area_size) {
                     ResolvedSize::Tile(mut size) => {
                         if !border.off {
-                            size -= border.width.0 * 2.;
+                            size -= border.width.value().0 * 2.;
                         }
                         size
                     }
@@ -1364,7 +1364,7 @@ fn compute_toplevel_bounds(
 ) -> Size<i32, Logical> {
     let mut border = 0.;
     if !border_config.off {
-        border = border_config.width.0 * 2.;
+        border = border_config.width.value().0 * 2.;
     }
 
     Size::from((

--- a/src/layout/focus_ring.rs
+++ b/src/layout/focus_ring.rs
@@ -65,7 +65,7 @@ impl FocusRing {
         scale: f64,
         alpha: f32,
     ) {
-        let width = self.config.width.0;
+        let width = self.config.width.value().0;
         self.full_size = win_size + Size::from((width, width)).upscale(2.);
 
         let color = if is_urgent {
@@ -77,7 +77,7 @@ impl FocusRing {
         };
 
         for buf in &mut self.buffers {
-            buf.set_color(color.to_array_premul());
+            buf.set_color(color.value().to_array_premul());
         }
 
         let radius = radius.fit_to(self.full_size.w as f32, self.full_size.h as f32);
@@ -93,7 +93,7 @@ impl FocusRing {
         self.use_border_shader = radius != CornerRadius::default() || gradient.is_some();
 
         // Set the defaults for solid color + rounded corners.
-        let gradient = gradient.unwrap_or_else(|| Gradient::from(*color));
+        let gradient = gradient.unwrap_or_else(|| Gradient::from(*color.value()));
 
         let full_rect = Rectangle::new(Point::from((-width, -width)), self.full_size);
         let gradient_area = match gradient.relative_to {
@@ -261,7 +261,7 @@ impl FocusRing {
     }
 
     pub fn width(&self) -> f64 {
-        self.config.width.0
+        self.config.width.value().0
     }
 
     pub fn is_off(&self) -> bool {

--- a/src/layout/focus_ring.rs
+++ b/src/layout/focus_ring.rs
@@ -93,7 +93,7 @@ impl FocusRing {
         self.use_border_shader = radius != CornerRadius::default() || gradient.is_some();
 
         // Set the defaults for solid color + rounded corners.
-        let gradient = gradient.unwrap_or_else(|| Gradient::from(color));
+        let gradient = gradient.unwrap_or_else(|| Gradient::from(*color));
 
         let full_rect = Rectangle::new(Point::from((-width, -width)), self.full_size);
         let gradient_area = match gradient.relative_to {
@@ -221,7 +221,7 @@ impl FocusRing {
     ) -> impl Iterator<Item = FocusRingRenderElement> {
         let mut rv = ArrayVec::<_, 8>::new();
 
-        if self.config.off {
+        if *self.config.off {
             return rv.into_iter();
         }
 
@@ -265,7 +265,7 @@ impl FocusRing {
     }
 
     pub fn is_off(&self) -> bool {
-        self.config.off
+        *self.config.off
     }
 
     pub fn config(&self) -> &niri_config::FocusRing {

--- a/src/layout/insert_hint_element.rs
+++ b/src/layout/insert_hint_element.rs
@@ -16,7 +16,7 @@ impl InsertHintElement {
         Self {
             inner: FocusRing::new(niri_config::FocusRing {
                 off: config.off,
-                width: FloatOrInt(0.),
+                width: FloatOrInt(0.).into(),
                 active_color: config.color,
                 inactive_color: config.color,
                 urgent_color: config.color,
@@ -30,7 +30,7 @@ impl InsertHintElement {
     pub fn update_config(&mut self, config: niri_config::InsertHint) {
         self.inner.update_config(niri_config::FocusRing {
             off: config.off,
-            width: FloatOrInt(0.),
+            width: FloatOrInt(0.).into(),
             active_color: config.color,
             inactive_color: config.color,
             urgent_color: config.color,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -641,7 +641,7 @@ impl Options {
             .unwrap_or(Some(PresetSize::Proportion(0.5)));
 
         Self {
-            gaps: layout.gaps.0,
+            gaps: layout.gaps.value().0,
             struts: layout.struts,
             focus_ring: layout.focus_ring,
             border: layout.border,
@@ -668,8 +668,8 @@ impl Options {
         let round = |logical: f64| round_logical_in_physical_max1(scale, logical);
 
         self.gaps = round(self.gaps);
-        self.focus_ring.width = FloatOrInt(round(self.focus_ring.width.0)).into();
-        self.border.width = FloatOrInt(round(self.border.width.0)).into();
+        self.focus_ring.width = FloatOrInt(round(self.focus_ring.width.value().0)).into();
+        self.border.width = FloatOrInt(round(self.border.width.value().0)).into();
 
         self
     }
@@ -5265,7 +5265,7 @@ impl<W: LayoutElement> Layout<W> {
                 let rules = window.rules();
                 let border = rules.border.resolve_against(self.options.border);
                 if !border.off {
-                    fixed += border.width.0 * 2.;
+                    fixed += border.width.value().0 * 2.;
                 }
 
                 ColumnWidth::Fixed(fixed)

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -657,9 +657,9 @@ impl Options {
             animations: config.animations.clone(),
             gestures: config.gestures,
             overview: config.overview,
-            disable_resize_throttling: config.debug.disable_resize_throttling,
-            disable_transactions: config.debug.disable_transactions,
-            deactivate_unfocused_windows: config.debug.deactivate_unfocused_windows,
+            disable_resize_throttling: *config.debug.disable_resize_throttling,
+            disable_transactions: *config.debug.disable_transactions,
+            deactivate_unfocused_windows: *config.debug.deactivate_unfocused_windows,
             preset_window_heights,
         }
     }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -668,8 +668,8 @@ impl Options {
         let round = |logical: f64| round_logical_in_physical_max1(scale, logical);
 
         self.gaps = round(self.gaps);
-        self.focus_ring.width = FloatOrInt(round(self.focus_ring.width.0));
-        self.border.width = FloatOrInt(round(self.border.width.0));
+        self.focus_ring.width = FloatOrInt(round(self.focus_ring.width.0)).into();
+        self.border.width = FloatOrInt(round(self.border.width.0)).into();
 
         self
     }

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -1724,7 +1724,7 @@ impl<W: LayoutElement> Monitor<W> {
         };
 
         let config = &self.options.gestures.dnd_edge_workspace_switch;
-        let trigger_height = config.trigger_height.0;
+        let trigger_height = config.resolved_trigger_height().0;
 
         // Restrict the scrolling horizontally to the strip of workspaces to avoid unwanted trigger
         // after using the hot corner or during horizontal scroll.
@@ -1771,14 +1771,14 @@ impl<W: LayoutElement> Monitor<W> {
 
         // Delay starting the gesture a bit to avoid unwanted movement when dragging across
         // monitors.
-        let delay = Duration::from_millis(u64::from(config.delay_ms));
+        let delay = Duration::from_millis(u64::from(config.resolved_delay_ms()));
         if now.saturating_sub(nonzero_start) < delay {
             return true;
         }
 
         let time_delta = now.saturating_sub(last_time).as_secs_f64();
 
-        let delta = delta * time_delta * config.max_speed.0;
+        let delta = delta * time_delta * config.resolved_max_speed().0;
 
         gesture.tracker.push(delta, now);
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -3033,14 +3033,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         // Delay starting the gesture a bit to avoid unwanted movement when dragging across
         // monitors.
-        let delay = Duration::from_millis(u64::from(config.delay_ms));
+        let delay = Duration::from_millis(u64::from(config.resolved_delay_ms()));
         if now.saturating_sub(nonzero_start) < delay {
             return true;
         }
 
         let time_delta = now.saturating_sub(last_time).as_secs_f64();
 
-        let delta = delta * time_delta * config.max_speed.0;
+        let delta = delta * time_delta * config.resolved_max_speed().0;
 
         gesture.tracker.push(delta, now);
 
@@ -3831,7 +3831,7 @@ impl<W: LayoutElement> Column<W> {
 
         // Animate the tab indicator for new columns.
         if display_mode == ColumnDisplay::Tabbed
-            && !rv.options.tab_indicator.hide_when_single_tab
+            && !*rv.options.tab_indicator.hide_when_single_tab
             && !rv.is_fullscreen()
         {
             // Usually new columns are created together with window movement actions. For new
@@ -5090,7 +5090,7 @@ impl<W: LayoutElement> Column<W> {
                 if self.display_mode == ColumnDisplay::Tabbed
                     && !self.is_fullscreen()
                     && self.tiles.len() == 1
-                    && !self.tab_indicator.config().hide_when_single_tab
+                    && !*self.tab_indicator.config().hide_when_single_tab
                 {
                     self.tab_indicator.start_open_animation(
                         self.clock.clone(),

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -487,7 +487,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             let size = match resolve_preset_size(size, &self.options, working_size.w, extra.w) {
                 ResolvedSize::Tile(mut size) => {
                     if !border.off {
-                        size -= border.width.0 * 2.;
+                        size -= border.width.value().0 * 2.;
                     }
                     size
                 }
@@ -501,14 +501,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let mut full_height = self.working_area.size.h - self.options.gaps * 2.;
         if !border.off {
-            full_height -= border.width.0 * 2.;
+            full_height -= border.width.value().0 * 2.;
         }
 
         let height = if let Some(height) = height {
             let height = match resolve_preset_size(height, &self.options, working_size.h, extra.h) {
                 ResolvedSize::Tile(mut size) => {
                     if !border.off {
-                        size -= border.width.0 * 2.;
+                        size -= border.width.value().0 * 2.;
                     }
                     size
                 }
@@ -5279,7 +5279,7 @@ fn compute_toplevel_bounds(
 ) -> Size<i32, Logical> {
     let mut border = 0.;
     if !border_config.off {
-        border = border_config.width.0 * 2.;
+        border = border_config.width.value().0 * 2.;
     }
 
     Size::from((

--- a/src/layout/shadow.rs
+++ b/src/layout/shadow.rs
@@ -54,7 +54,7 @@ impl Shadow {
         // Adjust width to draw all necessary pixels.
         let width = ceil(sigma * 3.);
 
-        let offset = self.config.offset;
+        let offset = *self.config.offset;
         let offset = Point::from((ceil(offset.x.0), ceil(offset.y.0)));
 
         let spread = self.config.spread.0;
@@ -74,12 +74,12 @@ impl Shadow {
         let shader_size = box_size + Size::from((width, width)).upscale(2.);
 
         let color = if is_active {
-            self.config.color
+            *self.config.color
         } else {
             // Default to slightly more transparent.
             self.config
                 .inactive_color
-                .unwrap_or(self.config.color * 0.75)
+                .unwrap_or(*self.config.color * 0.75)
         };
 
         let shader_geo = Rectangle::new(Point::from((-width, -width)), shader_size);

--- a/src/layout/shadow.rs
+++ b/src/layout/shadow.rs
@@ -48,16 +48,16 @@ impl Shadow {
         // * We do not divide anything, only add, subtract and multiply by integers.
         // * At rendering time, tile positions are rounded to physical pixels.
 
-        let width = self.config.softness.0;
+        let width = self.config.softness.value().0;
         // Like in CSS box-shadow.
         let sigma = width / 2.;
         // Adjust width to draw all necessary pixels.
         let width = ceil(sigma * 3.);
 
-        let offset = *self.config.offset;
+        let offset = *self.config.offset.value();
         let offset = Point::from((ceil(offset.x.0), ceil(offset.y.0)));
 
-        let spread = self.config.spread.0;
+        let spread = self.config.spread.value().0;
         let spread = ceil(spread.abs()).copysign(spread);
         let offset = offset - Point::from((spread, spread));
 
@@ -74,12 +74,12 @@ impl Shadow {
         let shader_size = box_size + Size::from((width, width)).upscale(2.);
 
         let color = if is_active {
-            *self.config.color
+            *self.config.color.value()
         } else {
             // Default to slightly more transparent.
             self.config
                 .inactive_color
-                .unwrap_or(*self.config.color * 0.75)
+                .unwrap_or(*self.config.color.value() * 0.75)
         };
 
         let shader_geo = Rectangle::new(Point::from((-width, -width)), shader_size);

--- a/src/layout/tab_indicator.rs
+++ b/src/layout/tab_indicator.rs
@@ -88,7 +88,7 @@ impl TabIndicator {
         let gap = round_max1(gap.abs()).copysign(gap);
         let gaps_between = round_max1(self.config.gaps_between_tabs.0);
 
-        let position = self.config.position;
+        let position = *self.config.position;
         let side = match position {
             TabIndicatorPosition::Left | TabIndicatorPosition::Right => area.size.h,
             TabIndicatorPosition::Top | TabIndicatorPosition::Bottom => area.size.w,
@@ -168,14 +168,14 @@ impl TabIndicator {
         is_active: bool,
         scale: f64,
     ) {
-        if !enabled || self.config.off {
+        if !enabled || *self.config.off {
             self.shader_locs.clear();
             self.shaders.clear();
             return;
         }
 
         let count = tab_count;
-        if self.config.hide_when_single_tab && count == 1 {
+        if *self.config.hide_when_single_tab && count == 1 {
             self.shader_locs.clear();
             self.shaders.clear();
             return;
@@ -184,7 +184,7 @@ impl TabIndicator {
         self.shaders.resize_with(count, Default::default);
         self.shader_locs.resize_with(count, Default::default);
 
-        let position = self.config.position;
+        let position = *self.config.position;
         let radius = self.config.corner_radius.0 as f32;
         let shared_rounded_corners = self.config.gaps_between_tabs.0 == 0.;
         let mut tabs_left = tab_count;
@@ -276,12 +276,12 @@ impl TabIndicator {
         scale: f64,
         point: Point<f64, Logical>,
     ) -> Option<usize> {
-        if self.config.off {
+        if *self.config.off {
             return None;
         }
 
         let count = tab_count;
-        if self.config.hide_when_single_tab && count == 1 {
+        if *self.config.hide_when_single_tab && count == 1 {
             return None;
         }
 
@@ -309,9 +309,9 @@ impl TabIndicator {
 
     /// Extra size occupied by the tab indicator.
     pub fn extra_size(&self, tab_count: usize, scale: f64) -> Size<f64, Logical> {
-        if self.config.off
-            || !self.config.place_within_column
-            || (self.config.hide_when_single_tab && tab_count == 1)
+        if *self.config.off
+            || !*self.config.place_within_column
+            || (*self.config.hide_when_single_tab && tab_count == 1)
         {
             return Size::from((0., 0.));
         }
@@ -324,7 +324,7 @@ impl TabIndicator {
         // that it peeks from the other side of the window".
         let size = f64::max(0., width + gap);
 
-        match self.config.position {
+        match *self.config.position {
             TabIndicatorPosition::Left | TabIndicatorPosition::Right => Size::from((size, 0.)),
             TabIndicatorPosition::Top | TabIndicatorPosition::Bottom => Size::from((0., size)),
         }
@@ -332,7 +332,7 @@ impl TabIndicator {
 
     /// Offset of the tabbed content due to space occupied by the tab indicator.
     pub fn content_offset(&self, tab_count: usize, scale: f64) -> Point<f64, Logical> {
-        match self.config.position {
+        match *self.config.position {
             TabIndicatorPosition::Left | TabIndicatorPosition::Top => {
                 self.extra_size(tab_count, scale).to_point()
             }
@@ -385,7 +385,7 @@ impl TabInfo {
             // one is enabled.
             let focus_ring_config = tile.focus_ring().config();
             let border_config = tile.border().config();
-            let config = if focus_ring_config.off {
+            let config = if *focus_ring_config.off {
                 border_config
             } else {
                 focus_ring_config
@@ -398,7 +398,7 @@ impl TabInfo {
             } else {
                 (config.inactive_color, config.inactive_gradient)
             };
-            gradient.unwrap_or_else(|| Gradient::from(color))
+            gradient.unwrap_or_else(|| Gradient::from(*color))
         };
 
         let gradient = gradient_from_rule()

--- a/src/layout/tab_indicator.rs
+++ b/src/layout/tab_indicator.rs
@@ -83,17 +83,17 @@ impl TabIndicator {
 
         let progress = self.open_anim.as_ref().map_or(1., |a| a.value().max(0.));
 
-        let width = round_max1(self.config.width.0);
-        let gap = self.config.gap.0;
+        let width = round_max1(self.config.width.value().0);
+        let gap = self.config.gap.value().0;
         let gap = round_max1(gap.abs()).copysign(gap);
-        let gaps_between = round_max1(self.config.gaps_between_tabs.0);
+        let gaps_between = round_max1(self.config.gaps_between_tabs.value().0);
 
-        let position = *self.config.position;
+        let position = *self.config.position.value();
         let side = match position {
             TabIndicatorPosition::Left | TabIndicatorPosition::Right => area.size.h,
             TabIndicatorPosition::Top | TabIndicatorPosition::Bottom => area.size.w,
         };
-        let total_prop = self.config.length.total_proportion.unwrap_or(0.5);
+        let total_prop = self.config.length.value().total_proportion.unwrap_or(0.5);
         let min_length = round(side * total_prop.clamp(0., 2.));
 
         // Compute px_per_tab before applying the animation to gaps_between in order to avoid it
@@ -104,7 +104,7 @@ impl TabIndicator {
         let px_per_tab = (length + gaps_between) / count as f64 - gaps_between;
 
         let px_per_tab = px_per_tab * progress;
-        let gaps_between = round(self.config.gaps_between_tabs.0 * progress);
+        let gaps_between = round(self.config.gaps_between_tabs.value().0 * progress);
 
         let length = count as f64 * (px_per_tab + gaps_between) - gaps_between;
         let px_per_tab = floor_logical_in_physical_max1(scale, px_per_tab);
@@ -184,9 +184,9 @@ impl TabIndicator {
         self.shaders.resize_with(count, Default::default);
         self.shader_locs.resize_with(count, Default::default);
 
-        let position = *self.config.position;
-        let radius = self.config.corner_radius.0 as f32;
-        let shared_rounded_corners = self.config.gaps_between_tabs.0 == 0.;
+        let position = *self.config.position.value();
+        let radius = self.config.corner_radius.value().0 as f32;
+        let shared_rounded_corners = self.config.gaps_between_tabs.value().0 == 0.;
         let mut tabs_left = tab_count;
 
         let rects = self.tab_rects(area, count, scale);
@@ -317,14 +317,14 @@ impl TabIndicator {
         }
 
         let round = |logical: f64| round_logical_in_physical(scale, logical);
-        let width = round(self.config.width.0);
-        let gap = round(self.config.gap.0);
+        let width = round(self.config.width.value().0);
+        let gap = round(self.config.gap.value().0);
 
         // No, I am *not* falling into the rabbit hole of "what if the tab indicator is wide enough
         // that it peeks from the other side of the window".
         let size = f64::max(0., width + gap);
 
-        match *self.config.position {
+        match *self.config.position.value() {
             TabIndicatorPosition::Left | TabIndicatorPosition::Right => Size::from((size, 0.)),
             TabIndicatorPosition::Top | TabIndicatorPosition::Bottom => Size::from((0., size)),
         }
@@ -332,7 +332,7 @@ impl TabIndicator {
 
     /// Offset of the tabbed content due to space occupied by the tab indicator.
     pub fn content_offset(&self, tab_count: usize, scale: f64) -> Point<f64, Logical> {
-        match *self.config.position {
+        match *self.config.position.value() {
             TabIndicatorPosition::Left | TabIndicatorPosition::Top => {
                 self.extra_size(tab_count, scale).to_point()
             }
@@ -398,7 +398,7 @@ impl TabInfo {
             } else {
                 (config.inactive_color, config.inactive_gradient)
             };
-            gradient.unwrap_or_else(|| Gradient::from(*color))
+            gradient.unwrap_or_else(|| Gradient::from(*color.value()))
         };
 
         let gradient = gradient_from_rule()

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -2062,8 +2062,8 @@ fn large_negative_height_change() {
     ];
 
     let mut options = Options::default();
-    options.border.off = false;
-    options.border.width = FloatOrInt(1.);
+    options.border.off = false.into();
+    options.border.width = FloatOrInt(1.).into();
 
     check_ops_with_options(options, &ops);
 }
@@ -2081,8 +2081,8 @@ fn large_max_size() {
     ];
 
     let mut options = Options::default();
-    options.border.off = false;
-    options.border.width = FloatOrInt(1.);
+    options.border.off = false.into();
+    options.border.width = FloatOrInt(1.).into();
 
     check_ops_with_options(options, &ops);
 }
@@ -2288,8 +2288,8 @@ fn removing_all_outputs_preserves_empty_named_workspaces() {
 #[test]
 fn config_change_updates_cached_sizes() {
     let mut config = Config::default();
-    config.layout.border.off = false;
-    config.layout.border.width = FloatOrInt(2.);
+    config.layout.border.off = false.into();
+    config.layout.border.width = FloatOrInt(2.).into();
 
     let mut layout = Layout::new(Clock::default(), &config);
 
@@ -2301,7 +2301,7 @@ fn config_change_updates_cached_sizes() {
     }
     .apply(&mut layout);
 
-    config.layout.border.width = FloatOrInt(4.);
+    config.layout.border.width = FloatOrInt(4.).into();
     layout.update_config(&config);
 
     layout.verify_invariants();
@@ -2419,8 +2419,8 @@ fn fixed_height_takes_max_non_auto_into_account() {
 
     let options = Options {
         border: niri_config::Border {
-            off: false,
-            width: niri_config::FloatOrInt(4.),
+            off: false.into(),
+            width: niri_config::FloatOrInt(4.).into(),
             ..Default::default()
         },
         gaps: 0.,
@@ -3168,8 +3168,8 @@ fn preset_column_width_fixed_correct_with_border() {
     let options = Options {
         preset_column_widths: vec![PresetSize::Fixed(500)],
         border: niri_config::Border {
-            off: false,
-            width: FloatOrInt(5.),
+            off: false.into(),
+            width: FloatOrInt(5.).into(),
             ..Default::default()
         },
         ..Default::default()
@@ -3403,8 +3403,8 @@ prop_compose! {
         width in arbitrary_spacing(),
     ) -> niri_config::FocusRing {
         niri_config::FocusRing {
-            off,
-            width: FloatOrInt(width),
+            off: off.into(),
+            width: FloatOrInt(width).into(),
             ..Default::default()
         }
     }
@@ -3416,8 +3416,8 @@ prop_compose! {
         width in arbitrary_spacing(),
     ) -> niri_config::Border {
         niri_config::Border {
-            off,
-            width: FloatOrInt(width),
+            off: off.into(),
+            width: FloatOrInt(width).into(),
             ..Default::default()
         }
     }
@@ -3429,8 +3429,8 @@ prop_compose! {
         width in arbitrary_spacing(),
     ) -> niri_config::Shadow {
         niri_config::Shadow {
-            on,
-            softness: FloatOrInt(width),
+            on: on.into(),
+            softness: FloatOrInt(width).into(),
             ..Default::default()
         }
     }
@@ -3447,13 +3447,13 @@ prop_compose! {
         position in arbitrary_tab_indicator_position(),
     ) -> niri_config::TabIndicator {
         niri_config::TabIndicator {
-            off,
-            hide_when_single_tab,
-            place_within_column,
-            width: FloatOrInt(width),
-            gap: FloatOrInt(gap),
-            length: TabIndicatorLength { total_proportion: Some(length) },
-            position,
+            off: off.into(),
+            hide_when_single_tab: hide_when_single_tab.into(),
+            place_within_column: place_within_column.into(),
+            width: FloatOrInt(width).into(),
+            gap: FloatOrInt(gap).into(),
+            length: TabIndicatorLength { total_proportion: Some(length) }.into(),
+            position: position.into(),
             ..Default::default()
         }
     }

--- a/src/layout/tests/fullscreen.rs
+++ b/src/layout/tests/fullscreen.rs
@@ -189,8 +189,8 @@ fn unfullscreen_with_large_border() {
 
     let options = Options {
         border: niri_config::Border {
-            off: false,
-            width: niri_config::FloatOrInt(10000.),
+            off: false.into(),
+            width: niri_config::FloatOrInt(10000.).into(),
             ..Default::default()
         },
         ..Default::default()

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1852,10 +1852,10 @@ fn compute_workspace_shadow_config(
     let norm = view_size.h / 1080.;
 
     let mut config = niri_config::Shadow::from(config);
-    config.softness.0 *= norm;
-    config.spread.0 *= norm;
-    config.offset.x.0 *= norm;
-    config.offset.y.0 *= norm;
+    config.softness.value_mut().0 *= norm;
+    config.spread.value_mut().0 *= norm;
+    config.offset.value_mut().x.0 *= norm;
+    config.offset.value_mut().y.0 *= norm;
 
     config
 }

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1688,7 +1688,7 @@ impl<W: LayoutElement> Workspace<W> {
 
     pub fn dnd_scroll_gesture_scroll(&mut self, pos: Point<f64, Logical>, speed: f64) -> bool {
         let config = &self.options.gestures.dnd_edge_view_scroll;
-        let trigger_width = config.trigger_width.0;
+        let trigger_width = config.resolved_trigger_width().0;
 
         // This working area intentionally does not include extra struts from Options.
         let x = pos.x - self.working_area.loc.x;

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1415,13 +1415,15 @@ impl State {
         }
 
         // Reload the repeat info.
-        if config.input.keyboard.repeat_rate != old_config.input.keyboard.repeat_rate
-            || config.input.keyboard.repeat_delay != old_config.input.keyboard.repeat_delay
+        if config.input.keyboard.resolved_repeat_rate()
+            != old_config.input.keyboard.resolved_repeat_rate()
+            || config.input.keyboard.resolved_repeat_delay()
+                != old_config.input.keyboard.resolved_repeat_delay()
         {
             let keyboard = self.niri.seat.get_keyboard().unwrap();
             keyboard.change_repeat_info(
-                config.input.keyboard.repeat_rate.into(),
-                config.input.keyboard.repeat_delay.into(),
+                config.input.keyboard.resolved_repeat_rate().into(),
+                config.input.keyboard.resolved_repeat_delay().into(),
             );
         }
 
@@ -1657,7 +1659,7 @@ impl State {
 
             let background_color = config
                 .and_then(|c| c.background_color)
-                .unwrap_or(full_config.layout.background_color)
+                .unwrap_or(*full_config.layout.background_color)
                 .to_array_unpremul();
             let background_color = Color32F::from(background_color);
 
@@ -2439,8 +2441,8 @@ impl Niri {
         let mut seat: Seat<State> = seat_state.new_wl_seat(&display_handle, backend.seat_name());
         let keyboard = match seat.add_keyboard(
             config_.input.keyboard.xkb.to_xkb_config(),
-            config_.input.keyboard.repeat_delay.into(),
-            config_.input.keyboard.repeat_rate.into(),
+            config_.input.keyboard.resolved_repeat_delay().into(),
+            config_.input.keyboard.resolved_repeat_rate().into(),
         ) {
             Err(err) => {
                 if let smithay::input::keyboard::Error::BadKeymap = err {
@@ -2450,8 +2452,8 @@ impl Niri {
                 }
                 seat.add_keyboard(
                     Default::default(),
-                    config_.input.keyboard.repeat_delay.into(),
-                    config_.input.keyboard.repeat_rate.into(),
+                    config_.input.keyboard.resolved_repeat_delay().into(),
+                    config_.input.keyboard.resolved_repeat_rate().into(),
                 )
                 .unwrap()
             }
@@ -2906,7 +2908,7 @@ impl Niri {
 
         let background_color = c
             .and_then(|c| c.background_color)
-            .unwrap_or(config.layout.background_color)
+            .unwrap_or(*config.layout.background_color)
             .to_array_unpremul();
 
         let mut backdrop_color = c

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1382,7 +1382,7 @@ impl State {
             self.niri.layout.ensure_named_workspace(ws_config);
         }
 
-        let rate = 1.0 / config.animations.slowdown.0.max(0.001);
+        let rate = 1.0 / config.animations.slowdown.value().0.max(0.001);
         self.niri.clock.set_rate(rate);
         self.niri
             .clock
@@ -1659,7 +1659,7 @@ impl State {
 
             let background_color = config
                 .and_then(|c| c.background_color)
-                .unwrap_or(*full_config.layout.background_color)
+                .unwrap_or(*full_config.layout.background_color.value())
                 .to_array_unpremul();
             let background_color = Color32F::from(background_color);
 
@@ -2313,7 +2313,7 @@ impl Niri {
 
         let mut animation_clock = Clock::default();
 
-        let rate = 1.0 / config_.animations.slowdown.0.max(0.001);
+        let rate = 1.0 / config_.animations.slowdown.value().0.max(0.001);
         animation_clock.set_rate(rate);
         animation_clock.set_complete_instantly(config_.animations.off);
 
@@ -2908,7 +2908,7 @@ impl Niri {
 
         let background_color = c
             .and_then(|c| c.background_color)
-            .unwrap_or(*config.layout.background_color)
+            .unwrap_or(*config.layout.background_color.value())
             .to_array_unpremul();
 
         let mut backdrop_color = c

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2130,7 +2130,7 @@ impl State {
 
                 {
                     let config = self.niri.config.borrow();
-                    if config.debug.force_pipewire_invalid_modifier {
+                    if *config.debug.force_pipewire_invalid_modifier {
                         render_formats = render_formats
                             .into_iter()
                             .filter(|f| f.modifier == Modifier::Invalid)

--- a/src/tests/animations.rs
+++ b/src/tests/animations.rs
@@ -74,7 +74,7 @@ fn set_up() -> Fixture {
     });
 
     let mut config = Config::default();
-    config.layout.gaps = FloatOrInt(0.0);
+    config.layout.gaps = FloatOrInt(0.0).into();
     config.animations.window_resize.anim.kind = LINEAR;
     config.animations.window_movement.0.kind = LINEAR;
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -2,7 +2,7 @@ use std::cmp::{max, min};
 
 use niri_config::window_rule::{Match, WindowRule};
 use niri_config::{
-    BlockOutFrom, BorderRule, CornerRadius, FloatingPosition, PresetSize, ShadowRule,
+    BlockOutFrom, BorderRule, CornerRadius, FloatingPosition, Mergeable, PresetSize, ShadowRule,
     TabIndicatorRule,
 };
 use niri_ipc::ColumnDisplay;


### PR DESCRIPTION
- Support position-aware `include "someotherfile.kdl"`
  - All the included files get watched too
  - They are basically just rendered into a singular config, then processed as normal.
- Add top-down merging for many sections
  - Add `MaybeSet` and `BoolFlag` so that default values can be differentiated between explicitly set values (so that later configs don't reset previously set values tod efaults)
  - Added a `niri-macros` for procedural `Mergeable` macro
    - It was just an idea to prevent needing to define `merge_with` logic for each configuration struct
  - Not all fields can be merged - but `layout`, `input`, `animations`, `gestures`, `binds`, `debug` and their children can be (if they have children)
  - `window-rule` and any named stuff like `output` or `workspace` remain un-changed logic wise.
- Added a doc page

~~Originally replaced the file watcher with [notify-debouncer-mini](https://docs.rs/notify-debouncer-mini) but reverted back to the original approach. That one remains in the history nonetheless as a potential future enhancement.~~