### PR TITLE
ci: user Cachix nix installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
           show-progress: false
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v3
+        uses: cachix/install-nix-action@v31
         continue-on-error: true
 
       - run: nix flake check


### PR DESCRIPTION
- From Jan 2026, the DetSys installer (the current one) will [default to its Nix fork](https://github.com/DeterminateSystems/nix-installer-action/commit/4f7e5a32d2a8a1b61ba67d0b83df6ecd26da7df3), which is flawed ([1](https://github.com/DeterminateSystems/nix-src/issues/171), [2](https://github.com/hercules-ci/flake.parts-website/issues/1760)), so I switch to the Cachix installer.
- Plus, remove the flake check action, which does nothing valuable and only generate an [unnoticeable one-line warning in CI log](https://github.com/YaLTeR/niri/actions/runs/20430047603/job/58698582190#step:4:56).