### PR TITLE
Add ability to inhibit idle on windows

### DIFF
--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -622,6 +622,12 @@ pub enum BlockOutFrom {
     ScreenCapture,
 }
 
+#[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InhibitIdle {
+    Always,
+    Fullscreen,
+}
+
 #[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
 pub struct BorderRule {
     #[knuffel(child)]

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -656,6 +656,36 @@ mod tests {
     }
 
     #[test]
+    fn inhibit() {
+        let parsed = do_parse(
+            r##"
+            window-rule {
+                inhibit-idle "fullscreen"                
+            }
+            window-rule {
+                inhibit-idle "always"
+            }
+            window-rule {
+                inhibit-idle null
+            }
+            window-rule {
+            }
+            "##,
+        );
+
+        assert!(matches!(
+            parsed.window_rules[0].inhibit_idle,
+            Some(Some(InhibitIdle::Fullscreen))
+        ));
+        assert!(matches!(
+            parsed.window_rules[1].inhibit_idle,
+            Some(Some(InhibitIdle::Always))
+        ));
+        assert!(matches!(parsed.window_rules[2].inhibit_idle, Some(None)));
+        assert!(matches!(parsed.window_rules[3].inhibit_idle, None));
+    }
+
+    #[test]
     fn parse() {
         let parsed = do_parse(
             r##"
@@ -1888,6 +1918,7 @@ mod tests {
                             saturation: None,
                         },
                     },
+                    inhibit_idle: None,
                 },
             ],
             layer_rules: [

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -6,7 +6,7 @@ use crate::appearance::{
 };
 use crate::layout::DefaultPresetSize;
 use crate::utils::{MergeWith, RegexEq};
-use crate::FloatOrInt;
+use crate::{FloatOrInt, InhibitIdle};
 
 #[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
 pub struct WindowRule {
@@ -79,6 +79,8 @@ pub struct WindowRule {
     pub background_effect: BackgroundEffectRule,
     #[knuffel(child, default)]
     pub popups: PopupsRule,
+    #[knuffel(child, unwrap(argument))]
+    pub inhibit_idle: Option<Option<InhibitIdle>>,
 }
 
 /// Rules for popup surfaces.

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, ensure, Context};
 use calloop::futures::Scheduler;
 use niri_config::debug::PreviewRender;
 use niri_config::{
-    Config, FloatOrInt, Key, Modifiers, OutputName, TrackLayout, WarpMouseToFocusMode,
+    Config, FloatOrInt, InhibitIdle, Key, Modifiers, OutputName, TrackLayout, WarpMouseToFocusMode,
     WorkspaceReference, Xkb,
 };
 use smithay::backend::allocator::Fourcc;
@@ -4000,7 +4000,17 @@ impl Niri {
                 with_states(surface, |states| {
                     surface_primary_scanout_output(surface, states).is_some()
                 })
-            });
+            })
+            || self
+                .layout
+                .windows()
+                .into_iter()
+                .any(|a| match a.1.rules().inhibit_idle {
+                    Some(InhibitIdle::Always) => true,
+                    Some(InhibitIdle::Fullscreen) => a.1.sizing_mode().is_fullscreen(),
+                    None => false,
+                });
+
         self.idle_notifier_state.set_is_inhibited(is_inhibited);
     }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -4,7 +4,7 @@ use niri_config::utils::MergeWith as _;
 use niri_config::window_rule::{Match, WindowRule};
 use niri_config::{
     BackgroundEffect, BlockOutFrom, BorderRule, CornerRadius, FloatingPosition, PresetSize,
-    ResolvedPopupsRules, ShadowRule, TabIndicatorRule,
+    ResolvedPopupsRules, ShadowRule, TabIndicatorRule, InhibitIdle
 };
 use niri_ipc::ColumnDisplay;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
@@ -125,6 +125,9 @@ pub struct ResolvedWindowRules {
 
     /// Rules for this window's popups.
     pub popups: ResolvedPopupsRules,
+    
+    /// Whether to inhibit idle for this window.
+    pub inhibit_idle: Option<InhibitIdle>,
 }
 
 impl<'a> WindowRef<'a> {
@@ -303,6 +306,10 @@ impl ResolvedWindowRules {
                     resolved.tiled_state = Some(x);
                 }
 
+                if let Some(x) = rule.inhibit_idle {
+                    resolved.inhibit_idle = x;
+                }
+                
                 resolved
                     .background_effect
                     .merge_with(&rule.background_effect);


### PR DESCRIPTION
This adds the ability to inhibit idle on a window if configured.

There are a few discussions about the topic
#742 
#1855 

There are 3 options:
- `inhibit_idle "always"` - whenever this window is present. 
- `inhibit_idle "fullscreen"` - whenever this window is fullscreen
- `inhibit_idle  "never"` - don't inhibit on this window

Option 1 is useful, for example converting a video file that may take a couple of hours, but the window itself is not necessarily fullscreen
```kdl
window-rule {
    match title="HandBrake"
    inhibit-idle "always"
}
```
Option 2 is useful, for example when you are watching video, playing games with a controller and the window is fullscreen
```kdl
window-rule {
    match app-id="librewolf"
    inhibit-idle "fullscreen"
}
```
Option 3 is to disable inhibit on this window for example if you have enabled inhibit fullscreen on all windows, but you want this window as the exception not to inhibit when fullscreen
```kdl
window-rule {
    inhibit-idle "fullscreen"
}
window-rule {
    match app-id="Alacritty"
    inhibit-idle "never"
}
```
