### PR TITLE
Add option for mouse movement toggling DPMS

### DIFF
--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -183,6 +183,8 @@ pub struct Mouse {
     pub middle_emulation: bool,
     #[knuffel(child)]
     pub scroll_factor: Option<ScrollFactor>,
+    #[knuffel(child)]
+    pub wake_monitor_on_movement: bool,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -100,7 +100,7 @@ impl State {
             }
         } else {
             // Power on monitors if they were off.
-            if should_activate_monitors(&event) {
+            if self.should_activate_monitors(&event) {
                 self.niri.activate_monitors(&mut self.backend);
 
                 // Notify the idle-notifier of activity only if we're also powering on the
@@ -209,6 +209,29 @@ impl State {
                 self.niri.devices.remove(device);
             }
             _ => (),
+        }
+    }
+
+    fn should_activate_monitors<I: InputBackend>(&mut self, event: &InputEvent<I>) -> bool {
+        let config = self.niri.config.borrow();
+
+        match event {
+            InputEvent::Keyboard { event } if event.state() == KeyState::Pressed => true,
+            InputEvent::PointerButton { event } if event.state() == ButtonState::Pressed => true,
+            InputEvent::PointerMotion { .. }
+            | InputEvent::PointerMotionAbsolute { .. }
+            | InputEvent::PointerAxis { .. } => config.input.mouse.wake_monitor_on_movement,
+            InputEvent::GestureSwipeBegin { .. }
+            | InputEvent::GesturePinchBegin { .. }
+            | InputEvent::GestureHoldBegin { .. }
+            | InputEvent::TouchDown { .. }
+            | InputEvent::TouchMotion { .. }
+            | InputEvent::TabletToolAxis { .. }
+            | InputEvent::TabletToolProximity { .. }
+            | InputEvent::TabletToolTip { .. }
+            | InputEvent::TabletToolButton { .. } => true,
+            // Ignore events like device additions and removals, key releases, gesture ends.
+            _ => false,
         }
     }
 
@@ -4136,27 +4159,6 @@ fn modifiers_from_state(mods: ModifiersState) -> Modifiers {
         modifiers |= Modifiers::ISO_LEVEL5_SHIFT;
     }
     modifiers
-}
-
-fn should_activate_monitors<I: InputBackend>(event: &InputEvent<I>) -> bool {
-    match event {
-        InputEvent::Keyboard { event } if event.state() == KeyState::Pressed => true,
-        InputEvent::PointerButton { event } if event.state() == ButtonState::Pressed => true,
-        InputEvent::PointerMotion { .. }
-        | InputEvent::PointerMotionAbsolute { .. }
-        | InputEvent::PointerAxis { .. }
-        | InputEvent::GestureSwipeBegin { .. }
-        | InputEvent::GesturePinchBegin { .. }
-        | InputEvent::GestureHoldBegin { .. }
-        | InputEvent::TouchDown { .. }
-        | InputEvent::TouchMotion { .. }
-        | InputEvent::TabletToolAxis { .. }
-        | InputEvent::TabletToolProximity { .. }
-        | InputEvent::TabletToolTip { .. }
-        | InputEvent::TabletToolButton { .. } => true,
-        // Ignore events like device additions and removals, key releases, gesture ends.
-        _ => false,
-    }
 }
 
 fn should_hide_hotkey_overlay<I: InputBackend>(event: &InputEvent<I>) -> bool {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -106,6 +106,9 @@ impl State {
                 // Notify the idle-notifier of activity only if we're also powering on the
                 // monitors.
                 self.niri.notify_activity();
+
+                // Prevent waking input from passing through
+                return;
             }
         }
 


### PR DESCRIPTION
I've got a very sensitive mouse, and I typically come back to find my monitor awake up any time anything happens in the house. I've been using a temporary solution of just flipping the mouse.  I thought to myself, surely other people would like to have it as an option, so I decided to draft a PR - `input.mouse.wake-monitor-on-movement` is required to be set in order for mouse movement to wake the monitor. I have it marked as a draft for these reasons:

- I'm not sure if `input.mouse` is the proper home for this option
- I haven't added anything to the docs yet because of the aforementioned
- I moved `should_activate_monitors` into `State` in order to be able to read the config
- I also added a small snippet to capture inputs that wake the monitor. I found it a bit annoying that a space press would pass through to whatever the currently-focused window was. Maybe this could be an option too?