### PR TITLE
Add delay to hot corner

### DIFF
--- a/niri-config/src/gestures.rs
+++ b/niri-config/src/gestures.rs
@@ -111,4 +111,8 @@ pub struct HotCorners {
     pub bottom_right: bool,
     #[knuffel(child, unwrap(argument))]
     pub open_delay_ms: Option<u16>,
+    #[knuffel(child, unwrap(argument))]
+    pub open_region_width: Option<u16>,
+    #[knuffel(child, unwrap(argument))]
+    pub open_region_height: Option<u16>,
 }

--- a/niri-config/src/gestures.rs
+++ b/niri-config/src/gestures.rs
@@ -109,4 +109,6 @@ pub struct HotCorners {
     pub bottom_left: bool,
     #[knuffel(child)]
     pub bottom_right: bool,
+    #[knuffel(child, unwrap(argument))]
+    pub open_delay_ms: Option<u16>,
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 use calloop::timer::{TimeoutAction, Timer};
 use input::event::gesture::GestureEventCoordinates as _;
 use niri_config::{
-    Action, Bind, Binds, Config, Key, ModKey, Modifiers, MruDirection, SwitchBinds, Trigger,
+    Action, Bind, Binds, Config, Key, ModKey, Modifiers, MruDirection, OutputName, SwitchBinds,
+    Trigger,
 };
 use niri_ipc::LayoutSwitchTarget;
 use smithay::backend::input::{
@@ -2580,7 +2581,18 @@ impl State {
                 .with_grab(|_, grab| grab_allows_hot_corner(grab))
                 .unwrap_or(true)
         {
-            let timer = Timer::from_duration(Duration::from_millis(1000));
+            let config = self.niri.config.borrow();
+            let hot_corners = under
+                .output
+                .unwrap()
+                .user_data()
+                .get::<OutputName>()
+                .and_then(|name| config.outputs.find(name))
+                .and_then(|c| c.hot_corners)
+                .unwrap_or(config.gestures.hot_corners);
+            let delay = hot_corners.open_delay_ms;
+
+            let timer = Timer::from_duration(Duration::from_millis(u64::from(delay.unwrap_or(0))));
 
             let token = self
                 .niri
@@ -2691,7 +2703,18 @@ impl State {
                 .with_grab(|_, grab| grab_allows_hot_corner(grab))
                 .unwrap_or(true)
         {
-            let timer = Timer::from_duration(Duration::from_millis(1000));
+            let config = self.niri.config.borrow();
+            let hot_corners = under
+                .output
+                .unwrap()
+                .user_data()
+                .get::<OutputName>()
+                .and_then(|name| config.outputs.find(name))
+                .and_then(|c| c.hot_corners)
+                .unwrap_or(config.gestures.hot_corners);
+            let delay = hot_corners.open_delay_ms;
+
+            let timer = Timer::from_duration(Duration::from_millis(u64::from(delay.unwrap_or(0))));
 
             let token = self
                 .niri

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -3273,17 +3273,22 @@ impl Niri {
         let geom = self.global_space.output_geometry(output).unwrap();
         let size = geom.size.to_f64();
 
+        let region_size = Size::new(
+            f64::from(hot_corners.open_region_width.unwrap_or(1)),
+            f64::from(hot_corners.open_region_height.unwrap_or(1)),
+        );
+
         let contains = move |corner: Point<f64, Logical>| {
-            Rectangle::new(corner, Size::new(1., 1.)).contains(pos)
+            Rectangle::new(corner, region_size).contains(pos)
         };
 
-        if hot_corners.top_right && contains(Point::new(size.w - 1., 0.)) {
+        if hot_corners.top_right && contains(Point::new(size.w - region_size.w, 0.)) {
             return true;
         }
-        if hot_corners.bottom_left && contains(Point::new(0., size.h - 1.)) {
+        if hot_corners.bottom_left && contains(Point::new(0., size.h - region_size.h)) {
             return true;
         }
-        if hot_corners.bottom_right && contains(Point::new(size.w - 1., size.h - 1.)) {
+        if hot_corners.bottom_right && contains(Point::new(size.w - region_size.w, size.h - region_size.h)) {
             return true;
         }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -363,7 +363,7 @@ pub struct Niri {
     /// Used for limiting the notify to once per iteration, so that it's not spammed with high
     /// resolution mice.
     pub notified_activity_this_iteration: bool,
-    pub pointer_inside_hot_corner: bool,
+    pub pointer_inside_hot_corner_timer: Option<RegistrationToken>,
     pub tablet_cursor_location: Option<Point<f64, Logical>>,
     pub gesture_swipe_3f_cumulative: Option<(f64, f64)>,
     pub overview_scroll_swipe_gesture: ScrollSwipeGesture,
@@ -2784,7 +2784,7 @@ impl Niri {
             pointer_inactivity_timer: None,
             pointer_inactivity_timer_got_reset: false,
             notified_activity_this_iteration: false,
-            pointer_inside_hot_corner: false,
+            pointer_inside_hot_corner_timer: None,
             tablet_cursor_location: None,
             gesture_swipe_3f_cumulative: None,
             overview_scroll_swipe_gesture: ScrollSwipeGesture::new(),


### PR DESCRIPTION
# Rationale

The hot corner feature is very useful but I end up triggering it all the time when I do not mean to. This PR implements a configurable short delay during which the cursor must be held in the hot corner before the overview is opened, similar to KDE's hot corner functionality.

# Changes

* Added the field `open-delay-ms` to the `hot-corners` configuration object.
* The overview opening is now controlled by a callback triggering `open-delay-ms` milliseconds after the cursor enters the hot corner region. The callback is canceled upon leaving the hot corner region.
* To aid the user in positioning the cursor in the hot corner for the full time, two new options have been added to the `hot-corners` configuration object, `open-region-width` and `open-region-height`.
* The hot corner triggers if the cursor is within `open-region-width` horizontal pixels of the corner and `open-region-height` vertical pixels of the corner.

# Remarks

This PR is functional, but I am not fully satisfied with the code quality. Reviews are *heavily* requested to ensure that the code conforms to the style preferred by active niri developers. I think that my additions to the hot corners configuration could certainly be cleaned up, but I got lost in the complexity of changing the configuration format too much.

This PR also provides no documentation or tests. This is intentional as through the review process the exact form of the feature and its configuration is liable to change. I will write both, but I may need guidance through some aspects.

I have tested the code on my end, however, and a screencast showing the correct functioning of all added features will be forthcoming.