### PR TITLE
wiki: Recommend pick-window instead of focused-window

### DIFF
--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -172,7 +172,7 @@ window-rule {
 }
 ```
 
-You can find the title and the app ID of the currently focused window by running `niri msg focused-window`.
+You can find the title and the app ID of a window by running `niri msg pick-window` and clicking on the window in question.
 
 > [!TIP]
 > Another way to find the window title and app ID is to configure the `wlr/taskbar` module in [Waybar](https://github.com/Alexays/Waybar) to include them in the tooltip:


### PR DESCRIPTION
focused-window is only useful for querying terminal windows (unless combined with sleep or similar tricks.)