### PR TITLE
feat: allow optional includes

### DIFF
--- a/docs/wiki/Configuration:-Include.md
+++ b/docs/wiki/Configuration:-Include.md
@@ -118,8 +118,8 @@ window-rule {
 
 <sup>Since: next release</sup>
 
-By default, including a nonexistent file will cause an error. You can allow
-nonexistent includes by setting `optional=true`:
+By default, including a nonexistent file will cause an error.
+You can allow nonexistent includes by setting `optional=true`:
 
 ```kdl,must-fail
 // Won't fail if this file doesn't exist.

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -294,7 +294,10 @@ where
                     // Parse the path argument
                     let mut iter_args = node.arguments.iter();
                     let path_val = iter_args.next().ok_or_else(|| {
-                        DecodeError::missing(node, "additional argument for include path is required")
+                        DecodeError::missing(
+                            node,
+                            "additional argument for include path is required",
+                        )
                     })?;
                     let path: PathBuf = knuffel::traits::DecodeScalar::decode(path_val, ctx)?;
 


### PR DESCRIPTION
Cf. #3012 

This seems to have the desired behavior, regarding optional configuration. It may be desirable to drop the `tracing::warn!`. But, I figured it doesn't hurt to give users the feedback if they explicitly run `niri validate`. No toast/notification appears on log-in which would otherwise be a bit scary.


This seems to work in my system configuration https://github.com/johnrichardrinehart/JohnOS/commit/b75129a2cfad7a7dcd53cbbfc7d4083077e91300. I also tested this ex situ (first). `optional=false` fails if the file doesn't exist. `optional=true` succeeds. Omitting is the same as `optional=false`.

Also, no changes needed to be made to the watcher logic, apparently. My "included" configuration changes were picked up within 500ms of `rm /tmp/niri.kdl && mv /tmp/niri.kdl.bkp /tmp/niri.kdl` and removed within 500ms of `mv /tmp/niri.kdl /tmp/niri.kdl.bkp`. So, all should be good.

Just let me know about dropping that `warn!` commit.

# Justification/Rationale

1. Many users describe their system configuration in a way that makes my default `niri` configuration immutable at runtime. So, if they want to do things like
    ```
    include "/tmp/niri.kdl"
    ```
    they can't unless `/tmp/niri.kdl` already exists. And, this file may be used only for development purposes so it doesn't make sense to ensure that it always exists.

1. This is a small patch to the grammar and behavior of `niri`, available only under opt-in conditions. So, it should affect a relatively small subset of users (low support burden)

1. This has already been requested [independently](https://github.com/YaLTeR/niri/issues/3012) in a [few places](https://github.com/YaLTeR/niri/pull/2482#issuecomment-3352515217). And, this PR (description) has only positive responses, so far. So, let's give the people what they want!

