### PR TITLE
Add appearance-rule blocks for portal appearance settings

### DIFF
--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -99,6 +99,7 @@ nav:
     - Layout: Configuration:-Layout.md
     - Named Workspaces: Configuration:-Named-Workspaces.md
     - Miscellaneous: Configuration:-Miscellaneous.md
+    - Appearance Rules: Configuration:-Appearance-Rules.md
     - Window Rules: Configuration:-Window-Rules.md
     - Layer Rules: Configuration:-Layer-Rules.md
     - Animations: Configuration:-Animations.md

--- a/docs/wiki/Configuration:-Appearance-Rules.md
+++ b/docs/wiki/Configuration:-Appearance-Rules.md
@@ -1,0 +1,62 @@
+### Overview
+
+Appearance rules let you apply parts of the config based on system appearance settings (provided through `xdg-desktop-portal`).
+
+Like window rules, appearance rules are processed in order of appearance in the config file.
+This means you can start with a base configuration, then override it for specific appearance modes later.
+
+Each `appearance-rule` can contain `layout`, `overview`, and `animations` blocks (with the same contents as the top-level blocks).
+
+```kdl
+overview {
+    backdrop-color "#112233"
+}
+
+appearance-rule {
+    match color-scheme="dark"
+
+    overview {
+        backdrop-color "#445566"
+    }
+}
+```
+
+### Matching
+
+Each appearance rule can have several `match` and `exclude` directives.
+In order for the rule to apply, the current appearance settings need to match *any* of the `match` directives, and *none* of the `exclude` directives.
+
+If you omit all `match` directives, the rule matches all appearance settings (subject to `exclude`).
+
+Match and exclude directives have the same syntax.
+There can be multiple matchers in one directive, then all of them need to match for the directive to apply.
+
+```kdl
+appearance-rule {
+    match color-scheme="dark" contrast="high"
+    exclude reduced-motion=true
+
+    animations {
+        // For example, slow down animations in high-contrast dark mode.
+        slowdown 2.0
+    }
+}
+```
+
+### Matchers
+
+- `color-scheme`: `"light"` or `"dark"`.
+- `contrast`: `"high"`.
+- `reduced-motion`: `true` or `false`.
+
+For example, you can honor reduced motion by disabling animations when the setting is enabled:
+
+```kdl
+appearance-rule {
+    match reduced-motion=true
+
+    animations {
+        off
+    }
+}
+```

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -29,6 +29,7 @@
 * [Layout](./Configuration:-Layout.md)
 * [Named Workspaces](./Configuration:-Named-Workspaces.md)
 * [Miscellaneous](./Configuration:-Miscellaneous.md)
+* [Appearance Rules](./Configuration:-Appearance-Rules.md)
 * [Window Rules](./Configuration:-Window-Rules.md)
 * [Layer Rules](./Configuration:-Layer-Rules.md)
 * [Animations](./Configuration:-Animations.md)

