### PR TITLE
Included example for other media keys in the default config.

### DIFF
--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -379,12 +379,12 @@ binds {
     XF86AudioMute        allow-when-locked=true { spawn-sh "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"; }
     XF86AudioMicMute     allow-when-locked=true { spawn-sh "wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"; }
 
-    // Example media keys mapping using playerctl
+    // Example media keys mapping using playerctl.
     // This will work with any MPRIS-enabled media player.
-    xF86AudioPlay        allow-when-locked=true { spawn-sh "playerctl play-pause"; }
-    xF86AudioStop        allow-when-locked=true { spawn-sh "playerctl stop"; }
-    xF86AudioPrev        allow-when-locked=true { spawn-sh "playerctl previous"; }
-    xF86AudioNext        allow-when-locked=true { spawn-sh "playerctl next"; }
+    XF86AudioPlay        allow-when-locked=true { spawn-sh "playerctl play-pause"; }
+    XF86AudioStop        allow-when-locked=true { spawn-sh "playerctl stop"; }
+    XF86AudioPrev        allow-when-locked=true { spawn-sh "playerctl previous"; }
+    XF86AudioNext        allow-when-locked=true { spawn-sh "playerctl next"; }
 
     // Example brightness key mappings for brightnessctl.
     // You can use regular spawn with multiple arguments too (to avoid going through "sh"),


### PR DESCRIPTION
Included example for media keys: play/pause, stop, previous and next using **playerctl**. 
As far as I know, this program is installed by default in most distros.