### PR TITLE
CI: free disk space before running nix flake check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,10 @@ jobs:
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          dotnet: false
+          large-packages: false
+        
       - uses: actions/checkout@v4
         with:
           show-progress: false


### PR DESCRIPTION
This prevents a `No space left on device` error as can be seen here: https://github.com/YaLTeR/niri/actions/runs/19403781415/job/55515251373#step:5:3659