### PR TITLE
Add IPC action to toggle animations

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -350,6 +350,10 @@ pub enum Action {
     UnsetWindowUrgent(u64),
     #[knuffel(skip)]
     LoadConfigFile,
+    #[knuffel(skip)]
+    SetAnimations {
+        off: bool,
+    },
 }
 
 impl From<niri_ipc::Action> for Action {
@@ -644,6 +648,7 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::SetWindowUrgent { id } => Self::SetWindowUrgent(id),
             niri_ipc::Action::UnsetWindowUrgent { id } => Self::UnsetWindowUrgent(id),
             niri_ipc::Action::LoadConfigFile {} => Self::LoadConfigFile,
+            niri_ipc::Action::SetAnimations { off } => Self::SetAnimations { off },
         }
     }
 }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -215,6 +215,13 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(short, long))]
         delay_ms: Option<u16>,
     },
+    SetAnimations {
+        #[cfg_attr(
+            feature = "clap",
+            arg(long, action = clap::ArgAction::Set, default_value_t = true)
+        )]
+        off: bool,
+    },
     /// Open the screenshot UI.
     Screenshot {
         ///  Whether to show the mouse pointer by default in the screenshot UI.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2144,6 +2144,19 @@ impl State {
                 }
                 self.niri.queue_redraw_all();
             }
+            Action::SetAnimations { off } => {
+                {
+                    let mut config = self.niri.config.borrow_mut();
+                    if config.animations.off == off {
+                        return;
+                    }
+                    config.animations.off = off;
+                }
+
+                self.niri.clock.set_complete_instantly(off);
+                self.niri.advance_animations();
+                self.niri.queue_redraw_all();
+            }
             Action::LoadConfigFile => {
                 if let Some(watcher) = &self.niri.config_file_watcher {
                     watcher.load_config();


### PR DESCRIPTION
  - expose set-animations in the IPC API (defaulting to on)
  - update bindable action enum so configs can call it
  - toggle the runtime config, clock, and redraw when invoked
