### PR TITLE
layout: add anchor [left|right]

### DIFF
--- a/niri-config/src/layout.rs
+++ b/niri-config/src/layout.rs
@@ -24,6 +24,7 @@ pub struct Layout {
     pub gaps: f64,
     pub struts: Struts,
     pub background_color: Color,
+    pub anchor: Anchor,
 }
 
 impl Default for Layout {
@@ -52,6 +53,7 @@ impl Default for Layout {
                 PresetSize::Proportion(2. / 3.),
             ],
             background_color: DEFAULT_BACKGROUND_COLOR,
+            anchor: Anchor::default(),
         }
     }
 }
@@ -78,6 +80,7 @@ impl MergeWith<LayoutPart> for Layout {
             default_column_display,
             struts,
             background_color,
+            anchor,
         );
 
         if let Some(x) = part.default_column_width {
@@ -126,6 +129,8 @@ pub struct LayoutPart {
     pub struts: Option<Struts>,
     #[knuffel(child)]
     pub background_color: Option<Color>,
+    #[knuffel(child, unwrap(argument))]
+    pub anchor: Option<Anchor>,
 }
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
@@ -168,6 +173,15 @@ pub enum CenterFocusedColumn {
     /// Focusing a column will center it if it doesn't fit on the screen together with the
     /// previously focused column.
     OnOverflow,
+}
+
+#[derive(knuffel::DecodeScalar, Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub enum Anchor {
+    /// Columns are anchored to the left edge of the output.
+    #[default]
+    Left,
+    /// Columns are anchored to the right edge of the output.
+    Right,
 }
 
 impl<S> knuffel::Decode<S> for DefaultPresetSize

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1451,6 +1451,7 @@ mod tests {
                     b: 0.25,
                     a: 1.0,
                 },
+                anchor: Left,
             },
             prefer_no_csd: true,
             cursor: Cursor {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use niri_config::utils::MergeWith as _;
-use niri_config::{CenterFocusedColumn, PresetSize, Struts};
+use niri_config::{Anchor, CenterFocusedColumn, PresetSize, Struts};
 use niri_ipc::{ColumnDisplay, SizeChange, WindowLayout};
 use ordered_float::NotNan;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -972,7 +972,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             if was_empty {
                 0
             } else {
-                self.active_column_idx + 1
+                match self.options.layout.anchor {
+                    Anchor::Left => self.active_column_idx + 1,
+                    Anchor::Right => 0,
+                }
             }
         });
 
@@ -986,39 +989,72 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         self.data.insert(idx, ColumnData::new(&column));
         self.columns.insert(idx, column);
 
