### PR TITLE
Fix typo in screenshot action documentation

### DIFF
--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -354,7 +354,7 @@ binds {
 Actions for taking screenshots.
 
 - `screenshot`: opens the built-in interactive screenshot UI.
-- `screenshot-screen`, `screenshow-window`: takes a screenshot of the focused screen or window respectively.
+- `screenshot-screen`, `screenshot-window`: takes a screenshot of the focused screen or window respectively.
 
 The screenshot is both stored to the clipboard and saved to disk, according to the [`screenshot-path` option](./Configuration:-Miscellaneous.md#screenshot-path).
 


### PR DESCRIPTION
Fixes a typo in the documentation where screenshot-window was incorrectly written as screenshow-window.
Changes:

Corrected screenshow-window to screenshot-window in the action documentation