### PR TITLE
Redraw cursor if hidden during screenshot

### DIFF
--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1826,6 +1826,12 @@ impl State {
             return;
         }
 
+        // Redraw the pointer if hidden through cursor{} options
+        if self.niri.pointer_visibility == PointerVisibility::Hidden {
+            self.niri.pointer_visibility = PointerVisibility::Visible;
+            self.niri.queue_redraw_all();
+        }
+
         let default_output = self
             .niri
             .output_under_cursor()


### PR DESCRIPTION
Fix #2498

When using hide-when-typing or hide-after-inactive-ms, the cursor is completely gone from screenshots, and this seems to be the simplest fix for both cases