### PR TITLE
screenshot_ui: add ctrl+a command to select entire output

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1636,7 +1636,11 @@ impl State {
                 self.niri.queue_redraw_all();
             }
             Action::MaximizeColumn => {
-                self.niri.layout.toggle_full_width();
+                if self.niri.screenshot_ui.is_open() {
+                    self.niri.screenshot_ui.select_entire_output();
+                } else {
+                    self.niri.layout.toggle_full_width();
+                }
             }
             Action::MaximizeWindowToEdges => {
                 let focus = self.niri.layout.focus().map(|m| m.window.clone());
@@ -4570,6 +4574,7 @@ fn allowed_during_screenshot(action: &Action) -> bool {
             | Action::SetWindowWidth(_)
             | Action::SetWindowHeight(_)
             | Action::SetColumnWidth(_)
+            | Action::MaximizeColumn
     )
 }
 

--- a/src/ui/screenshot_ui.rs
+++ b/src/ui/screenshot_ui.rs
@@ -460,6 +460,25 @@ impl ScreenshotUi {
         self.update_buffers();
     }
 
+    pub fn select_entire_output(&mut self) {
+        let Self::Open {
+            selection,
+            output_data,
+            ..
+        } = self
+        else {
+            return;
+        };
+
+        let current_data = &output_data[&selection.0];
+        let size = current_data.size;
+
+        selection.1 = Point::new(0, 0);
+        selection.2 = Point::new(size.w - 1, size.h - 1);
+
+        self.update_buffers();
+    }
+
     pub fn set_width(&mut self, change: SizeChange) {
         let Self::Open {
             selection: (output, a, b),


### PR DESCRIPTION
<details>
<summary>images</summary>

<img width="1389" height="1678" alt="image" src="https://github.com/user-attachments/assets/e47e0a99-18e7-4c38-ac4a-9ddae40a2128" />
<img width="1408" height="1703" alt="image" src="https://github.com/user-attachments/assets/afd1b7cc-408b-4dba-9098-b0ceea69f859" />

</details>

adds a simple <kbd>ctrl+a</kbd> keybind to the screenshot ui to select the entire output