--- a/niri-config/src/appearance_rule.rs
+++ b/niri-config/src/appearance_rule.rs
@@ -1,0 +1,185 @@
+use std::str::FromStr;
+
+use crate::animations::AnimationsPart;
+use crate::{LayoutPart, OverviewPart};
+
+#[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
+pub struct AppearanceRule {
+    #[knuffel(children(name = "match"))]
+    pub matches: Vec<Match>,
+    #[knuffel(children(name = "exclude"))]
+    pub excludes: Vec<Match>,
+
+    #[knuffel(child)]
+    pub layout: Option<LayoutPart>,
+    #[knuffel(child)]
+    pub overview: Option<OverviewPart>,
+    #[knuffel(child)]
+    pub animations: Option<AnimationsPart>,
+}
+
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Match {
+    #[knuffel(property(name = "color-scheme"), str)]
+    pub color_scheme: Option<ColorScheme>,
+    #[knuffel(property, str)]
+    pub contrast: Option<Contrast>,
+    #[knuffel(property(name = "reduced-motion"))]
+    pub reduced_motion: Option<bool>,
+}
+
+impl AppearanceRule {
+    pub fn matches(&self, appearance: AppearanceSettings) -> bool {
+        let include_matches =
+            self.matches.is_empty() || self.matches.iter().any(|m| m.matches(appearance));
+        if !include_matches {
+            return false;
+        }
+
+        if self.excludes.iter().any(|m| m.matches(appearance)) {
+            return false;
+        }
+
+        true
+    }
+}
+
+impl Match {
+    pub fn matches(&self, appearance: AppearanceSettings) -> bool {
+        if let Some(expected) = self.color_scheme {
+            if appearance.color_scheme != Some(expected) {
+                return false;
+            }
+        }
+
+        if let Some(expected) = self.contrast {
+            if appearance.contrast != Some(expected) {
+                return false;
+            }
+        }
+
+        if let Some(expected) = self.reduced_motion {
+            if appearance.reduced_motion != expected {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct AppearanceSettings {
+    pub color_scheme: Option<ColorScheme>,
+    pub contrast: Option<Contrast>,
+    pub reduced_motion: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorScheme {
+    Light,
+    Dark,
+}
+
+impl FromStr for ColorScheme {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "light" => Ok(Self::Light),
+            "dark" => Ok(Self::Dark),
+            _ => Err(format!(
+                "invalid color scheme {s:?}, expected \"light\" or \"dark\""
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Contrast {
+    High,
+}
+
+impl FromStr for Contrast {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "high" => Ok(Self::High),
+            _ => Err(format!("invalid contrast {s:?}, expected \"high\"")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Config;
+
+    #[test]
+    fn parses_appearance_rule_block() {
+        let config = Config::parse_mem(
+            r#"
+            appearance-rule {
+                match color-scheme="dark"
+                layout {
+                    gaps 8
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.appearance_rules.len(), 1);
+        let rule = &config.appearance_rules[0];
+        assert_eq!(rule.matches.len(), 1);
+        assert!(rule.layout.is_some());
+    }
+
+    #[test]
+    fn match_semantics() {
+        let appearance = AppearanceSettings {
+            color_scheme: Some(ColorScheme::Dark),
+            contrast: None,
+            reduced_motion: false,
+        };
+
+        let m = Match {
+            color_scheme: Some(ColorScheme::Dark),
+            contrast: None,
+            reduced_motion: Some(false),
+        };
+        assert!(m.matches(appearance));
+
+        let m = Match {
+            color_scheme: Some(ColorScheme::Light),
+            contrast: None,
+            reduced_motion: None,
+        };
+        assert!(!m.matches(appearance));
+
+        let rule = AppearanceRule {
+            matches: vec![
+                Match {
+                    color_scheme: Some(ColorScheme::Light),
+                    contrast: None,
+                    reduced_motion: None,
+                },
+                Match {
+                    color_scheme: Some(ColorScheme::Dark),
+                    contrast: None,
+                    reduced_motion: None,
+                },
+            ],
+            excludes: vec![Match {
+                color_scheme: None,
+                contrast: None,
+                reduced_motion: Some(true),
+            }],
+            layout: None,
+            overview: None,
+            animations: None,
+        };
+        assert!(rule.matches(appearance));
+    }
+}

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -30,6 +30,7 @@ pub mod macros;
 
 pub mod animations;
 pub mod appearance;
+pub mod appearance_rule;
 pub mod binds;
 pub mod debug;
 pub mod error;
@@ -46,6 +47,7 @@ pub mod workspace;
 
 pub use crate::animations::{Animation, Animations};
 pub use crate::appearance::*;
+pub use crate::appearance_rule::{AppearanceRule, AppearanceSettings, ColorScheme, Contrast};
 pub use crate::binds::*;
 pub use crate::debug::Debug;
 pub use crate::error::{ConfigIncludeError, ConfigParseResult};
@@ -82,6 +84,7 @@ pub struct Config {
     pub overview: Overview,
     pub environment: Environment,
     pub xwayland_satellite: XwaylandSatellite,
+    pub appearance_rules: Vec<AppearanceRule>,
     pub window_rules: Vec<WindowRule>,
     pub layer_rules: Vec<LayerRule>,
     pub binds: Binds,
@@ -159,6 +162,7 @@ where
                 "output"
                     | "spawn-at-startup"
                     | "spawn-sh-at-startup"
+                    | "appearance-rule"
                     | "window-rule"
                     | "layer-rule"
                     | "workspace"
@@ -207,6 +211,7 @@ where
                 }
                 "spawn-at-startup" => m_push!(spawn_at_startup),
                 "spawn-sh-at-startup" => m_push!(spawn_sh_at_startup),
+                "appearance-rule" => m_push!(appearance_rules),
                 "window-rule" => m_push!(window_rules),
                 "layer-rule" => m_push!(layer_rules),
                 "workspace" => m_push!(workspaces),
@@ -1631,6 +1636,7 @@ mod tests {
                 off: false,
                 path: "xwayland-satellite",
             },
+            appearance_rules: [],
             window_rules: [
                 WindowRule {
                     matches: [

--- a/src/dbus/freedesktop_portal_settings.rs
+++ b/src/dbus/freedesktop_portal_settings.rs
@@ -1,0 +1,133 @@
+use std::collections::HashMap;
+
+use futures_util::StreamExt;
+use niri_config::{AppearanceSettings, ColorScheme, Contrast};
+use zbus::zvariant;
+
+pub enum PortalSettingsToNiri {
+    AppearanceChanged(AppearanceSettings),
+}
+
+pub fn start(
+    to_niri: calloop::channel::Sender<PortalSettingsToNiri>,
+) -> anyhow::Result<zbus::blocking::Connection> {
+    let conn = zbus::blocking::Connection::session()?;
+
+    let async_conn = conn.inner().clone();
+    let future = async move {
+        let proxy = zbus::Proxy::new(
+            &async_conn,
+            "org.freedesktop.portal.Desktop",
+            "/org/freedesktop/portal/desktop",
+            "org.freedesktop.portal.Settings",
+        )
+        .await;
+        let proxy = match proxy {
+            Ok(x) => x,
+            Err(err) => {
+                warn!("error creating portal Settings proxy: {err:?}");
+                return;
+            }
+        };
+
+        let mut changed = match proxy.receive_signal("SettingChanged").await {
+            Ok(x) => x,
+            Err(err) => {
+                warn!("error subscribing to portal SettingChanged: {err:?}");
+                return;
+            }
+        };
+
+        let mut appearance = AppearanceSettings::default();
+
+        let read_all = proxy
+            .call::<_, _, HashMap<String, HashMap<String, zvariant::OwnedValue>>>(
+                "ReadAll",
+                &(vec!["org.freedesktop.appearance"],),
+            )
+            .await;
+        match read_all {
+            Ok(values) => {
+                if let Some(namespace) = values.get("org.freedesktop.appearance") {
+                    apply_appearance_updates(&mut appearance, namespace.iter());
+                }
+            }
+            Err(err) => {
+                warn!("error reading portal appearance settings: {err:?}");
+            }
+        }
+
+        if let Err(err) = to_niri.send(PortalSettingsToNiri::AppearanceChanged(appearance)) {
+            warn!("error sending portal appearance settings to niri: {err:?}");
+            return;
+        };
+
+        while let Some(signal) = changed.next().await {
+            let args = signal
+                .body()
+                .deserialize::<(String, String, zvariant::OwnedValue)>();
+            let (namespace, key, value) = match args {
+                Ok(x) => x,
+                Err(err) => {
+                    warn!("error parsing portal SettingChanged args: {err:?}");
+                    continue;
+                }
+            };
+
+            if namespace != "org.freedesktop.appearance" {
+                continue;
+            }
+
+            let mut updated = appearance;
+            apply_appearance_updates(&mut updated, std::iter::once((&key, &value)));
+            if updated == appearance {
+                continue;
+            }
+
+            appearance = updated;
+            if let Err(err) = to_niri.send(PortalSettingsToNiri::AppearanceChanged(appearance)) {
+                warn!("error sending portal appearance settings to niri: {err:?}");
+                return;
+            };
+        }
+    };
+
+    let task = conn
+        .inner()
+        .executor()
+        .spawn(future, "monitor portal settings changes");
+    task.detach();
+
+    Ok(conn)
+}
+
+fn apply_appearance_updates<'a>(
+    appearance: &mut AppearanceSettings,
+    updates: impl IntoIterator<Item = (&'a String, &'a zvariant::OwnedValue)>,
+) {
+    for (key, value) in updates {
+        let Ok(value) = value.downcast_ref::<u32>() else {
+            continue;
+        };
+
+        match key.as_str() {
+            "color-scheme" => {
+                appearance.color_scheme = match value {
+                    1 => Some(ColorScheme::Dark),
+                    2 => Some(ColorScheme::Light),
+                    _ => None,
+                };
+            }
+            "contrast" => {
+                appearance.contrast = match value {
+                    1 => Some(Contrast::High),
+                    _ => None,
+                };
+            }
+            "reduced-motion" => {
+                appearance.reduced_motion = value == 1;
+            }
+            _ => (),
+        }
+    }
+}

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -14,6 +14,7 @@ use _server_decoration::server::org_kde_kwin_server_decoration_manager::Mode as 
 use anyhow::{bail, ensure, Context};
 use calloop::futures::Scheduler;
 use niri_config::debug::PreviewRender;
+use niri_config::utils::MergeWith as _;
 use niri_config::{
     Config, FloatOrInt, Key, Modifiers, OutputName, TrackLayout, WarpMouseToFocusMode,
     WorkspaceReference, Xkb,
@@ -122,6 +123,8 @@ use crate::dbus::freedesktop_locale1::Locale1ToNiri;
 #[cfg(feature = "dbus")]
 use crate::dbus::freedesktop_login1::Login1ToNiri;
 #[cfg(feature = "dbus")]
+use crate::dbus::freedesktop_portal_settings::PortalSettingsToNiri;
+#[cfg(feature = "dbus")]
 use crate::dbus::gnome_shell_introspect::{self, IntrospectToNiri, NiriToIntrospect};
 #[cfg(feature = "dbus")]
 use crate::dbus::gnome_shell_screenshot::{NiriToScreenshot, ScreenshotToNiri};
@@ -190,6 +193,11 @@ const FRAME_CALLBACK_THROTTLE: Option<Duration> = Some(Duration::from_millis(995
 
 pub struct Niri {
     pub config: Rc<RefCell<Config>>,
+
+    pub portal_appearance: niri_config::AppearanceSettings,
+    pub portal_base_layout: niri_config::Layout,
+    pub portal_base_overview: niri_config::Overview,
+    pub portal_base_animations: niri_config::Animations,
 
     /// Output config from the config file.
     ///
@@ -1405,6 +1413,27 @@ impl State {
 
         self.niri.config_error_notification.hide();
 
+        self.niri.portal_base_layout = config.layout.clone();
+        self.niri.portal_base_overview = config.overview;
+        self.niri.portal_base_animations = config.animations.clone();
+
+        // Merge appearance rules into the config.
+        for rule in &config.appearance_rules {
+            if !rule.matches(self.niri.portal_appearance) {
+                continue;
+            }
+
+            if let Some(part) = &rule.layout {
+                config.layout.merge_with(part);
+            }
+            if let Some(part) = &rule.overview {
+                config.overview.merge_with(part);
+            }
+            if let Some(part) = &rule.animations {
+                config.animations.merge_with(part);
+            }
+        }
+
         // Find & orphan removed named workspaces.
         let mut removed_workspaces: Vec<String> = vec![];
         for ws in &self.niri.config.borrow().workspaces {
@@ -2419,6 +2448,100 @@ impl State {
         self.set_xkb_config(xkb.to_xkb_config());
         self.ipc_keyboard_layouts_changed();
     }
+
+    #[cfg(feature = "dbus")]
+    pub fn on_portal_settings_msg(&mut self, msg: PortalSettingsToNiri) {
+        let PortalSettingsToNiri::AppearanceChanged(appearance) = msg;
+
+        trace!("portal appearance settings changed: {appearance:?}");
+        if self.niri.portal_appearance == appearance {
+            return;
+        }
+
+        self.niri.portal_appearance = appearance;
+
+        let mut new_layout = self.niri.portal_base_layout.clone();
+        let mut new_overview = self.niri.portal_base_overview;
+        let mut new_animations = self.niri.portal_base_animations.clone();
+
+        {
+            let config = self.niri.config.borrow();
+            for rule in &config.appearance_rules {
+                if !rule.matches(self.niri.portal_appearance) {
+                    continue;
+                }
+
+                if let Some(part) = &rule.layout {
+                    new_layout.merge_with(part);
+                }
+                if let Some(part) = &rule.overview {
+                    new_overview.merge_with(part);
+                }
+                if let Some(part) = &rule.animations {
+                    new_animations.merge_with(part);
+                }
+            }
+        }
+
+        let (any_changed, overview_backdrop_changed) = {
+            let mut config = self.niri.config.borrow_mut();
+            let mut any_changed = false;
+            let overview_backdrop_changed =
+                config.overview.backdrop_color != new_overview.backdrop_color;
+
+            if config.layout != new_layout {
+                config.layout = new_layout;
+                any_changed = true;
+            }
+            if config.overview != new_overview {
+                config.overview = new_overview;
+                any_changed = true;
+            }
+            if config.animations != new_animations {
+                config.animations = new_animations;
+                any_changed = true;
+            }
+
+            (any_changed, overview_backdrop_changed)
+        };
+
+        if !any_changed {
+            return;
+        }
+
+        let config = self.niri.config.borrow();
+
+        let rate = 1.0 / config.animations.slowdown.max(0.001);
+        self.niri.clock.set_rate(rate);
+        self.niri
+            .clock
+            .set_complete_instantly(config.animations.off);
+
+        self.niri.layout.update_config(&config);
+
+        if overview_backdrop_changed {
+            for output in self.niri.global_space.outputs() {
+                let name = output.user_data().get::<OutputName>().unwrap();
+                let output_config = config.outputs.find(name);
+
+                let mut backdrop_color = output_config
+                    .and_then(|c| c.backdrop_color)
+                    .unwrap_or(config.overview.backdrop_color)
+                    .to_array_unpremul();
+                backdrop_color[3] = 1.;
+                let backdrop_color = Color32F::from(backdrop_color);
+
+                if let Some(state) = self.niri.output_state.get_mut(output) {
+                    if state.backdrop_buffer.color() != backdrop_color {
+                        state.backdrop_buffer.set_color(backdrop_color);
+                    }
+                }
+            }
+        }
+
+        drop(config);
+        self.niri.queue_redraw_all();
+    }
 }
 
 impl Niri {
@@ -2688,9 +2811,18 @@ impl Niri {
             )
             .unwrap();
 
+        let portal_appearance = niri_config::AppearanceSettings::default();
+        let portal_base_layout = config_.layout.clone();
+        let portal_base_overview = config_.overview;
+        let portal_base_animations = config_.animations.clone();
+
         drop(config_);
         let mut niri = Self {
             config,
+            portal_appearance,
+            portal_base_layout,
+            portal_base_overview,
+            portal_base_animations,
             config_file_output_config,
             config_file_watcher: None,
 

--- a/src/tests/appearance_rules.rs
+++ b/src/tests/appearance_rules.rs
@@ -1,0 +1,190 @@
+use niri_config::{AppearanceSettings, ColorScheme, Config};
+use smithay::backend::renderer::Color32F;
+
+use super::fixture::Fixture;
+use crate::dbus::freedesktop_portal_settings::PortalSettingsToNiri;
+
+fn parse_config(text: &str) -> Config {
+    Config::parse_mem(text).unwrap()
+}
+
+#[test]
+fn portal_update_applies_and_reverts_config() {
+    let config = parse_config(
+        r##"
+        overview {
+            backdrop-color "#112233"
+        }
+
+        appearance-rule {
+            match color-scheme="dark"
+
+            overview {
+                backdrop-color "#445566"
+            }
+        }
+        "##,
+    );
+
+    let mut fixture = Fixture::with_config(config);
+
+    let dark = AppearanceSettings {
+        color_scheme: Some(ColorScheme::Dark),
+        ..Default::default()
+    };
+    fixture
+        .niri_state()
+        .on_portal_settings_msg(PortalSettingsToNiri::AppearanceChanged(dark));
+    let config = fixture.niri().config.borrow();
+    assert_eq!(config.overview.backdrop_color, "#445566".parse().unwrap());
+    drop(config);
+
+    let light = AppearanceSettings {
+        color_scheme: Some(ColorScheme::Light),
+        ..Default::default()
+    };
+    fixture
+        .niri_state()
+        .on_portal_settings_msg(PortalSettingsToNiri::AppearanceChanged(light));
+    let config = fixture.niri().config.borrow();
+    assert_eq!(config.overview.backdrop_color, "#112233".parse().unwrap());
+}
+
+#[test]
+fn reload_config_uses_current_portal_state() {
+    let mut fixture = Fixture::new();
+
+    fixture.niri().portal_appearance = AppearanceSettings {
+        color_scheme: Some(ColorScheme::Dark),
+        ..Default::default()
+    };
+
+    let config = parse_config(
+        r##"
+        overview {
+            backdrop-color "#112233"
+        }
+
+        appearance-rule {
+            match color-scheme="dark"
+
+            overview {
+                backdrop-color "#445566"
+            }
+        }
+        "##,
+    );
+
+    fixture.niri_state().reload_config(Ok(config));
+    let config = fixture.niri().config.borrow();
+    assert_eq!(config.overview.backdrop_color, "#445566".parse().unwrap());
+    drop(config);
+
+    fixture.niri().portal_appearance = AppearanceSettings {
+        color_scheme: Some(ColorScheme::Light),
+        ..Default::default()
+    };
+
+    let config = parse_config(
+        r##"
+        overview {
+            backdrop-color "#112233"
+        }
+
+        appearance-rule {
+            match color-scheme="dark"
+
+            overview {
+                backdrop-color "#445566"
+            }
+        }
+        "##,
+    );
+
+    fixture.niri_state().reload_config(Ok(config));
+    let config = fixture.niri().config.borrow();
+    assert_eq!(config.overview.backdrop_color, "#112233".parse().unwrap());
+}
+
+#[test]
+fn backdrop_buffer_updates_on_portal_change() {
+    let config = parse_config(
+        r##"
+        overview {
+            backdrop-color "#112233"
+        }
+
+        appearance-rule {
+            match color-scheme="dark"
+
+            overview {
+                backdrop-color "#445566"
+            }
+        }
+        "##,
+    );
+
+    let mut fixture = Fixture::with_config(config);
+    fixture.add_output(1, (800, 600));
+
+    let output = fixture.niri_output(1);
+
+    let base = "#112233".parse::<niri_config::Color>().unwrap();
+    let mut base_arr = base.to_array_unpremul();
+    base_arr[3] = 1.0;
+    let base = Color32F::from(base_arr);
+
+    let state = fixture.niri().output_state.get(&output).unwrap();
+    assert_eq!(state.backdrop_buffer.color(), base);
+
+    fixture
+        .niri_state()
+        .on_portal_settings_msg(PortalSettingsToNiri::AppearanceChanged(
+            AppearanceSettings {
+                color_scheme: Some(ColorScheme::Dark),
+                ..Default::default()
+            },
+        ));
+
+    let dark = "#445566".parse::<niri_config::Color>().unwrap();
+    let mut dark_arr = dark.to_array_unpremul();
+    dark_arr[3] = 1.0;
+    let dark = Color32F::from(dark_arr);
+
+    let state = fixture.niri().output_state.get(&output).unwrap();
+    assert_eq!(state.backdrop_buffer.color(), dark);
+
+    fixture
+        .niri_state()
+        .on_portal_settings_msg(PortalSettingsToNiri::AppearanceChanged(
+            AppearanceSettings {
+                color_scheme: Some(ColorScheme::Light),
+                ..Default::default()
+            },
+        ));
+    let state = fixture.niri().output_state.get(&output).unwrap();
+    assert_eq!(state.backdrop_buffer.color(), base);
+
+    // Ensure per-output override wins after a portal update.
+    fixture
+        .niri_state()
+        .modify_output_config("headless-1", |output| {
+            output.backdrop_color = Some("#010203".parse().unwrap());
+        });
+    fixture
+        .niri_state()
+        .on_portal_settings_msg(PortalSettingsToNiri::AppearanceChanged(
+            AppearanceSettings {
+                color_scheme: Some(ColorScheme::Dark),
+                ..Default::default()
+            },
+        ));
+
+    let override_color = "#010203".parse::<niri_config::Color>().unwrap();
+    let mut override_arr = override_color.to_array_unpremul();
+    override_arr[3] = 1.0;
+    let override_color = Color32F::from(override_arr);
+
+    let state = fixture.niri().output_state.get(&output).unwrap();
+    assert_eq!(state.backdrop_buffer.color(), override_color);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,6 +5,8 @@ mod fixture;
 mod server;
 
 mod animations;
+#[cfg(feature = "dbus")]
+mod appearance_rules;
 mod floating;
 mod fullscreen;
 mod layer_shell;


### PR DESCRIPTION
This PR adds portal-driven "appearance rules" that let users conditionally apply parts of their config based on system appearance settings exposed via xdg-desktop-portal ([org.freedesktop.appearance](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Settings.html)).

It introduces a new top-level config block, appearance-rule { ... }, which can override layout, overview, and animations when its match conditions apply.

This enables doing things like light/dark mode toggles for niri config without external scripts. This is useful when the config is read-only, for example with NixOS or system wide configs in /etc.

The appearance-rule block is intentionally modeled after window-rule / layer-rule since they are all conceptually conditional config. 

These matchers are supported:

- `color-scheme`: `"light"` or `"dark"`
- `contrast`: `"high"`
- `reduced-motion`: `true` or `false`

Example:

```kdl
overview {
    backdrop-color "#112233"
}

appearance-rule {
    match color-scheme="dark"

    overview {
        backdrop-color "#445566"
    }
}

appearance-rule {
    match reduced-motion=true

    animations {
        off
    }
}
```