### PR TITLE
feat: add new input-passthrough window rule

### DIFF
--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -72,6 +72,8 @@ pub struct WindowRule {
     pub scroll_factor: Option<FloatOrInt<0, 100>>,
     #[knuffel(child, unwrap(argument))]
     pub tiled_state: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub input_passthrough: Option<bool>,
 }
 
 #[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -860,6 +860,10 @@ impl<W: LayoutElement> Tile<W> {
         let offset = self.bob_offset();
         let point = point - offset;
 
+        if self.window.rules().input_passthrough == Some(true) {
+            return None;
+        }
+
         if self.is_in_input_region(point) {
             let win_pos = self.buf_loc() + offset;
             Some(HitType::Input { win_pos })

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -119,6 +119,7 @@ pub struct ResolvedWindowRules {
 
     /// Override whether to set the Tiled xdg-toplevel state on the window.
     pub tiled_state: Option<bool>,
+    pub input_passthrough: Option<bool>,
 }
 
 impl<'a> WindowRef<'a> {
@@ -240,6 +241,7 @@ impl ResolvedWindowRules {
             variable_refresh_rate: None,
             scroll_factor: None,
             tiled_state: None,
+            input_passthrough: None,
         }
     }
 
@@ -364,6 +366,9 @@ impl ResolvedWindowRules {
                 }
                 if let Some(x) = rule.tiled_state {
                     resolved.tiled_state = Some(x);
+                }
+                if let Some(x) = rule.input_passthrough {
+                    resolved.input_passthrough = Some(x);
                 }
             }
 


### PR DESCRIPTION
Adds a new window rule that makes windows transparent to input events, allowing clicks to pass through to windows below.

Use cases: Gaming overlays, custom HUDs, desktop-wide status displays, or watching content on top without stealing input from applications underneath (Discord/OBS/video players over games or coding tools). Especially useful when coupled with floating and opacity rules to create custom overlays with ease. No other window manager has this feature surprisingly afaik.

## Implementation

- Added `input_passthrough` config property to window rules.
- Modified `Tile::hit()` to return None for passthrough windows.

Core logic is a simple check in `tile.rs`:
```rust
if self.window.rules().input_passthrough == Some(tr>
    return None; // Pass through all input
}
```

## Example usage:
```kdl
window-rule {
    match app-id=r#"^discord$"#
    opacity 0.5  
    //^ Optional - just to see content under if target window is 100% alpha
    input-passthrough true
}
```