### PR TITLE
feat: transition for opacity changes, including "flash" effect

### DIFF
--- a/niri-config/src/layout.rs
+++ b/niri-config/src/layout.rs
@@ -2,10 +2,14 @@ use knuffel::errors::DecodeError;
 use niri_ipc::{ColumnDisplay, SizeChange};
 
 use crate::appearance::{
-    Border, FocusRing, InsertHint, Shadow, TabIndicator, DEFAULT_BACKGROUND_COLOR,
+    Border, FocusRing, InsertHint, OpacityTransition, Shadow, TabIndicator,
+    DEFAULT_BACKGROUND_COLOR,
 };
 use crate::utils::{expect_only_children, Flag, MergeWith};
-use crate::{BorderRule, Color, FloatOrInt, InsertHintPart, ShadowRule, TabIndicatorPart};
+use crate::{
+    BorderRule, Color, FloatOrInt, FocusOpacityPart, InsertHintPart, OpacityTransitionPart,
+    ShadowRule, TabIndicatorPart,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Layout {
@@ -14,6 +18,7 @@ pub struct Layout {
     pub shadow: Shadow,
     pub tab_indicator: TabIndicator,
     pub insert_hint: InsertHint,
+    pub opacity_transition: OpacityTransition,
     pub preset_column_widths: Vec<PresetSize>,
     pub default_column_width: Option<PresetSize>,
     pub preset_window_heights: Vec<PresetSize>,
@@ -34,6 +39,7 @@ impl Default for Layout {
             shadow: Shadow::default(),
             tab_indicator: TabIndicator::default(),
             insert_hint: InsertHint::default(),
+            opacity_transition: OpacityTransition::default(),
             preset_column_widths: vec![
                 PresetSize::Proportion(1. / 3.),
                 PresetSize::Proportion(0.5),
@@ -80,6 +86,14 @@ impl MergeWith<LayoutPart> for Layout {
             background_color,
         );
 
+        if let Some(focus_opacity) = &part.focus_opacity {
+            self.opacity_transition.flash.merge_with(focus_opacity);
+        }
+
+        if let Some(opacity_transition) = &part.opacity_transition {
+            self.opacity_transition.merge_with(opacity_transition);
+        }
+
         if let Some(x) = part.default_column_width {
             self.default_column_width = x.0;
         }
@@ -106,6 +120,10 @@ pub struct LayoutPart {
     pub tab_indicator: Option<TabIndicatorPart>,
     #[knuffel(child)]
     pub insert_hint: Option<InsertHintPart>,
+    #[knuffel(child)]
+    pub focus_opacity: Option<FocusOpacityPart>,
+    #[knuffel(child)]
+    pub opacity_transition: Option<OpacityTransitionPart>,
     #[knuffel(child, unwrap(children))]
     pub preset_column_widths: Option<Vec<PresetSize>>,
     #[knuffel(child)]

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1343,6 +1343,15 @@ mod tests {
                         },
                     ),
                 },
+                opacity_transition: OpacityTransition {
+                    enabled: false,
+                    duration_ms: 200,
+                    flash: FocusOpacity {
+                        enabled: false,
+                        flash_opacity: 0.8,
+                        disable_on_solo: true,
+                    },
+                },
                 preset_column_widths: [
                     Proportion(
                         0.25,

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -249,6 +249,23 @@ layout {
         color "#0007"
     }
 
+    // Enable focus flash effect for windows.
+    // This will make newly focused windows flash by briefly lowering their opacity.
+    focus-opacity {
+        // Uncomment this line to enable focus flash.
+        // on
+
+        // Opacity to flash to when window gains focus (0.0 to 1.0).
+        // The window will briefly change to this opacity, then return to its normal opacity.
+        flash-opacity 0.8
+
+        // Animation duration in milliseconds for the complete flash cycle.
+        animation-duration-ms 150
+
+        // Disable focus flash when there's only one window.
+        disable-on-solo true
+    }
+
     // Struts shrink the area occupied by windows, similarly to layer-shell panels.
     // You can think of them as a kind of outer gaps. They are set in logical pixels.
     // Left and right struts will cause the next window to the side to always be visible.

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1164,17 +1164,37 @@ impl<W: LayoutElement> FloatingSpace<W> {
 
     pub fn refresh(&mut self, is_active: bool, is_focused: bool) {
         let active = self.active_window_id.clone();
-        for tile in &mut self.tiles {
-            let win = tile.window_mut();
+        // Pre-calculate solo window status to avoid borrowing issues
+        let is_solo_window =
+            self.options.layout.opacity_transition.flash.enabled && self.tiles.len() == 1;
 
+        for tile in &mut self.tiles {
+            let mut is_tile_active = is_active && Some(tile.window().id()) == active.as_ref();
+            if self.options.deactivate_unfocused_windows {
+                is_tile_active &= is_focused;
+            }
+
+            let is_focused_now = is_tile_active && is_focused;
+
+            if self.options.layout.opacity_transition.flash.enabled
+                || self.options.layout.opacity_transition.enabled
+            {
+                let target_opacity =
+                    tile.window().rules().opacity.unwrap_or(1.0).clamp(0.0, 1.0) as f64;
+                // Run focus flash state machine before the tile is mutably borrowed below.
+                tile.update_opacity(
+                    &self.options.layout,
+                    target_opacity,
+                    is_focused_now,
+                    true, // Floating tiles are always visible/proximity
+                    is_solo_window,
+                );
+            }
+
+            let win = tile.window_mut();
             win.set_active_in_column(true);
             win.set_floating(true);
-
-            let mut is_active = is_active && Some(win.id()) == active.as_ref();
-            if self.options.deactivate_unfocused_windows {
-                is_active &= is_focused;
-            }
-            win.set_activated(is_active);
+            win.set_activated(is_tile_active);
 
             let resize_data = self
                 .interactive_resize

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -3621,7 +3621,40 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     }
 
     pub fn refresh(&mut self, is_active: bool, is_focused: bool) {
-        for (col_idx, col) in self.columns.iter_mut().enumerate() {
+        // Pre-calculate values
+        let is_solo_window = self.options.layout.opacity_transition.flash.enabled
+            && self.columns.len() == 1
+            && self.columns.first().is_some_and(|c| c.tiles.len() == 1);
+        let active_column_idx = self.active_column_idx;
+        let deactivate_unfocused_windows = self.options.deactivate_unfocused_windows;
+
+        // When focus opacity or opacity transition is enabled, we need to process all tiles
+        // (including off-screen ones) for proper animation behavior, so we don't filter
+        // columns
+        let should_process_all_tiles_for_proximity =
+            self.options.layout.opacity_transition.flash.enabled
+                || self.options.layout.opacity_transition.enabled;
+
+        let scale = self.scale;
+        let view_pos = self.view_pos();
+        let column_xs: Vec<_> = self.column_xs(self.data.iter().copied()).collect();
+
+        // Pre-calculate proximity rect to avoid borrowing self inside the loop
+        const PROXIMITY_THRESHOLD: f64 = 400.0;
+        let viewport_rect = Rectangle::new(Point::from((-view_pos, 0.)), self.view_size);
+        let expanded_viewport = Rectangle::new(
+            Point::new(
+                viewport_rect.loc.x - PROXIMITY_THRESHOLD,
+                viewport_rect.loc.y - PROXIMITY_THRESHOLD,
+            ),
+            Size::new(
+                viewport_rect.size.w + 2.0 * PROXIMITY_THRESHOLD,
+                viewport_rect.size.h + 2.0 * PROXIMITY_THRESHOLD,
+            ),
+        );
+
+        // Process all tiles (visible and proximate off-screen) together
+        for (col_idx, (col, &col_x)) in self.columns.iter_mut().zip(&column_xs).enumerate() {
             let mut col_resize_data = None;
             if let Some(resize) = &self.interactive_resize {
                 if col.contains(&resize.window) {
@@ -3658,22 +3691,59 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     })
             };
 
+            let tile_offsets: Vec<_> = col.tile_offsets().collect();
+            let col_render_off = col.render_offset();
+            let active_tile_idx = col.active_tile_idx;
+
+            // Process each tile in this column
             for (tile_idx, tile) in col.tiles.iter_mut().enumerate() {
-                let win = tile.window_mut();
-
-                let active_in_column = col.active_tile_idx == tile_idx;
-                win.set_active_in_column(active_in_column);
-                win.set_floating(false);
-
-                let mut active = is_active && self.active_column_idx == col_idx;
-                if self.options.deactivate_unfocused_windows {
-                    active &= active_in_column && is_focused;
+                let active_in_column = active_tile_idx == tile_idx;
+                let mut is_tile_active = is_active && active_column_idx == col_idx;
+                if deactivate_unfocused_windows {
+                    is_tile_active &= active_in_column && is_focused;
                 } else {
                     // In tabbed mode, all tabs have activated state to reduce unnecessary
                     // animations when switching tabs.
-                    active &= active_in_column || is_tabbed;
+                    is_tile_active &= active_in_column || is_tabbed;
                 }
-                win.set_activated(active);
+
+                let is_focused_now = is_tile_active && is_focused;
+
+                // Calculate proximity for this tile
+                let is_in_proximity = if should_process_all_tiles_for_proximity {
+                    let view_off = Point::from((-view_pos, 0.));
+                    let col_off = Point::from((col_x, 0.));
+                    let tile_off = tile_offsets[tile_idx];
+                    let pos = view_off + col_off + col_render_off + tile_off + tile.render_offset();
+                    let pos = pos.to_physical_precise_round(scale).to_logical(scale);
+
+                    let tile_rect = Rectangle::new(pos, tile.tile_size());
+                    tile_rect.intersection(expanded_viewport).is_some()
+                } else {
+                    // If focus opacity is disabled, proximity doesn't matter
+                    false
+                };
+
+                // Update opacity animation state
+                if self.options.layout.opacity_transition.flash.enabled
+                    || self.options.layout.opacity_transition.enabled
+                {
+                    let target_opacity =
+                        tile.window().rules().opacity.unwrap_or(1.0).clamp(0.0, 1.0) as f64;
+                    tile.update_opacity(
+                        &self.options.layout,
+                        target_opacity,
+                        is_focused_now,
+                        is_in_proximity,
+                        is_solo_window,
+                    );
+                }
+
+                // Continue with normal tile processing
+                let win = tile.window_mut();
+                win.set_active_in_column(active_in_column);
+                win.set_floating(false);
+                win.set_activated(is_tile_active);
 
                 win.set_interactive_resize(col_resize_data);
 

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -2,7 +2,7 @@ use core::f64;
 use std::rc::Rc;
 
 use niri_config::utils::MergeWith as _;
-use niri_config::{Color, CornerRadius, GradientInterpolation};
+use niri_config::{Color, CornerRadius, GradientInterpolation, Layout};
 use niri_ipc::WindowLayout;
 use smithay::backend::renderer::element::{Element, Kind};
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -32,6 +32,8 @@ use crate::utils::transaction::Transaction;
 use crate::utils::{
     baba_is_float_offset, round_logical_in_physical, round_logical_in_physical_max1,
 };
+
+const FOCUS_FLASH_EPSILON: f64 = 0.001;
 
 /// Toplevel window with decorations.
 #[derive(Debug)]
@@ -93,6 +95,15 @@ pub struct Tile<W: LayoutElement> {
 
     /// The animation of the tile's opacity.
     pub(super) alpha_animation: Option<AlphaAnimation>,
+
+    /// Whether the window was focused during the last render update.
+    pub(super) was_focused: bool,
+
+    /// Whether the tile was in proximity during the last render update.
+    pub(super) was_in_proximity: bool,
+
+    /// State machine for unified opacity animations (focus flash + smooth transitions).
+    opacity_state: OpacityState,
 
     /// Offset during the initial interactive move rubberband.
     pub(super) interactive_move_offset: Point<f64, Logical>,
@@ -171,6 +182,25 @@ pub(super) struct AlphaAnimation {
     offscreen: OffscreenBuffer,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+enum OpacityState {
+    #[default]
+    Idle,
+    /// The window is smoothly transitioning from one opacity to another.
+    Transitioning { target: f64 },
+    /// The window is performing a focus flash effect.
+    Flashing {
+        phase: FlashPhase,
+        base_opacity: f64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FlashPhase {
+    Rising,
+    Falling,
+}
+
 impl<W: LayoutElement> Tile<W> {
     pub fn new(
         window: W,
@@ -202,6 +232,9 @@ impl<W: LayoutElement> Tile<W> {
             move_x_animation: None,
             move_y_animation: None,
             alpha_animation: None,
+            was_focused: false,
+            was_in_proximity: false,
+            opacity_state: OpacityState::Idle,
             interactive_move_offset: Point::from((0., 0.)),
             unmap_snapshot: None,
             rounded_corner_damage: Default::default(),
@@ -450,6 +483,7 @@ impl<W: LayoutElement> Tile<W> {
                 .alpha_animation
                 .as_ref()
                 .is_some_and(|alpha| !alpha.anim.is_done())
+            || !matches!(self.opacity_state, OpacityState::Idle)
     }
 
     pub fn update_render_elements(&mut self, is_active: bool, view_rect: Rectangle<f64, Logical>) {
@@ -650,6 +684,139 @@ impl<W: LayoutElement> Tile<W> {
         }
     }
 
+    /// Call this every refresh to update the opacity animation state.
+    /// This handles both the focus flash effect and smooth transitions between active/inactive
+    /// states.
+    pub fn update_opacity(
+        &mut self,
+        layout_config: &Layout,
+        target_opacity: f64,
+        is_focused: bool,
+        is_in_proximity: bool,
+        is_solo_window: bool,
+    ) {
+        let transition_config = &layout_config.opacity_transition;
+        let focus_config = &transition_config.flash;
+
+        self.was_in_proximity = is_in_proximity;
+
+        let current_visual = self
+            .alpha_animation
+            .as_ref()
+            .map(|alpha| alpha.anim.value())
+            .unwrap_or_else(|| self.window.rules().opacity.unwrap_or(1.0).clamp(0.0, 1.0) as f64);
+
+        // 1. Check for Focus Flash Trigger
+        // If we just gained focus and flash is enabled, we INITIALIZE the flash and return early.
+        // We do not run the state machine match this frame.
+        let flash_enabled =
+            focus_config.enabled && !(is_solo_window && focus_config.disable_on_solo);
+        if is_focused && !self.was_focused && flash_enabled {
+            let flash_alpha = focus_config.flash_opacity.clamp(0.0, 1.0) as f64;
+            let (rise_duration_ms, _) = Self::focus_flash_durations(transition_config.duration_ms);
+
+            // Start Flash
+            self.opacity_state = OpacityState::Flashing {
+                phase: FlashPhase::Rising,
+                base_opacity: target_opacity,
+            };
+            self.animate_alpha(
+                current_visual,
+                flash_alpha,
+                Self::focus_flash_animation(rise_duration_ms),
+            );
+            self.was_focused = true;
+            return;
+        }
+        self.was_focused = is_focused;
+
+        // 2. Handle Existing Animation State (The Update Loop)
+        // This runs on every frame AFTER the trigger frame. It advances the current state.
+        match self.opacity_state {
+            OpacityState::Flashing {
+                phase,
+                mut base_opacity,
+            } => {
+                // If target_opacity changes during a flash, update base_opacity
+                // so we land on the correct value.
+                if !Self::nearly_equal(base_opacity, target_opacity) {
+                    base_opacity = target_opacity;
+                    self.opacity_state = OpacityState::Flashing {
+                        phase,
+                        base_opacity,
+                    };
+                }
+
+                // Advance flash animation logic
+                if let Some(alpha) = &self.alpha_animation {
+                    if alpha.anim.is_done() {
+                        match phase {
+                            FlashPhase::Rising => {
+                                // Rising done -> Switch to Falling
+                                let (_, fall_duration_ms) =
+                                    Self::focus_flash_durations(transition_config.duration_ms);
+                                self.opacity_state = OpacityState::Flashing {
+                                    phase: FlashPhase::Falling,
+                                    base_opacity,
+                                };
+                                self.animate_alpha(
+                                    alpha.anim.value(),
+                                    base_opacity,
+                                    Self::focus_flash_animation(fall_duration_ms),
+                                );
+                            }
+                            FlashPhase::Falling => {
+                                // Falling done -> Flash complete
+                                self.opacity_state = OpacityState::Idle;
+                            }
+                        }
+                    }
+                } else {
+                    // Animation was cancelled externally? Reset state.
+                    self.opacity_state = OpacityState::Idle;
+                }
+            }
+
+            OpacityState::Transitioning { target } => {
+                // If the target changed mid-transition, retarget the animation.
+                if !Self::nearly_equal(target, target_opacity) {
+                    self.opacity_state = OpacityState::Transitioning {
+                        target: target_opacity,
+                    };
+                    self.animate_alpha(
+                        current_visual,
+                        target_opacity,
+                        Self::focus_flash_animation(transition_config.duration_ms),
+                    );
+                } else if let Some(alpha) = &self.alpha_animation {
+                    if alpha.anim.is_done() {
+                        self.opacity_state = OpacityState::Idle;
+                    }
+                } else {
+                    self.opacity_state = OpacityState::Idle;
+                }
+            }
+
+            OpacityState::Idle => {
+                // 3. Detect Need for Smooth Transition
+                if !Self::nearly_equal(current_visual, target_opacity) && transition_config.enabled
+                {
+                    // Start Smooth Transition
+                    self.opacity_state = OpacityState::Transitioning {
+                        target: target_opacity,
+                    };
+                    self.animate_alpha(
+                        current_visual,
+                        target_opacity,
+                        Self::focus_flash_animation(transition_config.duration_ms),
+                    );
+                }
+            }
+        }
+
+        self.was_focused = is_focused;
+    }
+
     pub fn window(&self) -> &W {
         &self.window
     }
@@ -676,6 +843,26 @@ impl<W: LayoutElement> Tile<W> {
         }
     }
 
+    fn focus_flash_animation(duration_ms: u32) -> niri_config::Animation {
+        niri_config::Animation {
+            off: false,
+            kind: niri_config::animations::Kind::Easing(niri_config::animations::EasingParams {
+                duration_ms: duration_ms.max(1),
+                curve: niri_config::animations::Curve::EaseOutQuad,
+            }),
+        }
+    }
+
+    fn focus_flash_durations(total_ms: u32) -> (u32, u32) {
+        let total = total_ms.max(1);
+        let rise = total.div_ceil(2);
+        let fall = total.saturating_sub(rise).max(1);
+        (rise, fall)
+    }
+
+    fn nearly_equal(a: f64, b: f64) -> bool {
+        (a - b).abs() <= FOCUS_FLASH_EPSILON
+    }
     fn expanded_progress(&self) -> f64 {
         if let Some(resize) = &self.resize_animation {
             if let Some(anim) = &resize.expanded_progress {
@@ -1023,7 +1210,11 @@ impl<W: LayoutElement> Tile<W> {
         let win_alpha = if self.window.is_ignoring_opacity_window_rule() {
             1.
         } else {
-            let alpha = self.window.rules().opacity.unwrap_or(1.).clamp(0., 1.);
+            let alpha = self
+                .alpha_animation
+                .as_ref()
+                .map(|a| a.anim.value() as f32)
+                .unwrap_or_else(|| self.window.rules().opacity.unwrap_or(1.).clamp(0., 1.));
 
             // Interpolate towards alpha = 1. at fullscreen.
             let p = fullscreen_progress as f32;


### PR DESCRIPTION
Hi, 

Resubmitting as a superceeding PR since in the previous PR #2804 the user [sashaduke](https://github.com/sashaduke) had a feature request. When considering it, I felt integrating it made a lot of sense, since they share a lot of overlap.  

This PR introduces two complementary features. 
1, Smooth opacity transitions when changing focus between two windows of different opacity.  Requested in [#1801](https://github.com/YaLTeR/niri/discussions/1801).
2, Focus flash, as discussed in #2804 and [#1380](https://github.com/YaLTeR/niri/discussions/1380), which provides visual feedback via a short opacity change when a window is focused. Making it easier to see which window is focused. Especially when not using borders or focus rings.

[niri-demo-vp9-crf26.webm](https://github.com/user-attachments/assets/8eb44c0a-eaba-4c58-aca4-c4875fecdc90)

The new settings goes into the ``layout`` block 

```
layout {
    opacity-transition {
        on                    // Enable smooth transitions
        duration-ms 350       // Animation duration for both transitions and flash
        flash {
            on                // Enable focus flash effect
            flash-opacity 0.8 // Target opacity during flash (0.0 - 1.0)
            disable-on-solo   // Optional: disable flash for solo windows
        }
    }
}
```
