### PR TITLE
input: resync keyboard focus when backend state desyncs

### DIFF
--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1212,6 +1212,7 @@ impl State {
         };
 
         let keyboard = self.niri.seat.get_keyboard().unwrap();
+        let current_focus = keyboard.current_focus();
         if self.niri.keyboard_focus != focus {
             trace!(
                 "keyboard focus changed from {:?} to {:?}",
@@ -1330,6 +1331,9 @@ impl State {
 
             // FIXME: can be more granular.
             self.niri.queue_redraw_all();
+        } else if current_focus.as_ref() != focus.surface() {
+            debug!("resyncing keyboard focus");
+            keyboard.set_focus(self, focus.into_surface(), SERIAL_COUNTER.next_serial());
         }
     }
 


### PR DESCRIPTION
When a virtual input device (like wtype) is destroyed, Smithay might clear the keyboard focus. However, Niri's internal state (self.niri.keyboard_focus) remains unchanged. This causes a desynchronization where Niri thinks a window is focused, but the backend doesn't send key events to it.

This patch adds a check in update_keyboard_focus: if Niri's focus target hasn't changed but the underlying backend focus is different, we force a set_focus call to restore synchronization.

Fixes #2314