### PR TITLE
Fix MRU tracking when overview is open

### DIFF
--- a/src/niri.rs
+++ b/src/niri.rs
@@ -387,6 +387,7 @@ pub struct Niri {
 
     pub window_mru_ui: WindowMruUi,
     pub pending_mru_commit: Option<PendingMruCommit>,
+    pub previous_layout_focus_id: Option<MappedId>,
 
     pub pick_window: Option<async_channel::Sender<Option<MappedId>>>,
     pub pick_color: Option<async_channel::Sender<Option<niri_ipc::PickedColor>>>,
@@ -767,6 +768,8 @@ impl State {
         self.niri.popups.cleanup();
         self.refresh_popup_grab();
         self.update_keyboard_focus();
+
+        self.update_focus_mru_timestamp();
 
         // Should be called before refresh_layout() because that one will refresh other window
         // states and then send a pending configure.
@@ -1247,40 +1250,6 @@ impl State {
             {
                 if let Some((mapped, _)) = self.niri.layout.find_window_and_output_mut(surface) {
                     mapped.set_is_focused(true);
-
-                    // If `mapped` does not have a focus timestamp, then the window is newly
-                    // created/mapped and a timestamp is unconditionally created.
-                    //
-                    // If `mapped` already has a timestamp only update it after the focus lock-in
-                    // period has gone by without the focus having elsewhere.
-                    let stamp = get_monotonic_time();
-
-                    let debounce = self.niri.config.borrow().recent_windows.debounce_ms;
-                    let debounce = Duration::from_millis(u64::from(debounce));
-
-                    if mapped.get_focus_timestamp().is_none() || debounce.is_zero() {
-                        mapped.set_focus_timestamp(stamp);
-                    } else {
-                        let timer = Timer::from_duration(debounce);
-
-                        let focus_token = self
-                            .niri
-                            .event_loop
-                            .insert_source(timer, move |_, _, state| {
-                                state.niri.mru_apply_keyboard_commit();
-                                TimeoutAction::Drop
-                            })
-                            .unwrap();
-                        if let Some(PendingMruCommit { token, .. }) =
-                            self.niri.pending_mru_commit.replace(PendingMruCommit {
-                                id: mapped.id(),
-                                token: focus_token,
-                                stamp,
-                            })
-                        {
-                            self.niri.event_loop.remove(token);
-                        }
-                    }
                 }
             }
 
@@ -1343,6 +1312,58 @@ impl State {
 
             // FIXME: can be more granular.
             self.niri.queue_redraw_all();
+        }
+    }
+
+    pub fn update_focus_mru_timestamp(&mut self) {
+        let current_focus_id = self.niri.layout.focus().map(|win| win.id());
+        if self.niri.previous_layout_focus_id == current_focus_id {
+            return;
+        }
+
+        self.niri.previous_layout_focus_id = current_focus_id;
+
+        if let Some(id) = current_focus_id {
+            if let Some(mapped) = self
+                .niri
+                .layout
+                .workspaces_mut()
+                .find_map(|ws| ws.windows_mut().find(|w| w.id() == id))
+            {
+                // If `mapped` does not have a focus timestamp, then the window is newly
+                // created/mapped and a timestamp is unconditionally created.
+                //
+                // If `mapped` already has a timestamp only update it after the focus lock-in
+                // period has gone by without the focus having elsewhere.
+                let stamp = get_monotonic_time();
+
+                let debounce = self.niri.config.borrow().recent_windows.debounce_ms;
+                let debounce = Duration::from_millis(u64::from(debounce));
+
+                if mapped.get_focus_timestamp().is_none() || debounce.is_zero() {
+                    mapped.set_focus_timestamp(stamp);
+                } else {
+                    let timer = Timer::from_duration(debounce);
+
+                    let focus_token = self
+                        .niri
+                        .event_loop
+                        .insert_source(timer, move |_, _, state| {
+                            state.niri.mru_apply_keyboard_commit();
+                            TimeoutAction::Drop
+                        })
+                        .unwrap();
+                    if let Some(PendingMruCommit { token, .. }) =
+                        self.niri.pending_mru_commit.replace(PendingMruCommit {
+                            id: mapped.id(),
+                            token: focus_token,
+                            stamp,
+                        })
+                    {
+                        self.niri.event_loop.remove(token);
+                    }
+                }
+            }
         }
     }
 
@@ -2808,6 +2829,7 @@ impl Niri {
 
             window_mru_ui,
             pending_mru_commit: None,
+            previous_layout_focus_id: None,
 
             pick_window: None,
             pick_color: None,


### PR DESCRIPTION
This PR fixes MRU focus window tracking when the overview is open. The issue was that Alt+Tab would work once, but subsequent presses wouldn't switch back to the previous window.

The root cause is that MRU timestamps were updated based on keyboard focus changes, but when the overview is open, keyboard focus stays on the overview even though layout focus changes (via arrow keys, MRU advances, or opening new windows).

The fix adds a `previous_layout_focus_id` field to track layout focus separately from keyboard focus. On each refresh cycle, if the layout focus changed, the MRU timestamp is updated for the newly focused window.

Fixes: #2834
Fixes: #2839