### PR TITLE
Add building a Debian package to the release process using cargo deb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
           cargo vendor --locked > .cargo/config.toml
           tar cJf niri-${{ github.event.inputs.version }}-vendored-dependencies.tar.xz vendor/
 
+      - name: Build Debian package
+        run: |
+          cargo deb 
+
       - name: Build
         run: cargo build --all --frozen --release
 
@@ -59,5 +63,5 @@ jobs:
         with:
           draft: true
           tag_name: v${{ github.event.inputs.version }}
-          files: niri-${{ github.event.inputs.version }}-vendored-dependencies.tar.xz
+          files: niri-${{ github.event.inputs.version }}-vendored-dependencies.tar.xz target/debian/niri_${{ github.event.inputs.version }}_amd64.deb
           fail_on_unmatched_files: true


### PR DESCRIPTION
I think it would be nice to build this on release. I think the package should be reasonably widely compatible as-is, but some tweaks/testing might be needed. I'm also not really sure whether I can test the workflow myself.

Once this is working, it could be added to https://github.com/wimpysworld/deb-get and this could be given as the instructions to get the latest upstream version for Debian/Ubuntu.