### PR TITLE
feat(workspace): New action `toggle_floating_layout`

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -328,6 +328,7 @@ pub enum Action {
     FocusFloating,
     FocusTiling,
     SwitchFocusBetweenFloatingAndTiling,
+    ToggleFloatingLayout,
     #[knuffel(skip)]
     MoveFloatingWindowById {
         id: Option<u64>,
@@ -629,6 +630,7 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::SwitchFocusBetweenFloatingAndTiling {} => {
                 Self::SwitchFocusBetweenFloatingAndTiling
             }
+            niri_ipc::Action::ToggleFloatingLayout {} => Self::ToggleFloatingLayout,
             niri_ipc::Action::MoveFloatingWindow { id, x, y } => {
                 Self::MoveFloatingWindowById { id, x, y }
             }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -801,6 +801,8 @@ pub enum Action {
     FocusTiling {},
     /// Toggles the focus between the floating and the tiling layout.
     SwitchFocusBetweenFloatingAndTiling {},
+    /// Toggles the floating layout.
+    ToggleFloatingLayout {},
     /// Move a floating window on screen.
     #[cfg_attr(feature = "clap", clap(about = "Move the floating window on screen"))]
     MoveFloatingWindow {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2037,6 +2037,12 @@ impl State {
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
+            Action::ToggleFloatingLayout => {
+                self.niri.layout.toggle_floating_layout();
+                self.maybe_warp_cursor_to_focus();
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
             Action::MoveFloatingWindowById { id, x, y } => {
                 let window = if let Some(id) = id {
                     let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -3180,6 +3180,13 @@ impl<W: LayoutElement> Layout<W> {
         workspace.switch_focus_floating_tiling();
     }
 
+    pub fn toggle_floating_layout(&mut self) {
+        let Some(workspace) = self.active_workspace_mut() else {
+            return;
+        };
+        workspace.toggle_floating_layout();
+    }
+
     pub fn move_floating_window(
         &mut self,
         id: Option<&W::Id>,


### PR DESCRIPTION
Previous PR #2369

Implement #1061

I hope it is acceptable this time.

Main changes:

1. A new action `toggle_floating_layout` that tries to toggle the visibility of
   the floating layout (the current behavior is that floating layout is always
   visible unless the scrolling layout is fullscreened).

2. A new state `FloatingActive::NoAndHidden` which represents the state when the
   floating layout is hidden.

3. Use a `deactivate_floating()` function to replace repeated lines:

   ```rs
   self.floating_is_active = FloatingActive::No;
   ```