### PR TITLE
feat: add xwayland matcher for window rule

### DIFF
--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -36,6 +36,7 @@ window-rule {
     match is-floating=true
     match is-window-cast-target=true
     match is-urgent=true
+    match is-xwayland=true
     match at-startup=true
 
     // Properties that apply once upon window opening.
@@ -300,6 +301,17 @@ window-rule {
     match is-urgent=true
 }
 ```
+
+#### `is-xwayland`
+
+<sup>Since: next release</sup>
+
+Can be `true` or `false`.
+Matches windows that is running under Xwayland.
+
+> [!NOTE]
+> This matcher requires you to use Niri's built-in [`xwayland-satellite` integration](./Xwayland.md).
+> If you launches `xwayland-satellite` yourself or with `spawn-at-startup`, this matcher will not work.
 
 #### `at-startup`
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1651,6 +1651,7 @@ mod tests {
                             is_floating: None,
                             is_window_cast_target: None,
                             is_urgent: None,
+                            is_xwayland: None,
                             at_startup: None,
                         },
                     ],
@@ -1670,6 +1671,7 @@ mod tests {
                             is_floating: None,
                             is_window_cast_target: None,
                             is_urgent: None,
+                            is_xwayland: None,
                             at_startup: None,
                         },
                         Match {
@@ -1685,6 +1687,7 @@ mod tests {
                             is_floating: None,
                             is_window_cast_target: None,
                             is_urgent: None,
+                            is_xwayland: None,
                             at_startup: None,
                         },
                     ],

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -93,6 +93,8 @@ pub struct Match {
     #[knuffel(property)]
     pub is_urgent: Option<bool>,
     #[knuffel(property)]
+    pub is_xwayland: Option<bool>,
+    #[knuffel(property)]
     pub at_startup: Option<bool>,
 }
 

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1297,6 +1297,8 @@ pub struct Window {
     pub is_floating: bool,
     /// Whether this window requests your attention.
     pub is_urgent: bool,
+    /// Whether this window is running under Xwayland.
+    pub is_xwayland: bool,
     /// Position- and size-related properties of the window.
     pub layout: WindowLayout,
     /// Timestamp when the window was most recently focused.

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -659,6 +659,11 @@ fn print_window(window: &Window) {
         if window.is_floating { "yes" } else { "no" }
     );
 
+    println!(
+        "  Is Xwayland: {}",
+        if window.is_xwayland { "yes" } else { "no" }
+    );
+
     if let Some(pid) = window.pid {
         println!("  PID: {pid}");
     } else {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -513,6 +513,7 @@ fn make_ipc_window(
         is_focused: mapped.is_focused(),
         is_floating: mapped.is_floating(),
         is_urgent: mapped.is_urgent(),
+        is_xwayland: mapped.is_xwayland(),
         layout,
         focus_timestamp: mapped.get_focus_timestamp().map(Timestamp::from),
     })

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2858,10 +2858,27 @@ impl Niri {
             primary_selection_disabled: config.clipboard.disable_primary,
             restricted,
             credentials_unknown,
+            is_xwayland: AtomicBool::new(false),
         });
 
-        if let Err(err) = self.display_handle.insert_client(client, data) {
-            warn!("error inserting client: {err}");
+        match self.display_handle.insert_client(client, data) {
+            Ok(c) => {
+                if !credentials_unknown {
+                    let credentials = c.get_credentials(&self.display_handle).unwrap();
+                    if self
+                        .satellite
+                        .as_ref()
+                        .map_or(None, |s| s.pid())
+                        .is_some_and(|pid| u32::try_from(credentials.pid).is_ok_and(|p| p == pid))
+                    {
+                        c.get_data::<ClientState>()
+                            .unwrap()
+                            .is_xwayland
+                            .store(true, Ordering::SeqCst);
+                    }
+                }
+            }
+            Err(err) => warn!("error inserting client: {err}"),
         }
     }
 
@@ -6550,6 +6567,7 @@ pub struct ClientState {
     pub restricted: bool,
     /// We cannot retrieve this client's socket credentials.
     pub credentials_unknown: bool,
+    pub is_xwayland: AtomicBool,
 }
 
 impl ClientData for ClientState {

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -1,4 +1,5 @@
 use std::cell::{Cell, Ref, RefCell};
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use niri_config::{Color, CornerRadius, GradientInterpolation, WindowRule};
@@ -27,6 +28,7 @@ use crate::layout::{
     ConfigureIntent, InteractiveResizeData, LayoutElement, LayoutElementRenderElement,
     LayoutElementRenderSnapshot, SizingMode,
 };
+use crate::niri::ClientState;
 use crate::niri_render_elements;
 use crate::render_helpers::border::BorderRenderElement;
 use crate::render_helpers::offscreen::OffscreenData;
@@ -572,6 +574,20 @@ impl Mapped {
 
     pub fn is_urgent(&self) -> bool {
         self.is_urgent
+    }
+
+    pub fn is_xwayland(&self) -> bool {
+        let Some(surface) = self.window.wl_surface() else {
+            return false;
+        };
+        let Some(client) = surface.client() else {
+            return false;
+        };
+        client
+            .get_data::<ClientState>()
+            .unwrap()
+            .is_xwayland
+            .load(Ordering::SeqCst)
     }
 }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -171,6 +171,13 @@ impl<'a> WindowRef<'a> {
             WindowRef::Mapped(mapped) => mapped.is_window_cast_target(),
         }
     }
+
+    pub fn is_xwayland(self) -> bool {
+        match self {
+            WindowRef::Unmapped(unmapped) => unmapped.is_xwayland(),
+            WindowRef::Mapped(mapped) => mapped.is_xwayland(),
+        }
+    }
 }
 
 impl ResolvedWindowRules {
@@ -498,6 +505,12 @@ fn window_matches(window: WindowRef, role: &XdgToplevelSurfaceRoleAttributes, m:
 
     if let Some(is_window_cast_target) = m.is_window_cast_target {
         if window.is_window_cast_target() != is_window_cast_target {
+            return false;
+        }
+    }
+
+    if let Some(is_xwayland) = m.is_xwayland {
+        if window.is_xwayland() != is_xwayland {
             return false;
         }
     }


### PR DESCRIPTION
Add xwayland matcher for window rules.

This requires user to use the built-in Xwayland-satellite integration.

~~TODO: add docs~~