### PR TITLE
docs: add move-column-to-workspace focus parameter example

### DIFF
--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -405,3 +405,15 @@ binds {
     Super+Alt+L allow-inhibiting=false { spawn "swaylock"; }
 }
 ```
+
+#### `move-column-to-workspace` (or up/down) focus parameter
+
+<sup>Since: v25.05</sup>
+
+It's possible to move a column without following it with the focus parameter:
+
+```kdl
+binds {
+   Alt+Shift+1 { move-column-to-workspace focus=false 1; }
+}
+```


### PR DESCRIPTION
I was just opening a discussion when I found about it when looking at how hard it'd be to implement, and noticed it was already done recently but no doc was added in #1332 !

Not sure this is the best place to add this, but it's better than nothing -- happy to let you add it somewhere else and close it instead, will likely be faster than iterating on details.

-----------------

This feature was added a while ago but nothing in the doc mentions it anywhere. Add a basic usage example.

Fixes: #1332