### PR TITLE
backend/tty: Consider only primary node in drm udev event

### DIFF
--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -512,6 +512,13 @@ impl Tty {
 
         let node = DrmNode::from_dev_id(device_id)?;
 
+        // Only consider primary node on udev event
+        // https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/768fbaad54027f8dd027e7e015e8eeb93cb38c52
+        if node.ty() != NodeType::Primary {
+            debug!("not a primary node, skipping");
+            return Ok(());
+        }
+
         if self.ignored_nodes.contains(&node) {
             debug!("node is ignored, skipping");
             return Ok(());
@@ -649,6 +656,11 @@ impl Tty {
             return;
         };
 
+        if node.ty() != NodeType::Primary {
+            debug!("not a primary node, skipping");
+            return;
+        }
+
         if self.ignored_nodes.contains(&node) {
             debug!("node is ignored, skipping");
             return;
@@ -766,6 +778,11 @@ impl Tty {
             warn!("error creating DrmNode");
             return;
         };
+
+        if node.ty() != NodeType::Primary {
+            debug!("not a primary node, skipping");
+            return;
+        }
 
         let Some(device) = self.devices.get_mut(&node) else {
             warn!("unknown device");


### PR DESCRIPTION
Previously discussed in #2521.

Skip `/dev/dri/render*`  nodes in device_added() to use hot-plugging via udev trigger.
`sudo udevadm trigger --action=remove /dev/dri/card0`

Reference link:
https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/768fbaad54027f8dd027e7e015e8eeb93cb38c52