### PR TITLE
Fix issue with screencasting when using gnome and gtk desktop portals in some cases. 

### DIFF
--- a/resources/niri-portals.conf
+++ b/resources/niri-portals.conf
@@ -3,3 +3,4 @@ default=gnome;gtk;
 org.freedesktop.impl.portal.Access=gtk;
 org.freedesktop.impl.portal.Notification=gtk;
 org.freedesktop.impl.portal.Secret=gnome-keyring;
+org.freedesktop.impl.portal.Settings=gtk;gnome;


### PR DESCRIPTION
This is a very small PR that aims to solve the issue mentioned and solved here #2399 .

The solution here is to also explicitly mention the settings portal to be backed by gnome and gtk, which is probably what happens anyways for people with just one desktop portal installed, but messes up when multiple are installed (like KDE). 

This helps apps like OBS who need both the settings portal and the screencast portal to come from gnome for it to properly work.

As far as I am aware, this should not cause any regressions. The extra line merely mentions something explicitly that fresh installs of niri on systems with no other DE/Window manager would do anyways. But if this is not the case, and there is some regression, please let me know.