### PR TITLE
tty: Fix a panic when updating ignored nodes on udev event

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -186,7 +186,7 @@ impl Backend {
 
     pub fn on_output_config_changed(&mut self, niri: &mut Niri) {
         match self {
-            Backend::Tty(tty) => tty.on_output_config_changed(niri),
+            Backend::Tty(tty) => tty.on_output_config_changed(niri, true),
             Backend::Winit(_) => (),
             Backend::Headless(_) => (),
         }


### PR DESCRIPTION
When called from the udev_dispatcher callback, the invocation udev_dispatcher.as_source_ref() will panic, since the dispatcher is being mutably borrowed.