### PR TITLE
Use Grab&Grabbing cursors for interactive move

### DIFF
--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -7,7 +7,7 @@ use smithay::desktop::{
     PopupKeyboardGrab, PopupKind, PopupManager, PopupPointerGrab, PopupUngrabStrategy, Window,
     WindowSurfaceType,
 };
-use smithay::input::pointer::{CursorIcon, Focus};
+use smithay::input::pointer::Focus;
 use smithay::output::Output;
 use smithay::reexports::wayland_protocols::xdg::decoration::zv1::server::zxdg_toplevel_decoration_v1;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_positioner::ConstraintAdjustment;
@@ -134,17 +134,13 @@ impl XdgShellHandler for State {
 
         match &start_data {
             PointerOrTouchStartData::Pointer(_) => {
-                if let Some(grab) =
-                    MoveGrab::new(self, start_data, window.clone(), true, CursorIcon::Move)
-                {
+                if let Some(grab) = MoveGrab::new(self, start_data, window.clone(), true, None) {
                     pointer.set_grab(self, grab, serial, Focus::Clear);
                 }
             }
             PointerOrTouchStartData::Touch(_) => {
                 let touch = self.niri.seat.get_touch().unwrap();
-                if let Some(grab) =
-                    MoveGrab::new(self, start_data, window.clone(), true, CursorIcon::Move)
-                {
+                if let Some(grab) = MoveGrab::new(self, start_data, window.clone(), true, None) {
                     touch.set_grab(self, grab, serial);
                 }
             }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2859,12 +2859,20 @@ impl State {
                         let start_data = PointerOrTouchStartData::Pointer(start_data);
                         let icon = CursorIcon::Grabbing;
                         if let Some(grab) =
-                            MoveGrab::new(self, start_data, window.clone(), false, icon)
+                            MoveGrab::new(self, start_data, window.clone(), false, Some(icon))
                         {
                             pointer.set_grab(self, grab, serial, Focus::Clear);
-                            self.niri
-                                .cursor_manager
-                                .set_cursor_image(CursorImageStatus::Named(icon));
+
+                            // Set the cursor to Grabbing right away for Mod+LMB since it doesn't
+                            // do any other gesture.
+                            //
+                            // In the overview, we click to activate window and close the overview,
+                            // in this case setting the cursor right away would be distracting.
+                            if !is_overview_open {
+                                self.niri
+                                    .cursor_manager
+                                    .set_cursor_image(CursorImageStatus::Named(icon));
+                            }
                         }
                     }
                 }
@@ -4112,13 +4120,9 @@ impl State {
                         location: pos,
                     };
                     let start_data = PointerOrTouchStartData::Touch(start_data);
-                    let icon = CursorIcon::Grabbing;
-                    if let Some(grab) = MoveGrab::new(self, start_data, window.clone(), true, icon)
+                    if let Some(grab) = MoveGrab::new(self, start_data, window.clone(), true, None)
                     {
                         handle.set_grab(self, grab, serial);
-                        self.niri
-                            .cursor_manager
-                            .set_cursor_image(CursorImageStatus::Named(icon));
                     }
                 }
 

--- a/src/input/move_grab.rs
+++ b/src/input/move_grab.rs
@@ -43,7 +43,7 @@ impl MoveGrab {
         start_data: PointerOrTouchStartData<State>,
         window: Window,
         enable_view_offset: bool,
-        move_icon: CursorIcon,
+        move_icon: Option<CursorIcon>,
     ) -> Option<Self> {
         let (output, pos_within_output) = state.niri.output_under(start_data.location())?;
 
@@ -55,7 +55,8 @@ impl MoveGrab {
             window,
             gesture: GestureState::Recognizing,
             enable_view_offset,
-            move_icon,
+            // Moving windows by their titlebars uses the default cursor by default.
+            move_icon: move_icon.unwrap_or(CursorIcon::Default),
         })
     }
 


### PR DESCRIPTION
There was no real indication that something can be dragged and thus it's generally harder to discover for someone not familiar with Mod+LMB to start dragging window around.

--

I was surprised that `Move` is usually linked to `Default`. The `Grab` might be missing, however `Grabbing` is rather common. Not feeling strong about this one, mostly a preference.