-        if !was_empty && idx <= self.active_column_idx {
+        if activate {
+            if was_empty {
+                // For the first window on an empty workspace.
+                if matches!(self.options.layout.anchor, Anchor::Right) {
+                    // Right anchor: Set view_offset to -anchor_offset so columns appear from the
+                    // right.
+                    self.view_offset = ViewOffset::Static(-self.anchor_offset());
+                    self.active_column_idx = idx;
+                } else {
+                    // Left anchor: Use standard logic which applies padding.
+                    self.view_offset = ViewOffset::Static(0.);
+                    self.view_offset = ViewOffset::Static(
+                        self.compute_new_view_offset_for_column(None, idx, None),
+                    );
+                    self.active_column_idx = idx;
+                }
+            } else if matches!(self.options.layout.anchor, Anchor::Right) {
+                // For right anchor, show as many columns as possible from the right.
+                let working_width = self.working_area.size.w;
+                let total_width = self.total_columns_width();
+
+                let target_view_pos = if total_width <= working_width {
+                    // All columns fit - align rightmost column to the right edge
+                    let rightmost_idx = self.columns.len() - 1;
+                    let rightmost_col_x = self.column_x(rightmost_idx);
+                    let rightmost_col_width = self.data[rightmost_idx].width;
+                    rightmost_col_x + rightmost_col_width - working_width
+                } else {
+                    // Overflow - left-align the newest (leftmost) column
+                    self.column_x(0)
+                };
+
+                self.view_offset = ViewOffset::Static(target_view_pos - self.column_x(idx));
+                self.active_column_idx = idx;
+            } else {
+                // Left anchor - use standard activation logic
+                let prev_offset =
+                    (idx == self.active_column_idx + 1).then(|| self.view_offset.stationary());
+
+                let anim_config =
+                    anim_config.unwrap_or(self.options.animations.horizontal_view_movement.0);
+                self.activate_column_with_anim_config(idx, anim_config);
+                self.activate_prev_column_on_removal = prev_offset;
+            }
+        } else if !was_empty && idx <= self.active_column_idx {
             self.active_column_idx += 1;
         }
 
         // Animate movement of other columns.
-        let offset = self.column_x(idx + 1) - self.column_x(idx);
-        let config = anim_config.unwrap_or(self.options.animations.window_movement.0);
-        if self.active_column_idx <= idx {
-            for col in &mut self.columns[idx + 1..] {
-                col.animate_move_from_with_config(-offset, config);
-            }
-        } else {
-            for col in &mut self.columns[..idx] {
-                col.animate_move_from_with_config(offset, config);
-            }
-        }
+        // Skip animation for right anchor when inserting at index 0, since columns don't move
+        // relative to each other - only the anchor_offset changes, which is handled by the
+        // view_offset adjustment.
+        let should_animate = !(matches!(self.options.layout.anchor, Anchor::Right) && idx == 0);
 
-        if activate {
-            // If this is the first window on an empty workspace, remove the effect of whatever
-            // view_offset was left over and skip the animation.
-            if was_empty {
-                self.view_offset = ViewOffset::Static(0.);
-                self.view_offset =
-                    ViewOffset::Static(self.compute_new_view_offset_for_column(None, idx, None));
+        if should_animate {
+            let offset = self.column_x(idx + 1) - self.column_x(idx);
+            let config = anim_config.unwrap_or(self.options.animations.window_movement.0);
+            if self.active_column_idx <= idx {
+                for col in &mut self.columns[idx + 1..] {
+                    col.animate_move_from_with_config(-offset, config);
+                }
+            } else {
+                for col in &mut self.columns[..idx] {
+                    col.animate_move_from_with_config(offset, config);
+                }
             }
-
-            let prev_offset = (!was_empty && idx == self.active_column_idx + 1)
-                .then(|| self.view_offset.stationary());
-
-            let anim_config =
-                anim_config.unwrap_or(self.options.animations.horizontal_view_movement.0);
-            self.activate_column_with_anim_config(idx, anim_config);
-            self.activate_prev_column_on_removal = prev_offset;
         }
     }
 
@@ -2298,11 +2334,33 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         self.column_x(self.active_column_idx) + self.view_offset.target()
     }
 
+    // Calculate the total width of all columns including gaps
+    fn total_columns_width(&self) -> f64 {
+        let gaps = self.options.layout.gaps;
+        let cols_width: f64 = self.data.iter().map(|d| d.width).sum();
+        let gaps_width = gaps * (self.columns.len().saturating_sub(1)) as f64;
+        cols_width + gaps_width
+    }
+
+    // Calculate the X offset for right-anchor mode
+    fn anchor_offset(&self) -> f64 {
+        match self.options.layout.anchor {
+            Anchor::Right => {
+                let total_width = self.total_columns_width();
+                let working_width = self.working_area.size.w;
+                let working_left = self.working_area.loc.x;
+                (working_width - total_width).max(0.) + working_left
+            }
+            Anchor::Left => 0.,
+        }
+    }
+
     // HACK: pass a self.data iterator in manually as a workaround for the lack of method partial
     // borrowing. Note that this method's return value does not borrow the entire &Self!
     fn column_xs(&self, data: impl Iterator<Item = ColumnData>) -> impl Iterator<Item = f64> {
         let gaps = self.options.layout.gaps;
-        let mut x = 0.;
+        let anchor_offset = self.anchor_offset();
+        let mut x = anchor_offset;
 
         // Chain with a dummy value to be able to get one past all columns' X.
         let dummy = ColumnData { width: 0. };


### PR DESCRIPTION
Controls whether windows are laid out left to right, the default or
right to left.

anchor "[left|right]" is a new config option with layout {},
or may be overridden by a per-output layout{} section.

Fixes: https://github.com/YaLTeR/niri/discussions/1642
Fixes: https://github.com/YaLTeR/niri/discussions/658

## Naming

There are other names which might well for this. Suggestions welcome if you have a better idea!
## Using

As noted in the commit, with this patch you an add

`anchor "right"` to the top level `layout {}` block
or have per-output overrides within an output's `layout` block.

`anchor "left"` is also supported, but is the same as not adding this
at all.

## Status

Works for basic cases. In draft state for feedback.

## Known issues

### Shrinking a window

If a window is resized to be smaller on an output with anchor=right, the right edge of the window should stay fixed (anchored!) and the left edge should move towards it.

### Growing the width of the output

- If you resize an output to be wider, a window that was right-anchored will lose the anchor. This is visually different behavior than left anchored. This is because the window is being widened by adding space on the right.
Not sure if we could widen the output on the left side in this case, or if we'd run into a problem with negative numbers.

### Combining with `always-center-single-column`

If using `always-center-single-column` in combining with anchor=right,
when adding a second window, the second window appear on the left as expected, and both windows will move to become right-aligned. This is nice, but differs from the anchor=left behavior. With the default anchor=left behavior, the first window centered, and add the second window to the right of it.

To me, the anchor=left behavior looks more like a bug-- as soon as there is more than one window, I would expect left or right anchoring to apply.

### Restoring state when unfullscreening.

If a right-anchored window is fullscreened and then unfullscreened, it returns to be left-anchored instead of right anchored. 

## Scope

Excluded from scope is the concept of anchoring windows
to the center. That is, a first window might
appear in the center, then when a second window appears
they move so that both are centered.

First, there really *two* center anchoring options people
might like, one where the second window appears on the right
and a second where the window appears on the left.

There are also already actions for "center-column", "center-window"
and "center-visible-columns", so if you want to you center columns,
there are already ways to do that.

