### PR TITLE
Update issue template to put niri config into `<details>` block

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,13 @@ assignees: ''
 <!-- Please describe the issue here at the top, then fill in the system information below. -->
 
 <!-- Attaching your full niri config can help diagnose the problem. -->
+<details><summary>Config</summary>
+
+```kdl
+insert config here
+```
+
+</details> 
 
 <!--
 If you have a problem with a specific app, please verify that it is running on Wayland, rather than X11. An easy way is to run xeyes and mouse over the app: xeyes will be able to "see" only X11 windows.


### PR DESCRIPTION
Since using Niri and reading through quite a few issues, I've found that I often scroll entirely past the config. From a user's point of view, I'm usually not interested in the reporter's entire config.

This makes issues much more readable and prevents readers from needing to scroll all the way past the config.