### PR TITLE
Remove window comparison

### DIFF
--- a/src/niri.rs
+++ b/src/niri.rs
@@ -6275,7 +6275,7 @@ impl Niri {
         }
 
         if let Some(window) = &new_focus.window {
-            if !self.layout.is_overview_open() && current_focus.window.as_ref() != Some(window) {
+            if !self.layout.is_overview_open() {
                 let (window, hit) = window;
 
                 // Don't trigger focus-follows-mouse over the tab indicator.


### PR DESCRIPTION
The issue lies with if !self.layout.is_overview_open() && current_focus.window.as_ref() != Some(window) in niri.rs 6283. We queried the current PointContents with self.contents_under which ends up being the same as the new_focus var.
Following video shows the fix.

https://github.com/user-attachments/assets/69c58daf-9b8c-4756-bd27-212e9bf0b782

Fixes #2856 


