### PR TITLE
Fix y-inversion bug in rounded corner rendering

### DIFF
--- a/src/ui/mru.rs
+++ b/src/ui/mru.rs
@@ -385,48 +385,58 @@ impl Thumbnail {
         let clip_shader = ClippedSurfaceRenderElement::shader(renderer).cloned();
         let geo = Rectangle::from_size(self.size.to_f64());
         // FIXME: deduplicate code with Tile::render_inner()
-        let elems = elems.map(move |elem| match elem {
-            LayoutElementRenderElement::Wayland(elem) => {
-                if let Some(shader) = clip_shader.clone() {
-                    if ClippedSurfaceRenderElement::will_clip(&elem, s, geo, radius) {
-                        let elem =
-                            ClippedSurfaceRenderElement::new(elem, s, geo, shader.clone(), radius);
-                        return ThumbnailRenderElement::ClippedSurface(elem);
+        let mut elems_vec = Vec::new();
+        for elem in elems {
+            let processed = match elem {
+                LayoutElementRenderElement::Wayland(elem) => {
+                    if let Some(shader) = clip_shader.clone() {
+                        if ClippedSurfaceRenderElement::will_clip(&elem, s, geo, radius) {
+                            let y_inverted = ClippedSurfaceRenderElement::buffer_y_inverted(&elem, renderer);
+                            let elem =
+                                ClippedSurfaceRenderElement::new(elem, s, geo, shader.clone(), radius, y_inverted);
+                            ThumbnailRenderElement::ClippedSurface(elem)
+                        } else {
+                            // If we don't have the shader, render it normally.
+                            let elem = LayoutElementRenderElement::Wayland(elem);
+                            ThumbnailRenderElement::LayoutElement(elem)
+                        }
+                    } else {
+                        // If we don't have the shader, render it normally.
+                        let elem = LayoutElementRenderElement::Wayland(elem);
+                        ThumbnailRenderElement::LayoutElement(elem)
                     }
                 }
-
-                // If we don't have the shader, render it normally.
-                let elem = LayoutElementRenderElement::Wayland(elem);
-                ThumbnailRenderElement::LayoutElement(elem)
-            }
-            LayoutElementRenderElement::SolidColor(elem) => {
-                // In this branch we're rendering a blocked-out window with a solid
-                // color. We need to render it with a rounded corner shader even if
-                // clip_to_geometry is false, because in this case we're assuming that
-                // the unclipped window CSD already has corners rounded to the
-                // user-provided radius, so our blocked-out rendering should match that
-                // radius.
-                if radius != CornerRadius::default() && has_border_shader {
-                    return BorderRenderElement::new(
-                        geo.size,
-                        Rectangle::from_size(geo.size),
-                        GradientInterpolation::default(),
-                        Color::from_color32f(elem.color()),
-                        Color::from_color32f(elem.color()),
-                        0.,
-                        Rectangle::from_size(geo.size),
-                        0.,
-                        radius,
-                        scale as f32,
-                        1.,
-                    )
-                    .into();
+                LayoutElementRenderElement::SolidColor(elem) => {
+                    // In this branch we're rendering a blocked-out window with a solid
+                    // color. We need to render it with a rounded corner shader even if
+                    // clip_to_geometry is false, because in this case we're assuming that
+                    // the unclipped window CSD already has corners rounded to the
+                    // user-provided radius, so our blocked-out rendering should match that
+                    // radius.
+                    if radius != CornerRadius::default() && has_border_shader {
+                        BorderRenderElement::new(
+                            geo.size,
+                            Rectangle::from_size(geo.size),
+                            GradientInterpolation::default(),
+                            Color::from_color32f(elem.color()),
+                            Color::from_color32f(elem.color()),
+                            0.,
+                            Rectangle::from_size(geo.size),
+                            0.,
+                            radius,
+                            scale as f32,
+                            1.,
+                        )
+                        .into()
+                    } else {
+                        // Otherwise, render the solid color as is.
+                        LayoutElementRenderElement::SolidColor(elem).into()
+                    }
                 }
-
-                // Otherwise, render the solid color as is.
-                LayoutElementRenderElement::SolidColor(elem).into()
-            }
-        });
+            };
+            elems_vec.push(processed);
+        }
+        let elems = elems_vec.into_iter();
 
         let elems = elems.map(move |elem| {
             let thumb_scale = Scale {


### PR DESCRIPTION
## Summary

Fixes rounded corner rendering for y-inverted Wayland buffers (dmabuf media players, certain GPU configurations).

## Changes

- Add `buffer_y_inverted()` helper to detect y-inverted buffers via Smithay's API
- Apply Y-axis coordinate transformation in clipped surface shader
- Convert lazy iterators to eager Vec materialization in tile.rs and mru.rs for renderer access

## Files Modified

- src/render_helpers/clipped_surface.rs
- src/layout/tile.rs
- src/ui/mru.rs