### PR TITLE
wiki: fix list in tab-indicator section

### DIFF
--- a/docs/wiki/Configuration:-Layout.md
+++ b/docs/wiki/Configuration:-Layout.md
@@ -461,6 +461,7 @@ When `gaps-between-tabs` is zero, only the first and the last tabs have rounded 
 They have the same semantics as the border and focus ring colors and gradients.
 
 Tab colors are picked in this order:
+
 1. Colors from the `tab-indicator` window rule, if set.
 1. Colors from the `tab-indicator` layout options, if set (you're here).
 1. If neither are set, niri picks the color matching the window border or focus ring, whichever one is active.


### PR DESCRIPTION
Apology for the minor PR (this is not for hacktober). Just fixes a markdown error in the docs.

Before:
<img width="1081" height="129" alt="Screenshot from 2025-10-16 15-19-24" src="https://github.com/user-attachments/assets/0bc1788e-902a-4456-8633-10d68b66cd48" />

After:
<img width="1119" height="275" alt="Screenshot from 2025-10-16 15-19-43" src="https://github.com/user-attachments/assets/299b8e03-3a29-4a20-9bf8-f3aa6088e7d0" />
