### PR TITLE
add window-rule match is-maximized

### DIFF
--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -83,6 +83,8 @@ pub struct Match {
     #[knuffel(property)]
     pub is_focused: Option<bool>,
     #[knuffel(property)]
+    pub is_maximized: Option<bool>,
+    #[knuffel(property)]
     pub is_active_in_column: Option<bool>,
     #[knuffel(property)]
     pub is_floating: Option<bool>,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1187,6 +1187,8 @@ pub struct Window {
     ///
     /// There can be either one focused window or zero (e.g. when a layer-shell surface has focus).
     pub is_focused: bool,
+    /// Whether this window is currently maximized.
+    pub is_maximized: bool,
     /// Whether this window is currently floating.
     ///
     /// If the window isn't floating then it is in the tiling layout.

--- a/niri-visual-tests/src/test_window.rs
+++ b/niri-visual-tests/src/test_window.rs
@@ -220,6 +220,8 @@ impl LayoutElement for TestWindow {
 
     fn set_floating(&mut self, _floating: bool) {}
 
+    fn set_maximized(&mut self, _maximized: bool) {}
+
     fn set_bounds(&self, _bounds: Size<i32, Logical>) {}
 
     fn is_ignoring_opacity_window_rule(&self) -> bool {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -612,6 +612,11 @@ fn print_window(window: &Window) {
         if window.is_floating { "yes" } else { "no" }
     );
 
+    println!(
+        "  Is maximized: {}",
+        if window.is_maximized { "yes" } else { "no" }
+    );
+
     if let Some(pid) = window.pid {
         println!("  PID: {pid}");
     } else {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -490,6 +490,7 @@ fn make_ipc_window(
         pid: mapped.credentials().map(|c| c.pid),
         workspace_id: workspace_id.map(|id| id.get()),
         is_focused: mapped.is_focused(),
+        is_maximized: mapped.is_maximized(),
         is_floating: mapped.is_floating(),
         is_urgent: mapped.is_urgent(),
         layout,
@@ -683,8 +684,9 @@ impl State {
             };
 
             let workspace_id = ws_id.map(|id| id.get());
-            let mut changed =
-                ipc_win.workspace_id != workspace_id || ipc_win.is_floating != mapped.is_floating();
+            let mut changed = ipc_win.workspace_id != workspace_id
+                || ipc_win.is_floating != mapped.is_floating()
+                || ipc_win.is_maximized != mapped.is_maximized();
 
             changed |= with_toplevel_role(mapped.toplevel(), |role| {
                 ipc_win.title != role.title || ipc_win.app_id != role.app_id

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -206,6 +206,7 @@ pub trait LayoutElement {
     fn set_activated(&mut self, active: bool);
     fn set_active_in_column(&mut self, active: bool);
     fn set_floating(&mut self, floating: bool);
+    fn set_maximized(&mut self, maximized: bool);
     fn set_bounds(&self, bounds: Size<i32, Logical>);
     fn is_ignoring_opacity_window_rule(&self) -> bool;
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -904,6 +904,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             }
         }
 
+        // Set window maximized if column is maximized
+        target_column.tiles[tile_idx]
+            .window_mut()
+            .set_maximized(target_column.is_full_width);
+
         // Adding a wider window into a column increases its width now (even if the window will
         // shrink later). Move the columns to account for this.
         let offset = self.column_x(col_idx + 1) - prev_next_x;
@@ -4637,7 +4642,12 @@ impl<W: LayoutElement> Column<W> {
     }
 
     fn toggle_full_width(&mut self) {
-        self.is_full_width = !self.is_full_width;
+        let is_full_width = !self.is_full_width;
+
+        self.tiles_mut()
+            .for_each(|(tile, _)| tile.window_mut().set_maximized(is_full_width));
+
+        self.is_full_width = is_full_width;
         self.update_tile_sizes(true);
     }
 

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -235,6 +235,8 @@ impl LayoutElement for TestWindow {
 
     fn set_floating(&mut self, _floating: bool) {}
 
+    fn set_maximized(&mut self, _maximized: bool) {}
+
     fn is_fullscreen(&self) -> bool {
         if self.0.is_windowed_fullscreen.get() {
             return false;

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -86,6 +86,9 @@ pub struct Mapped {
     /// Whether this window has the keyboard focus.
     is_focused: bool,
 
+    /// Whether this window is maximized.
+    is_maximized: bool,
+
     /// Whether this window is the active window in its column.
     is_active_in_column: bool,
 
@@ -240,6 +243,7 @@ impl Mapped {
             offscreen_data: RefCell::new(None),
             is_urgent: false,
             is_focused: false,
+            is_maximized: false,
             is_active_in_column: true,
             is_floating: false,
             is_window_cast_target: false,
@@ -312,6 +316,10 @@ impl Mapped {
 
     pub fn is_focused(&self) -> bool {
         self.is_focused
+    }
+
+    pub fn is_maximized(&self) -> bool {
+        self.is_maximized
     }
 
     pub fn is_active_in_column(&self) -> bool {
@@ -886,6 +894,12 @@ impl LayoutElement for Mapped {
     fn set_floating(&mut self, floating: bool) {
         let changed = self.is_floating != floating;
         self.is_floating = floating;
+        self.need_to_recompute_rules |= changed;
+    }
+
+    fn set_maximized(&mut self, maximized: bool) {
+        let changed = self.is_maximized != maximized;
+        self.is_maximized = maximized;
         self.need_to_recompute_rules |= changed;
     }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -133,6 +133,13 @@ impl<'a> WindowRef<'a> {
         }
     }
 
+    pub fn is_maximized(self) -> bool {
+        match self {
+            WindowRef::Unmapped(_) => false,
+            WindowRef::Mapped(mapped) => mapped.is_maximized(),
+        }
+    }
+
     pub fn is_urgent(self) -> bool {
         match self {
             WindowRef::Unmapped(_) => false,
@@ -438,6 +445,12 @@ fn window_matches(window: WindowRef, role: &XdgToplevelSurfaceRoleAttributes, m:
 
     if let Some(is_focused) = m.is_focused {
         if window.is_focused() != is_focused {
+            return false;
+        }
+    }
+
+    if let Some(is_maximized) = m.is_maximized {
+        if window.is_maximized() != is_maximized {
             return false;
         }
     }


### PR DESCRIPTION
Adds support for matching a window on its maximized state.

Also exposes it in ipc.

With this it's possible to do the following for example:
```kdl
window-rule {
  // match on any window that is maximized
  match is-maximized=true

  // change the border
  border {
    active-color "#0000004c"
  }

  // .. or enable VRR
  variable-refresh-rate true
}
```