### PR TITLE
Add support for disabling DRM devices

### DIFF
--- a/docs/wiki/Configuration:-Debug-Options.md
+++ b/docs/wiki/Configuration:-Debug-Options.md
@@ -18,6 +18,8 @@ debug {
     disable-direct-scanout
     restrict-primary-scanout-to-matching-format
     render-drm-device "/dev/dri/renderD129"
+    ignore-drm-device "/dev/dri/renderD128"
+    ignore-drm-device "/dev/dri/renderD130"
     force-pipewire-invalid-modifier
     dbus-interfaces-in-non-session-instances
     wait-for-frame-completion-before-queueing
@@ -112,6 +114,20 @@ You can set this to make niri use a different primary GPU than the default one.
 ```kdl
 debug {
     render-drm-device "/dev/dri/renderD129"
+}
+```
+
+### `ignore-drm-device`
+
+<sup>Since: next release</sup>
+
+List DRM devices that niri will ignore.
+Useful for GPU passthrough when you don't want niri to open a certain device.
+
+```kdl
+debug {
+    ignore-drm-device "/dev/dri/renderD128"
+    ignore-drm-device "/dev/dri/renderD130"
 }
 ```
 

--- a/niri-config/src/debug.rs
+++ b/niri-config/src/debug.rs
@@ -13,6 +13,7 @@ pub struct Debug {
     pub keep_max_bpc_unchanged: bool,
     pub restrict_primary_scanout_to_matching_format: bool,
     pub render_drm_device: Option<PathBuf>,
+    pub ignored_drm_devices: Vec<PathBuf>,
     pub force_pipewire_invalid_modifier: bool,
     pub emulate_zero_presentation_time: bool,
     pub disable_resize_throttling: bool,
@@ -45,6 +46,8 @@ pub struct DebugPart {
     pub restrict_primary_scanout_to_matching_format: Option<Flag>,
     #[knuffel(child, unwrap(argument))]
     pub render_drm_device: Option<PathBuf>,
+    #[knuffel(children(name = "ignore-drm-device"), unwrap(argument))]
+    pub ignored_drm_devices: Vec<PathBuf>,
     #[knuffel(child)]
     pub force_pipewire_invalid_modifier: Option<Flag>,
     #[knuffel(child)]
@@ -91,6 +94,9 @@ impl MergeWith<DebugPart> for Debug {
         );
 
         merge_clone_opt!((self, part), preview_render, render_drm_device);
+
+        self.ignored_drm_devices
+            .extend(part.ignored_drm_devices.iter().cloned());
     }
 }
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -831,6 +831,8 @@ mod tests {
 
             debug {
                 render-drm-device "/dev/dri/renderD129"
+                ignore-drm-device "/dev/dri/renderD128"
+                ignore-drm-device "/dev/dri/renderD130"
             }
 
             workspace "workspace-1" {
@@ -2008,6 +2010,10 @@ mod tests {
                 render_drm_device: Some(
                     "/dev/dri/renderD129",
                 ),
+                ignored_drm_devices: [
+                    "/dev/dri/renderD128",
+                    "/dev/dri/renderD130",
+                ],
                 force_pipewire_invalid_modifier: false,
                 emulate_zero_presentation_time: false,
                 disable_resize_throttling: false,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1504,6 +1504,10 @@ impl State {
             output_config_changed = true;
         }
 
+        if config.debug.ignored_drm_devices != old_config.debug.ignored_drm_devices {
+            output_config_changed = true;
+        }
+
         // FIXME: move backdrop rendering into layout::Monitor, then this will become unnecessary.
         if config.overview.backdrop_color != old_config.overview.backdrop_color {
             output_config_changed = true;


### PR DESCRIPTION
Adds a debug option disable-drm-device that specifies DRM devices that niri is not allowed to bind to. This is useful for, e.g., VFIO GPU passthrough.