### PR TITLE
feat: make shadow sizing more customizable

### DIFF
--- a/docs/wiki/Configuration:-Layer-Rules.md
+++ b/docs/wiki/Configuration:-Layer-Rules.md
@@ -29,6 +29,13 @@ layer-rule {
         draw-behind-window true
         color "#00000064"
         // inactive-color "#00000064"
+
+        struts {
+            // left 8
+            // right 8
+            // top -8
+            // bottom -8
+        }
     }
 
     geometry-corner-radius 12
@@ -126,6 +133,8 @@ That is, enabling shadows in the layout config section won't automatically enabl
 > For example, if a layer surface includes some invisible margins (like mako), niri has no way of knowing that, and will draw the shadow behind the entire surface, including the invisible margins.
 >
 > So to use niri shadows, you'll need to configure layer-shell clients to remove their own margins or shadows.
+> Alternatively, you can [configure shadow `struts`](./Configuration:-Layout.md#shadow)
+> to tell niri how the shadow should be sized.
 
 ```kdl
 // Add a shadow for fuzzel.

--- a/docs/wiki/Configuration:-Layout.md
+++ b/docs/wiki/Configuration:-Layout.md
@@ -11,7 +11,9 @@ layout {
     always-center-single-column
     empty-workspace-above-first
     default-column-display "tabbed"
+    
     background-color "#003300"
+    // background-in-working-area-only
 
     preset-column-widths {
         proportion 0.33333
@@ -60,6 +62,13 @@ layout {
         draw-behind-window true
         color "#00000070"
         // inactive-color "#00000054"
+        
+        struts {
+            // left 8
+            // right 8
+            // top -8
+            // bottom -8
+        }
     }
 
     tab-indicator {
@@ -407,6 +416,8 @@ These will also remove client-side shadows if the window draws any.
 
 `inactive-color` lets you override the shadow color for inactive windows; by default, a more transparent `color` is used.
 
+`struts` adjust the size and position of the shadow relative to the window. See [the documentation for struts in layout](#struts).
+
 Shadow drawing will follow the window corner radius set with the [`geometry-corner-radius` window rule](./Configuration:-Window-Rules.md#geometry-corner-radius).
 
 > [!NOTE]
@@ -559,3 +570,25 @@ layout {
 ```
 
 You can also set the color per-output [in the output config](./Configuration:-Outputs.md#layout-config-overrides).
+
+### `background-in-working-area-only`
+
+Set to `true` to ensure the [background color](#background-color) is only painted in the working area,
+and [workspace shadows](./Configuration:-Miscellaneous.md#workspace-shadow) are cropped to this region.
+
+This flag is most useful in combination with either edge-to-edge layer surfaces,
+or both a transparent background color and a custom wallpaper layer (e.g. swaybg)
+using [the `place-within-backdrop` layer rule](./Configuration:-Layer-Rules.md#place-within-backdrop).
+
+```kdl
+layout {
+    background-color "transparent"
+    background-in-working-area-only
+}
+
+layer-rule {
+    match namespace="^wallpaper$"
+
+    place-within-backdrop true
+}
+```

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -84,6 +84,13 @@ window-rule {
         draw-behind-window true
         color "#00000064"
         // inactive-color "#00000064"
+
+        struts {
+            // left 8
+            // right 8
+            // top -8
+            // bottom -8
+        }
     }
 
     tab-indicator {

--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -6,7 +6,7 @@ use miette::{miette, IntoDiagnostic as _};
 use smithay::backend::renderer::Color32F;
 
 use crate::utils::{Flag, MergeWith};
-use crate::FloatOrInt;
+use crate::{FloatOrInt, Struts};
 
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::from_array_unpremul([0.25, 0.25, 0.25, 1.]);
 pub const DEFAULT_BACKDROP_COLOR: Color = Color::from_array_unpremul([0.15, 0.15, 0.15, 1.]);
@@ -341,6 +341,7 @@ pub struct Shadow {
     pub draw_behind_window: bool,
     pub color: Color,
     pub inactive_color: Option<Color>,
+    pub struts: Struts,
 }
 
 impl Default for Shadow {
@@ -356,6 +357,7 @@ impl Default for Shadow {
             draw_behind_window: false,
             color: Color::from_rgba8_unpremul(0, 0, 0, 0x77),
             inactive_color: None,
+            struts: Struts::default(),
         }
     }
 }
@@ -369,7 +371,7 @@ impl MergeWith<ShadowRule> for Shadow {
 
         merge!((self, part), softness, spread);
 
-        merge_clone!((self, part), offset, draw_behind_window, color);
+        merge_clone!((self, part), offset, struts, draw_behind_window, color);
 
         merge_clone_opt!((self, part), inactive_color);
     }
@@ -390,6 +392,7 @@ pub struct WorkspaceShadow {
     pub softness: f64,
     pub spread: f64,
     pub color: Color,
+    pub struts: Struts,
 }
 
 impl Default for WorkspaceShadow {
@@ -403,6 +406,7 @@ impl Default for WorkspaceShadow {
             softness: 40.,
             spread: 10.,
             color: Color::from_rgba8_unpremul(0, 0, 0, 0x50),
+            struts: Struts::default(),
         }
     }
 }
@@ -414,8 +418,9 @@ impl From<WorkspaceShadow> for Shadow {
             offset: value.offset,
             softness: value.softness,
             spread: value.spread,
-            draw_behind_window: false,
             color: value.color,
+            struts: value.struts,
+            draw_behind_window: false,
             inactive_color: None,
         }
     }
@@ -429,6 +434,8 @@ pub struct WorkspaceShadowPart {
     pub on: bool,
     #[knuffel(child)]
     pub offset: Option<ShadowOffset>,
+    #[knuffel(child)]
+    pub struts: Option<Struts>,
     #[knuffel(child, unwrap(argument))]
     pub softness: Option<FloatOrInt<0, 1024>>,
     #[knuffel(child, unwrap(argument))]
@@ -444,7 +451,7 @@ impl MergeWith<WorkspaceShadowPart> for WorkspaceShadow {
             self.off = false;
         }
 
-        merge_clone!((self, part), offset, color);
+        merge_clone!((self, part), offset, struts, color);
         merge!((self, part), softness, spread);
     }
 }
@@ -646,6 +653,8 @@ pub struct ShadowRule {
     pub on: bool,
     #[knuffel(child)]
     pub offset: Option<ShadowOffset>,
+    #[knuffel(child)]
+    pub struts: Option<Struts>,
     #[knuffel(child, unwrap(argument))]
     pub softness: Option<FloatOrInt<0, 1024>>,
     #[knuffel(child, unwrap(argument))]
@@ -696,6 +705,7 @@ impl MergeWith<Self> for ShadowRule {
         merge_clone_opt!(
             (self, part),
             offset,
+            struts,
             softness,
             spread,
             draw_behind_window,

--- a/niri-config/src/layout.rs
+++ b/niri-config/src/layout.rs
@@ -24,6 +24,7 @@ pub struct Layout {
     pub gaps: f64,
     pub struts: Struts,
     pub background_color: Color,
+    pub background_in_working_area_only: bool,
 }
 
 impl Default for Layout {
@@ -52,6 +53,7 @@ impl Default for Layout {
                 PresetSize::Proportion(2. / 3.),
             ],
             background_color: DEFAULT_BACKGROUND_COLOR,
+            background_in_working_area_only: false,
         }
     }
 }
@@ -67,6 +69,7 @@ impl MergeWith<LayoutPart> for Layout {
             insert_hint,
             always_center_single_column,
             empty_workspace_above_first,
+            background_in_working_area_only,
             gaps,
         );
 
@@ -126,6 +129,8 @@ pub struct LayoutPart {
     pub struts: Option<Struts>,
     #[knuffel(child)]
     pub background_color: Option<Color>,
+    #[knuffel(child)]
+    pub background_in_working_area_only: Option<Flag>,
 }
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -5,7 +5,7 @@ use smithay::backend::renderer::element::surface::{
 };
 use smithay::backend::renderer::element::Kind;
 use smithay::desktop::{LayerSurface, PopupManager};
-use smithay::utils::{Logical, Point, Scale, Size};
+use smithay::utils::{Logical, Point, Rectangle, Scale, Size};
 use smithay::wayland::shell::wlr_layer::{ExclusiveZone, Layer};
 
 use super::ResolvedLayerRules;
@@ -102,8 +102,13 @@ impl MappedLayer {
 
         let radius = self.rules.geometry_corner_radius.unwrap_or_default();
         // FIXME: is_active based on keyboard focus?
-        self.shadow
-            .update_render_elements(size, true, radius, self.scale, 1.);
+        self.shadow.update_render_elements(
+            Rectangle::new(Point::new(0., 0.), size),
+            true,
+            radius,
+            self.scale,
+            1.,
+        );
     }
 
     pub fn are_animations_ongoing(&self) -> bool {

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -42,6 +42,7 @@ impl ResolvedLayerRules {
                 draw_behind_window: None,
                 color: None,
                 inactive_color: None,
+                struts: None,
             },
             geometry_corner_radius: None,
             place_within_backdrop: false,

--- a/src/layout/shadow.rs
+++ b/src/layout/shadow.rs
@@ -34,7 +34,7 @@ impl Shadow {
 
     pub fn update_render_elements(
         &mut self,
-        win_size: Size<f64, Logical>,
+        content_geometry: Rectangle<f64, Logical>,
         is_active: bool,
         radius: CornerRadius,
         scale: f64,
@@ -48,14 +48,17 @@ impl Shadow {
         // * We do not divide anything, only add, subtract and multiply by integers.
         // * At rendering time, tile positions are rounded to physical pixels.
 
+        let win_size = content_geometry.size;
+        let content = content_geometry.loc;
+
         let width = self.config.softness;
         // Like in CSS box-shadow.
         let sigma = width / 2.;
         // Adjust width to draw all necessary pixels.
         let width = ceil(sigma * 3.);
 
-        let offset_x = ceil(self.config.offset.x.0 + self.config.struts.left.0);
-        let offset_y = ceil(self.config.offset.y.0 + self.config.struts.top.0);
+        let offset_x = content.x + ceil(self.config.offset.x.0 + self.config.struts.left.0);
+        let offset_y = content.y + ceil(self.config.offset.y.0 + self.config.struts.top.0);
         let offset = Point::from((offset_x, offset_y));
 
         let spread = self.config.spread;
@@ -96,7 +99,7 @@ impl Shadow {
         let shader_geo = Rectangle::new(Point::from((-width, -width)), shader_size);
 
         // This is actually offset relative to shader_geo, this is handled below.
-        let window_geo = Rectangle::new(Point::from((0., 0.)), win_size);
+        let window_geo = Rectangle::new(content, win_size);
 
         if !self.config.draw_behind_window {
             let top_left = ceil(f64::from(win_radius.top_left));

--- a/src/layout/shadow.rs
+++ b/src/layout/shadow.rs
@@ -57,8 +57,8 @@ impl Shadow {
         // Adjust width to draw all necessary pixels.
         let width = ceil(sigma * 3.);
 
-        let offset_x = content.x + ceil(self.config.offset.x.0 + self.config.struts.left.0);
-        let offset_y = content.y + ceil(self.config.offset.y.0 + self.config.struts.top.0);
+        let offset_x = ceil(content.x + self.config.offset.x.0 + self.config.struts.left.0);
+        let offset_y = ceil(content.y + self.config.offset.y.0 + self.config.struts.top.0);
         let offset = Point::from((offset_x, offset_y));
 
         let spread = self.config.spread;

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -487,7 +487,7 @@ impl<W: LayoutElement> Tile<W> {
                 .scaled_by(1. - expanded_progress as f32)
         };
         self.shadow.update_render_elements(
-            animated_tile_size,
+            Rectangle::new(Point::new(0., 0.), animated_tile_size),
             is_active,
             radius,
             self.scale,

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -2018,7 +2018,12 @@ impl<W: LayoutElement> Workspace<W> {
         assert!(self.view_size.w > 0.);
         assert!(self.view_size.h > 0.);
 
-        assert_eq!(self.background_buffer.size(), self.view_size);
+        if options.layout.background_in_working_area_only {
+            assert_eq!(self.background_buffer.size(), self.working_area.size);
+        } else {
+            assert_eq!(self.background_buffer.size(), self.view_size);
+        }
+
         assert_eq!(
             self.background_buffer.color().components(),
             options.layout.background_color.to_array_unpremul(),

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -253,6 +253,11 @@ impl<W: LayoutElement> Workspace<W> {
             compute_workspace_shadow_config(options.overview.workspace_shadow, view_size);
 
         let background_color = options.layout.background_color.to_array_unpremul();
+        let background_size = if options.layout.background_in_working_area_only {
+            working_area.size
+        } else {
+            view_size
+        };
 
         Self {
             scrolling,
@@ -264,7 +269,7 @@ impl<W: LayoutElement> Workspace<W> {
             view_size,
             working_area,
             shadow: Shadow::new(shadow_config),
-            background_buffer: SolidColorBuffer::new(view_size, background_color),
+            background_buffer: SolidColorBuffer::new(background_size, background_color),
             output: Some(output),
             clock,
             base_options,
@@ -319,6 +324,11 @@ impl<W: LayoutElement> Workspace<W> {
             compute_workspace_shadow_config(options.overview.workspace_shadow, view_size);
 
         let background_color = options.layout.background_color.to_array_unpremul();
+        let background_size = if options.layout.background_in_working_area_only {
+            working_area.size
+        } else {
+            view_size
+        };
 
         Self {
             scrolling,
@@ -331,7 +341,7 @@ impl<W: LayoutElement> Workspace<W> {
             view_size,
             working_area,
             shadow: Shadow::new(shadow_config),
-            background_buffer: SolidColorBuffer::new(view_size, background_color),
+            background_buffer: SolidColorBuffer::new(background_size, background_color),
             clock,
             base_options,
             options,
@@ -387,7 +397,7 @@ impl<W: LayoutElement> Workspace<W> {
             .update_render_elements(is_active && self.floating_is_active.get(), view_rect);
 
         self.shadow.update_render_elements(
-            self.view_size,
+            self.background_geometry(),
             true,
             CornerRadius::default(),
             self.scale.fractional_scale(),
@@ -423,6 +433,15 @@ impl<W: LayoutElement> Workspace<W> {
 
         let background_color = options.layout.background_color.to_array_unpremul();
         self.background_buffer.set_color(background_color);
+
+        match (
+            self.options.layout.background_in_working_area_only,
+            options.layout.background_in_working_area_only,
+        ) {
+            (false, true) => self.background_buffer.resize(self.working_area.size),
+            (true, false) => self.background_buffer.resize(self.view_size),
+            _ => {}
+        }
 
         self.base_options = base_options;
         self.options = options;
@@ -534,6 +553,14 @@ impl<W: LayoutElement> Workspace<W> {
         self.set_view_size(scale, transform, view_size, working_area);
     }
 
+    fn background_geometry(&self) -> Rectangle<f64, Logical> {
+        if self.options.layout.background_in_working_area_only {
+            self.working_area
+        } else {
+            Rectangle::new(Point::new(0., 0.), self.view_size)
+        }
+    }
+
     fn set_view_size(
         &mut self,
         scale: smithay::output::Scale,
@@ -578,7 +605,8 @@ impl<W: LayoutElement> Workspace<W> {
             self.shadow.update_config(shadow_config);
         }
 
-        self.background_buffer.resize(size);
+        self.background_buffer
+            .resize(self.background_geometry().size);
 
         if scale_transform_changed {
             for window in self.windows() {
@@ -1666,7 +1694,7 @@ impl<W: LayoutElement> Workspace<W> {
     pub fn render_background(&self) -> SolidColorRenderElement {
         SolidColorRenderElement::from_buffer(
             &self.background_buffer,
-            Point::new(0., 0.),
+            self.background_geometry().loc,
             1.,
             Kind::Unspecified,
         )

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -222,6 +222,7 @@ impl ResolvedWindowRules {
                 draw_behind_window: None,
                 color: None,
                 inactive_color: None,
+                struts: None,
             },
             tab_indicator: TabIndicatorRule {
                 active_color: None,


### PR DESCRIPTION
## `shadow { struts {} }`
this PR adds support for struts in shadows:
```kdl
layout {
	shadow {
		struts {
			top 20
			bottom 20
		}
	}
}

overview {
	workspace-shadow {
		struts {
			top 20
			bottom 20
			left -20
			right -20
		}
	}
}
```

## `layout { background-in-working-area-only }`

also introduced, is a new `background-in-working-area-only` flag which will change how background & workspace shadows are calculated. here is a comparison of overview with the flag on and off:

<table>
<td><img width="552" alt="Screenshot from 2025-10-22 17-53-04" src="https://github.com/user-attachments/assets/76d7f5c2-6f66-4c9a-964d-a5facbe7b743" /></td>
<td><img width="552" alt="Screenshot from 2025-10-22 17-56-01" src="https://github.com/user-attachments/assets/fe646e67-64f6-4fa6-b4ca-9fd8191a15af" /></td></table>
