### PR TITLE
Remove unnecessary unsafe in `inhibit_power_key`

### DIFF
--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2777,8 +2777,6 @@ impl Niri {
 
     #[cfg(feature = "dbus")]
     pub fn inhibit_power_key(&mut self) -> anyhow::Result<()> {
-        use std::os::fd::{AsRawFd, BorrowedFd};
-
         use smithay::reexports::rustix::io::{fcntl_setfd, FdFlags};
 
         let conn = zbus::blocking::Connection::system()?;
@@ -2794,8 +2792,7 @@ impl Niri {
         let fd: zbus::zvariant::OwnedFd = message.body().deserialize()?;
 
         // Don't leak the fd to child processes.
-        let borrowed = unsafe { BorrowedFd::borrow_raw(fd.as_raw_fd()) };
-        if let Err(err) = fcntl_setfd(borrowed, FdFlags::CLOEXEC) {
+        if let Err(err) = fcntl_setfd(&fd, FdFlags::CLOEXEC) {
             warn!("error setting CLOEXEC on inhibit fd: {err:?}");
         };
 


### PR DESCRIPTION
Was reading through the code and saw `unsafe` being used to borrow an owned file descriptor. It seems like `zbus::zvariant::OwnedFd` does implement `AsFd` since [zbus 4.0](https://github.com/z-galaxy/zbus/issues/286), so this can be achieved without `unsafe` by simply removing the manual re-borrowing!

I've played around with Niri this past weekend, and it is *amazing*. Thanks for creating such a polished, approachable & hackable compositor! :yellow_heart: 