### PR TITLE
config: add hide-pointer-by-default screenshot option

### DIFF
--- a/docs/wiki/Configuration:-Miscellaneous.md
+++ b/docs/wiki/Configuration:-Miscellaneous.md
@@ -9,7 +9,9 @@ spawn-sh-at-startup "qs -c ~/source/qs/MyAwesomeShell"
 
 prefer-no-csd
 
-screenshot-path "~/Pictures/Screenshots/Screenshot from %Y-%m-%d %H-%M-%S.png"
+screenshot {
+    path "~/Pictures/Screenshots/Screenshot from %Y-%m-%d %H-%M-%S.png"
+}
 
 environment {
     QT_QPA_PLATFORM "wayland"
@@ -108,7 +110,7 @@ With `prefer-no-csd` set, applications that negotiate server-side decorations th
 prefer-no-csd
 ```
 
-### `screenshot-path`
+### `screenshot`
 
 Set the path where screenshots are saved.
 A `~` at the front will be expanded to the home directory.
@@ -118,13 +120,27 @@ The path is formatted with `strftime(3)` to give you the screenshot date and tim
 Niri will create the last folder of the path if it doesn't exist.
 
 ```kdl
-screenshot-path "~/Pictures/Screenshots/Screenshot from %Y-%m-%d %H-%M-%S.png"
+screenshot {
+    path "~/Pictures/Screenshots/Screenshot from %Y-%m-%d %H-%M-%S.png"
+}
 ```
 
 You can also set this option to `null` to disable saving screenshots to disk.
 
 ```kdl
-screenshot-path null
+screenshot {
+    path null
+}
+```
+
+#### `hide-pointer-by-default`
+
+If set, the mouse pointer will be hidden by default in the screenshot UI. You can still override this in keybindings or IPC.
+
+```kdl
+screenshot {
+    hide-pointer-by-default
+}
 ```
 
 ### `environment`

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -120,13 +120,13 @@ pub enum Action {
     #[knuffel(skip)]
     ScreenshotTogglePointer,
     Screenshot(
-        #[knuffel(property(name = "show-pointer"), default = true)] bool,
+        #[knuffel(property(name = "show-pointer"))] Option<bool>,
         // Path; not settable from knuffel
         Option<String>,
     ),
     ScreenshotScreen(
         #[knuffel(property(name = "write-to-disk"), default = true)] bool,
-        #[knuffel(property(name = "show-pointer"), default = true)] bool,
+        #[knuffel(property(name = "show-pointer"))] Option<bool>,
         // Path; not settable from knuffel
         Option<String>,
     ),

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -73,7 +73,7 @@ pub struct Config {
     pub layout: Layout,
     pub prefer_no_csd: bool,
     pub cursor: Cursor,
-    pub screenshot_path: ScreenshotPath,
+    pub screenshot: Screenshot,
     pub clipboard: Clipboard,
     pub hotkey_overlay: HotkeyOverlay,
     pub config_notification: ConfigNotification,
@@ -163,6 +163,7 @@ where
                     | "layer-rule"
                     | "workspace"
                     | "include"
+                    | "screenshot"
             ) && !seen.insert(name)
             {
                 ctx.emit_error(DecodeError::unexpected(
@@ -196,6 +197,7 @@ where
                 "animations" => m_merge!(animations),
                 "gestures" => m_merge!(gestures),
                 "overview" => m_merge!(overview),
+                "screenshot" => m_merge!(screenshot),
                 "xwayland-satellite" => m_merge!(xwayland_satellite),
                 "switch-events" => m_merge!(switch_events),
                 "debug" => m_merge!(debug),
@@ -232,11 +234,6 @@ where
 
                 "prefer-no-csd" => {
                     config.borrow_mut().prefer_no_csd = Flag::decode_node(node, ctx)?.0
-                }
-
-                "screenshot-path" => {
-                    let part = knuffel::Decode::decode_node(node, ctx)?;
-                    config.borrow_mut().screenshot_path = part;
                 }
 
                 "layout" => {
@@ -812,7 +809,10 @@ mod tests {
                 hide-after-inactive-ms 3000
             }
 
-            screenshot-path "~/Screenshots/screenshot.png"
+            screenshot {
+                path "~/Screenshots/screenshot.png"
+                hide-pointer-by-default
+            }
 
             clipboard {
                 disable-primary
@@ -1461,11 +1461,12 @@ mod tests {
                     3000,
                 ),
             },
-            screenshot_path: ScreenshotPath(
-                Some(
+            screenshot: Screenshot {
+                path: Some(
                     "~/Screenshots/screenshot.png",
                 ),
-            ),
+                hide_pointer_by_default: true,
+            },
             clipboard: Clipboard {
                 disable_primary: true,
             },

--- a/niri-config/src/misc.rs
+++ b/niri-config/src/misc.rs
@@ -53,14 +53,35 @@ impl MergeWith<CursorPart> for Cursor {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, PartialEq)]
-pub struct ScreenshotPath(#[knuffel(argument)] pub Option<String>);
+#[derive(Debug, PartialEq)]
+pub struct Screenshot {
+    pub path: Option<String>,
+    pub hide_pointer_by_default: bool,
+}
 
-impl Default for ScreenshotPath {
+impl Default for Screenshot {
     fn default() -> Self {
-        Self(Some(String::from(
-            "~/Pictures/Screenshots/Screenshot from %Y-%m-%d %H-%M-%S.png",
-        )))
+        Self {
+            path: Some(String::from(
+                "~/Pictures/Screenshots/Screenshot from %Y-%m-%d %H-%M-%S.png",
+            )),
+            hide_pointer_by_default: false,
+        }
+    }
+}
+
+#[derive(knuffel::Decode, Debug, PartialEq, Clone)]
+pub struct ScreenshotPart {
+    #[knuffel(child, unwrap(argument))]
+    pub path: Option<Option<String>>,
+    #[knuffel(child)]
+    pub hide_pointer_by_default: Option<Flag>,
+}
+
+impl MergeWith<ScreenshotPart> for Screenshot {
+    fn merge_with(&mut self, part: &ScreenshotPart) {
+        merge_clone!((self, part), path);
+        merge!((self, part), hide_pointer_by_default);
     }
 }
 

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -218,15 +218,17 @@ pub enum Action {
     },
     /// Open the screenshot UI.
     Screenshot {
-        ///  Whether to show the mouse pointer by default in the screenshot UI.
-        #[cfg_attr(feature = "clap", arg(short = 'p', long, action = clap::ArgAction::Set, default_value_t = true))]
-        show_pointer: bool,
+        /// Whether to show the mouse pointer by default in the screenshot UI.
+        ///
+        /// if `None`, it is determined by the `screenshot.hide_pointer_by_default` config setting.
+        #[cfg_attr(feature = "clap", arg(short = 'p', long, action = clap::ArgAction::Set))]
+        show_pointer: Option<bool>,
 
         /// Path to save the screenshot to.
         ///
         /// The path must be absolute, otherwise an error is returned.
         ///
-        /// If `None`, the screenshot is saved according to the `screenshot-path` config setting.
+        /// If `None`, the screenshot is saved according to the `screenshot.path` config setting.
         #[cfg_attr(feature = "clap", arg(long, action = clap::ArgAction::Set))]
         path: Option<String>,
     },
@@ -234,19 +236,21 @@ pub enum Action {
     ScreenshotScreen {
         /// Write the screenshot to disk in addition to putting it in your clipboard.
         ///
-        /// The screenshot is saved according to the `screenshot-path` config setting.
+        /// The screenshot is saved according to the `screenshot.path` config setting.
         #[cfg_attr(feature = "clap", arg(short = 'd', long, action = clap::ArgAction::Set, default_value_t = true))]
         write_to_disk: bool,
 
         /// Whether to include the mouse pointer in the screenshot.
-        #[cfg_attr(feature = "clap", arg(short = 'p', long, action = clap::ArgAction::Set, default_value_t = true))]
-        show_pointer: bool,
+        ///
+        /// if `None`, it is determined by the `screenshot.hide_pointer_by_default` config setting.
+        #[cfg_attr(feature = "clap", arg(short = 'p', long, action = clap::ArgAction::Set))]
+        show_pointer: Option<bool>,
 
         /// Path to save the screenshot to.
         ///
         /// The path must be absolute, otherwise an error is returned.
         ///
-        /// If `None`, the screenshot is saved according to the `screenshot-path` config setting.
+        /// If `None`, the screenshot is saved according to the `screenshot.path` config setting.
         #[cfg_attr(feature = "clap", arg(long, action = clap::ArgAction::Set))]
         path: Option<String>,
     },
@@ -260,7 +264,7 @@ pub enum Action {
         id: Option<u64>,
         /// Write the screenshot to disk in addition to putting it in your clipboard.
         ///
-        /// The screenshot is saved according to the `screenshot-path` config setting.
+        /// The screenshot is saved according to the `screenshot.path` config setting.
         #[cfg_attr(feature = "clap", arg(short = 'd', long, action = clap::ArgAction::Set, default_value_t = true))]
         write_to_disk: bool,
 
@@ -268,7 +272,7 @@ pub enum Action {
         ///
         /// The path must be absolute, otherwise an error is returned.
         ///
-        /// If `None`, the screenshot is saved according to the `screenshot-path` config setting.
+        /// If `None`, the screenshot is saved according to the `screenshot.path` config setting.
         #[cfg_attr(feature = "clap", arg(long, action = clap::ArgAction::Set))]
         path: Option<String>,
     },

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -288,10 +288,14 @@ hotkey-overlay {
 // You can change the path where screenshots are saved.
 // A ~ at the front will be expanded to the home directory.
 // The path is formatted with strftime(3) to give you the screenshot date and time.
-screenshot-path "~/Pictures/Screenshots/Screenshot from %Y-%m-%d %H-%M-%S.png"
+screenshot {
+    path "~/Pictures/Screenshots/Screenshot from %Y-%m-%d %H-%M-%S.png"
+}
 
 // You can also set this to null to disable saving screenshots to disk.
-// screenshot-path null
+// screenshot {
+//     path null
+// }
 
 // Animation settings.
 // The wiki explains how to configure individual animations:

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -708,12 +708,14 @@ impl State {
             Action::ScreenshotScreen(write_to_disk, show_pointer, path) => {
                 let active = self.niri.layout.active_output().cloned();
                 if let Some(active) = active {
+                    let include_pointer = show_pointer
+                        .unwrap_or(!self.niri.config.borrow().screenshot.hide_pointer_by_default);
                     self.backend.with_primary_renderer(|renderer| {
                         if let Err(err) = self.niri.screenshot(
                             renderer,
                             &active,
                             write_to_disk,
-                            show_pointer,
+                            include_pointer,
                             path,
                         ) {
                             warn!("error taking screenshot: {err:?}");
@@ -740,7 +742,9 @@ impl State {
                 self.niri.queue_redraw_all();
             }
             Action::Screenshot(show_cursor, path) => {
-                self.open_screenshot_ui(show_cursor, path);
+                let show_pointer = show_cursor
+                    .unwrap_or(!self.niri.config.borrow().screenshot.hide_pointer_by_default);
+                self.open_screenshot_ui(show_pointer, path);
                 self.niri.cancel_mru();
             }
             Action::ScreenshotWindow(write_to_disk, path) => {

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -620,7 +620,7 @@ mod tests {
     #[test]
     fn test_format_bind() {
         // Not bound.
-        assert_snapshot!(check("", Action::Screenshot(true, None)), @" (not bound) : Take a Screenshot");
+        assert_snapshot!(check("", Action::Screenshot(None, None)), @" (not bound) : Take a Screenshot");
 
         // Bound with a default title.
         assert_snapshot!(
@@ -628,7 +628,7 @@ mod tests {
                 r#"binds {
                     Mod+P { screenshot; }
                 }"#,
-                Action::Screenshot(true, None),
+                Action::Screenshot(None, None),
             ),
             @" Super + P : Take a Screenshot"
         );
@@ -639,7 +639,7 @@ mod tests {
                 r#"binds {
                     Mod+P hotkey-overlay-title="Hello" { screenshot; }
                 }"#,
-                Action::Screenshot(true, None),
+                Action::Screenshot(None, None),
             ),
             @" Super + P : Hello"
         );
@@ -651,7 +651,7 @@ mod tests {
                     Mod+P { screenshot; }
                     Print { screenshot; }
                 }"#,
-                Action::Screenshot(true, None),
+                Action::Screenshot(None, None),
             ),
             @" Super + P : Take a Screenshot"
         );
@@ -663,7 +663,7 @@ mod tests {
                     Mod+P { screenshot; }
                     Print hotkey-overlay-title="My Cool Bind" { screenshot; }
                 }"#,
-                Action::Screenshot(true, None),
+                Action::Screenshot(None, None),
             ),
             @" PrtSc : My Cool Bind"
         );
@@ -675,7 +675,7 @@ mod tests {
                     Mod+P hotkey-overlay-title="First" { screenshot; }
                     Print hotkey-overlay-title="My Cool Bind" { screenshot; }
                 }"#,
-                Action::Screenshot(true, None),
+                Action::Screenshot(None, None),
             ),
             @" Super + P : First"
         );
@@ -687,7 +687,7 @@ mod tests {
                     Mod+P { screenshot; }
                     Print hotkey-overlay-title=null { screenshot; }
                 }"#,
-                Action::Screenshot(true, None),
+                Action::Screenshot(None, None),
             ),
             @"None"
         );
@@ -699,7 +699,7 @@ mod tests {
                     Mod+P hotkey-overlay-title="Hello" { screenshot; }
                     Print hotkey-overlay-title=null { screenshot; }
                 }"#,
-                Action::Screenshot(true, None),
+                Action::Screenshot(None, None),
             ),
             @" Super + P : Hello"
         );

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -223,7 +223,7 @@ pub fn expand_home(path: &Path) -> anyhow::Result<Option<PathBuf>> {
 }
 
 pub fn make_screenshot_path(config: &Config) -> anyhow::Result<Option<PathBuf>> {
-    let Some(path) = &config.screenshot_path.0 else {
+    let Some(path) = &config.screenshot.path else {
         return Ok(None);
     };
 


### PR DESCRIPTION
Add a global option `hide-pointer-by-default` to set whether the pointer is displayed when taking a screenshot. But you can still override this in keybindings or IPC.

This pr breaks the original `screenshot-path` config and moves it to `screenshot { path }`, I'm not sure if this is appropriate.