### PR TITLE
Update LXQt wiki link in niri integration

### DIFF
--- a/docs/wiki/Integrating-niri.md
+++ b/docs/wiki/Integrating-niri.md
@@ -55,7 +55,7 @@ You will probably also want a desktop background tool ([swaybg](https://github.c
 
 Alternatively, some desktop environments and shells work with niri, and can give a more cohesive experience in one package:
 
-- [LXQt](https://lxqt-project.org/) officially supports niri, see [their wiki](https://github.com/lxqt/lxqt/wiki/ConfigWaylandSettings#general) for details on setting it up.
+- [LXQt](https://lxqt-project.org/) officially supports niri, see [their wiki](https://lxqt-project.org/wiki/Wayland-Session) for details on setting it up.
 - Many [XFCE](https://www.xfce.org/) components work on Wayland, including niri. See [their wiki](https://wiki.xfce.org/releng/wayland_roadmap#component_specific_status) for details.
 - There are complete desktop shells based on Quickshell that support niri, for example [DankMaterialShell](https://github.com/AvengeMedia/DankMaterialShell) and [Noctalia](https://github.com/noctalia-dev/noctalia-shell).
 - You can run a [COSMIC](https://system76.com/cosmic/) session with niri using [cosmic-ext-extra-sessions](https://github.com/Drakulix/cosmic-ext-extra-sessions).


### PR DESCRIPTION
The github wiki is deprecated