### PR TITLE
Refactor rendering to push-based instead of pull-based

### DIFF
--- a/niri-visual-tests/src/cases/gradient_area.rs
+++ b/niri-visual-tests/src/cases/gradient_area.rs
@@ -89,11 +89,8 @@ impl TestCase for GradientArea {
             1.,
             1.,
         );
-        rv.extend(
-            self.border
-                .render(renderer, g_loc)
-                .map(|elem| Box::new(elem) as _),
-        );
+        self.border
+            .render(renderer, g_loc, &mut |elem| rv.push(Box::new(elem) as _));
 
         rv.extend(
             [BorderRenderElement::new(

--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -268,12 +268,14 @@ impl TestCase for Layout {
         _size: Size<i32, Physical>,
     ) -> Vec<Box<dyn RenderElement<GlesRenderer>>> {
         self.layout.update_render_elements(Some(&self.output));
+
+        let mut rv = Vec::new();
         self.layout
             .monitor_for_output(&self.output)
             .unwrap()
-            .render_elements(renderer, RenderTarget::Output, true)
-            .flat_map(|(_, _, iter)| iter)
-            .map(|elem| Box::new(elem) as _)
-            .collect()
+            .render_workspaces(renderer, RenderTarget::Output, true, &mut |elem| {
+                rv.push(Box::new(elem) as _)
+            });
+        rv
     }
 }

--- a/niri-visual-tests/src/cases/tile.rs
+++ b/niri-visual-tests/src/cases/tile.rs
@@ -119,9 +119,15 @@ impl TestCase for Tile {
             true,
             Rectangle::new(Point::from((-location.x, -location.y)), size.to_logical(1.)),
         );
-        self.tile
-            .render(renderer, location, true, RenderTarget::Output)
-            .map(|elem| Box::new(elem) as _)
-            .collect()
+
+        let mut rv = Vec::new();
+        self.tile.render(
+            renderer,
+            location,
+            true,
+            RenderTarget::Output,
+            &mut |elem| rv.push(Box::new(elem) as _),
+        );
+        rv
     }
 }

--- a/niri-visual-tests/src/cases/window.rs
+++ b/niri-visual-tests/src/cases/window.rs
@@ -52,16 +52,15 @@ impl TestCase for Window {
             .to_f64()
             .downscale(2.);
 
-        self.window
-            .render(
-                renderer,
-                location,
-                Scale::from(1.),
-                1.,
-                RenderTarget::Output,
-            )
-            .into_iter()
-            .map(|elem| Box::new(elem) as _)
-            .collect()
+        let mut rv = Vec::new();
+        self.window.render_normal(
+            renderer,
+            location,
+            Scale::from(1.),
+            1.,
+            RenderTarget::Output,
+            &mut |elem| rv.push(Box::new(elem) as _),
+        );
+        rv
     }
 }

--- a/niri-visual-tests/src/test_window.rs
+++ b/niri-visual-tests/src/test_window.rs
@@ -9,7 +9,7 @@ use niri::layout::{
 use niri::render_helpers::offscreen::OffscreenData;
 use niri::render_helpers::renderer::NiriRenderer;
 use niri::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
-use niri::render_helpers::{RenderTarget, SplitElements};
+use niri::render_helpers::RenderTarget;
 use niri::utils::transaction::Transaction;
 use niri::window::ResolvedWindowRules;
 use smithay::backend::renderer::element::Kind;
@@ -149,36 +149,30 @@ impl LayoutElement for TestWindow {
         false
     }
 
-    fn render<R: NiriRenderer>(
+    fn render_normal<R: NiriRenderer>(
         &self,
         _renderer: &mut R,
         location: Point<f64, Logical>,
         _scale: Scale<f64>,
         alpha: f32,
         _target: RenderTarget,
-    ) -> SplitElements<LayoutElementRenderElement<R>> {
+        push: &mut dyn FnMut(LayoutElementRenderElement<R>),
+    ) {
         let inner = self.inner.borrow();
 
-        SplitElements {
-            normal: vec![
-                SolidColorRenderElement::from_buffer(
-                    &inner.buffer,
-                    location,
-                    alpha,
-                    Kind::Unspecified,
-                )
+        push(
+            SolidColorRenderElement::from_buffer(&inner.buffer, location, alpha, Kind::Unspecified)
                 .into(),
-                SolidColorRenderElement::from_buffer(
-                    &inner.csd_shadow_buffer,
-                    location
-                        - Point::from((inner.csd_shadow_width, inner.csd_shadow_width)).to_f64(),
-                    alpha,
-                    Kind::Unspecified,
-                )
-                .into(),
-            ],
-            popups: vec![],
-        }
+        );
+        push(
+            SolidColorRenderElement::from_buffer(
+                &inner.csd_shadow_buffer,
+                location - Point::from((inner.csd_shadow_width, inner.csd_shadow_width)).to_f64(),
+                alpha,
+                Kind::Unspecified,
+            )
+            .into(),
+        );
     }
 
     fn request_size(

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::cmp::min;
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use calloop::timer::{TimeoutAction, Timer};
 use input::event::gesture::GestureEventCoordinates as _;
@@ -1636,56 +1636,6 @@ impl State {
                 self.niri.layout.center_visible_columns();
                 // FIXME: granular
                 self.niri.queue_redraw_all();
-
-                let output = self.niri.layout.active_output().unwrap();
-                let output = output.clone();
-                self.niri.update_render_elements(Some(&output));
-
-                self.backend.with_primary_renderer(|renderer| {
-                    // let mon = self.niri.layout.monitor_for_output(output).unwrap();
-
-                    let N = 5000;
-                    let mut total = 0;
-                    let mut total_len = 0;
-                    let start = Instant::now();
-                    for _ in 0..N {
-                        let _span = tracy_client::span!("prev render");
-                        let elements = self.niri.render_prev(
-                            renderer,
-                            &output,
-                            true,
-                            crate::render_helpers::RenderTarget::Output,
-                        );
-                        total += elements.capacity();
-                        total_len += elements.len();
-                    }
-                    let elapsed = start.elapsed();
-                    warn!(
-                        "prev capacity: {total}, len: {total_len}, mean time: {:.3} ms",
-                        elapsed.as_secs_f64() / N as f64 * 1000.
-                    );
-
-                    total = 0;
-                    total_len = 0;
-                    let start = Instant::now();
-                    for _ in 0..N {
-                        let _span = tracy_client::span!("new render");
-                        let elements = self.niri.render(
-                            renderer,
-                            &output,
-                            true,
-                            crate::render_helpers::RenderTarget::Output,
-                        );
-                        total += elements.capacity();
-                        total_len += elements.len();
-                    }
-                    let elapsed = start.elapsed();
-
-                    warn!(
-                        " new capacity: {total}, len: {total_len}, mean time: {:.3} ms",
-                        elapsed.as_secs_f64() / N as f64 * 1000.
-                    );
-                });
             }
             Action::MaximizeColumn => {
                 self.niri.layout.toggle_full_width();

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -1,8 +1,6 @@
 use niri_config::utils::MergeWith as _;
 use niri_config::{Config, LayerRule};
-use smithay::backend::renderer::element::surface::{
-    render_elements_from_surface_tree, WaylandSurfaceRenderElement,
-};
+use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::Kind;
 use smithay::desktop::{LayerSurface, PopupManager};
 use smithay::utils::{Logical, Point, Scale, Size};
@@ -16,7 +14,7 @@ use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shadow::ShadowRenderElement;
 use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
 use crate::render_helpers::surface::push_elements_from_surface_tree;
-use crate::render_helpers::{RenderTarget, SplitElements};
+use crate::render_helpers::RenderTarget;
 use crate::utils::{baba_is_float_offset, round_logical_in_physical};
 
 #[derive(Debug)]
@@ -157,67 +155,7 @@ impl MappedLayer {
         Point::from((0., y))
     }
 
-    pub fn render<R: NiriRenderer>(
-        &self,
-        renderer: &mut R,
-        location: Point<f64, Logical>,
-        target: RenderTarget,
-    ) -> SplitElements<LayerSurfaceRenderElement<R>> {
-        let mut rv = SplitElements::default();
-
-        let scale = Scale::from(self.scale);
-        let alpha = self.rules.opacity.unwrap_or(1.).clamp(0., 1.);
-        let location = location + self.bob_offset();
-
-        if target.should_block_out(self.rules.block_out_from) {
-            // Round to physical pixels.
-            let location = location.to_physical_precise_round(scale).to_logical(scale);
-
-            // FIXME: take geometry-corner-radius into account.
-            let elem = SolidColorRenderElement::from_buffer(
-                &self.block_out_buffer,
-                location,
-                alpha,
-                Kind::Unspecified,
-            );
-            rv.normal.push(elem.into());
-        } else {
-            // Layer surfaces don't have extra geometry like windows.
-            let buf_pos = location;
-
-            let surface = self.surface.wl_surface();
-            for (popup, popup_offset) in PopupManager::popups_for_surface(surface) {
-                // Layer surfaces don't have extra geometry like windows.
-                let offset = popup_offset - popup.geometry().loc;
-
-                rv.popups.extend(render_elements_from_surface_tree(
-                    renderer,
-                    popup.wl_surface(),
-                    (buf_pos + offset.to_f64()).to_physical_precise_round(scale),
-                    scale,
-                    alpha,
-                    Kind::ScanoutCandidate,
-                ));
-            }
-
-            rv.normal = render_elements_from_surface_tree(
-                renderer,
-                surface,
-                buf_pos.to_physical_precise_round(scale),
-                scale,
-                alpha,
-                Kind::ScanoutCandidate,
-            );
-        }
-
-        let location = location.to_physical_precise_round(scale).to_logical(scale);
-        rv.normal
-            .extend(self.shadow.render(renderer, location).map(Into::into));
-
-        rv
-    }
-
-    pub fn render_push_normal<R: NiriRenderer>(
+    pub fn render_normal<R: NiriRenderer>(
         &self,
         renderer: &mut R,
         location: Point<f64, Logical>,
@@ -258,10 +196,10 @@ impl MappedLayer {
 
         let location = location.to_physical_precise_round(scale).to_logical(scale);
         self.shadow
-            .render_push(renderer, location, &mut |elem| push(elem.into()));
+            .render(renderer, location, &mut |elem| push(elem.into()));
     }
 
-    pub fn render_push_popups<R: NiriRenderer>(
+    pub fn render_popups<R: NiriRenderer>(
         &self,
         renderer: &mut R,
         location: Point<f64, Logical>,

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1053,40 +1053,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
         true
     }
 
-    pub fn render_elements<R: NiriRenderer>(
-        &self,
-        renderer: &mut R,
-        view_rect: Rectangle<f64, Logical>,
-        target: RenderTarget,
-        focus_ring: bool,
-    ) -> Vec<FloatingSpaceRenderElement<R>> {
-        let mut rv = Vec::new();
-
-        let scale = Scale::from(self.scale);
-
-        // Draw the closing windows on top of the other windows.
-        //
-        // FIXME: I guess this should rather preserve the stacking order when the window is closed.
-        for closing in self.closing_windows.iter().rev() {
-            let elem = closing.render(renderer.as_gles_renderer(), view_rect, scale, target);
-            rv.push(elem.into());
-        }
-
-        let active = self.active_window_id.clone();
-        for (tile, tile_pos) in self.tiles_with_render_positions() {
-            // For the active tile, draw the focus ring.
-            let focus_ring = focus_ring && Some(tile.window().id()) == active.as_ref();
-
-            rv.extend(
-                tile.render(renderer, tile_pos, focus_ring, target)
-                    .map(Into::into),
-            );
-        }
-
-        rv
-    }
-
-    pub fn render_push<R: NiriRenderer>(
+    pub fn render<R: NiriRenderer>(
         &self,
         renderer: &mut R,
         view_rect: Rectangle<f64, Logical>,
@@ -1109,7 +1076,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
             // For the active tile, draw the focus ring.
             let focus_ring = focus_ring && Some(tile.window().id()) == active.as_ref();
 
-            tile.render_push(renderer, tile_pos, focus_ring, target, &mut |elem| {
+            tile.render(renderer, tile_pos, focus_ring, target, &mut |elem| {
                 push(elem.into())
             });
         }

--- a/src/layout/focus_ring.rs
+++ b/src/layout/focus_ring.rs
@@ -1,6 +1,5 @@
 use std::iter::zip;
 
-use arrayvec::ArrayVec;
 use niri_config::{CornerRadius, Gradient, GradientRelativeTo};
 use smithay::backend::renderer::element::{Element as _, Kind};
 use smithay::utils::{Logical, Point, Rectangle, Size};
@@ -217,52 +216,6 @@ impl FocusRing {
     }
 
     pub fn render(
-        &self,
-        renderer: &mut impl NiriRenderer,
-        location: Point<f64, Logical>,
-    ) -> impl Iterator<Item = FocusRingRenderElement> {
-        let mut rv = ArrayVec::<_, 8>::new();
-
-        if self.config.off {
-            return rv.into_iter();
-        }
-
-        let border_width = -self.locations[0].y;
-
-        // If drawing as a border with width = 0, then there's nothing to draw.
-        if self.is_border && border_width == 0. {
-            return rv.into_iter();
-        }
-
-        let has_border_shader = BorderRenderElement::has_shader(renderer);
-
-        let mut push = |buffer, border: &BorderRenderElement, location: Point<f64, Logical>| {
-            let elem = if self.use_border_shader && has_border_shader {
-                border.clone().with_location(location).into()
-            } else {
-                let alpha = border.alpha();
-                SolidColorRenderElement::from_buffer(buffer, location, alpha, Kind::Unspecified)
-                    .into()
-            };
-            rv.push(elem);
-        };
-
-        if self.is_border {
-            for ((buf, border), loc) in zip(zip(&self.buffers, &self.borders), self.locations) {
-                push(buf, border, location + loc);
-            }
-        } else {
-            push(
-                &self.buffers[0],
-                &self.borders[0],
-                location + self.locations[0],
-            );
-        }
-
-        rv.into_iter()
-    }
-
-    pub fn render_push(
         &self,
         renderer: &mut impl NiriRenderer,
         location: Point<f64, Logical>,

--- a/src/layout/insert_hint_element.rs
+++ b/src/layout/insert_hint_element.rs
@@ -59,16 +59,8 @@ impl InsertHintElement {
         &self,
         renderer: &mut impl NiriRenderer,
         location: Point<f64, Logical>,
-    ) -> impl Iterator<Item = FocusRingRenderElement> {
-        self.inner.render(renderer, location)
-    }
-
-    pub fn render_push(
-        &self,
-        renderer: &mut impl NiriRenderer,
-        location: Point<f64, Logical>,
         push: &mut dyn FnMut(FocusRingRenderElement),
     ) {
-        self.inner.render_push(renderer, location, push)
+        self.inner.render(renderer, location, push)
     }
 }

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2897,75 +2897,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             .is_fullscreen()
     }
 
-    pub fn render_elements<R: NiriRenderer>(
-        &self,
-        renderer: &mut R,
-        target: RenderTarget,
-        focus_ring: bool,
-    ) -> Vec<ScrollingSpaceRenderElement<R>> {
-        let mut rv = vec![];
-
-        let scale = Scale::from(self.scale);
-
-        // Draw the closing windows on top of the other windows.
-        let view_rect = Rectangle::new(Point::from((self.view_pos(), 0.)), self.view_size);
-        for closing in self.closing_windows.iter().rev() {
-            let elem = closing.render(renderer.as_gles_renderer(), view_rect, scale, target);
-            rv.push(elem.into());
-        }
-
-        if self.columns.is_empty() {
-            return rv;
-        }
-
-        let mut first = true;
-
-        // This matches self.tiles_in_render_order().
-        let view_off = Point::from((-self.view_pos(), 0.));
-        for (col, col_x) in self.columns_in_render_order() {
-            let col_off = Point::from((col_x, 0.));
-            let col_render_off = col.render_offset();
-
-            // Draw the tab indicator on top.
-            {
-                let pos = view_off + col_off + col_render_off;
-                let pos = pos.to_physical_precise_round(scale).to_logical(scale);
-                rv.extend(col.tab_indicator.render(renderer, pos).map(Into::into));
-            }
-
-            for (tile, tile_off, visible) in col.tiles_in_render_order() {
-                let tile_pos =
-                    view_off + col_off + col_render_off + tile_off + tile.render_offset();
-                // Round to physical pixels.
-                let tile_pos = tile_pos.to_physical_precise_round(scale).to_logical(scale);
-
-                // And now the drawing logic.
-
-                // For the active tile (which comes first), draw the focus ring.
-                let focus_ring = focus_ring && first;
-                first = false;
-
-                // In the scrolling layout, we currently use visible only for hidden tabs in the
-                // tabbed mode. We want to animate their opacity when going in and out of tabbed
-                // mode, so we don't want to apply "visible" immediately. However, "visible" is
-                // also used for input handling, and there we *do* want to apply it immediately.
-                // So, let's just selectively ignore "visible" here when animating alpha.
-                let visible = visible || tile.alpha_animation.is_some();
-                if !visible {
-                    continue;
-                }
-
-                rv.extend(
-                    tile.render(renderer, tile_pos, focus_ring, target)
-                        .map(Into::into),
-                );
-            }
-        }
-
-        rv
-    }
-
-    pub fn render_push<R: NiriRenderer>(
+    pub fn render<R: NiriRenderer>(
         &self,
         renderer: &mut R,
         target: RenderTarget,
@@ -2998,7 +2930,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 let pos = view_off + col_off + col_render_off;
                 let pos = pos.to_physical_precise_round(scale).to_logical(scale);
                 col.tab_indicator
-                    .render_push(renderer, pos, &mut |elem| push(elem.into()));
+                    .render(renderer, pos, &mut |elem| push(elem.into()));
             }
 
             for (tile, tile_off, visible) in col.tiles_in_render_order() {
@@ -3023,7 +2955,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     continue;
                 }
 
-                tile.render_push(renderer, tile_pos, focus_ring, target, &mut |elem| {
+                tile.render(renderer, tile_pos, focus_ring, target, &mut |elem| {
                     push(elem.into())
                 });
             }

--- a/src/layout/shadow.rs
+++ b/src/layout/shadow.rs
@@ -166,26 +166,6 @@ impl Shadow {
         &self,
         renderer: &mut impl NiriRenderer,
         location: Point<f64, Logical>,
-    ) -> impl Iterator<Item = ShadowRenderElement> + '_ {
-        if !self.config.on {
-            return None.into_iter().flatten();
-        }
-
-        let has_shadow_shader = ShadowRenderElement::has_shader(renderer);
-        if !has_shadow_shader {
-            return None.into_iter().flatten();
-        }
-
-        let rv = zip(&self.shaders, &self.shader_rects)
-            .map(move |(shader, rect)| shader.clone().with_location(location + rect.loc));
-
-        Some(rv).into_iter().flatten()
-    }
-
-    pub fn render_push(
-        &self,
-        renderer: &mut impl NiriRenderer,
-        location: Point<f64, Logical>,
         push: &mut dyn FnMut(ShadowRenderElement),
     ) {
         if !self.config.on {

--- a/src/layout/tab_indicator.rs
+++ b/src/layout/tab_indicator.rs
@@ -294,23 +294,6 @@ impl TabIndicator {
         &self,
         renderer: &mut impl NiriRenderer,
         pos: Point<f64, Logical>,
-    ) -> impl Iterator<Item = TabIndicatorRenderElement> + '_ {
-        let has_border_shader = BorderRenderElement::has_shader(renderer);
-        if !has_border_shader {
-            return None.into_iter().flatten();
-        }
-
-        let rv = zip(&self.shaders, &self.shader_locs)
-            .map(move |(shader, loc)| shader.clone().with_location(pos + *loc))
-            .map(TabIndicatorRenderElement::from);
-
-        Some(rv).into_iter().flatten()
-    }
-
-    pub fn render_push(
-        &self,
-        renderer: &mut impl NiriRenderer,
-        pos: Point<f64, Logical>,
         push: &mut dyn FnMut(TabIndicatorRenderElement),
     ) {
         let has_border_shader = BorderRenderElement::has_shader(renderer);

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -166,17 +166,6 @@ impl LayoutElement for TestWindow {
         false
     }
 
-    fn render<R: NiriRenderer>(
-        &self,
-        _renderer: &mut R,
-        _location: Point<f64, Logical>,
-        _scale: Scale<f64>,
-        _alpha: f32,
-        _target: RenderTarget,
-    ) -> SplitElements<LayoutElementRenderElement<R>> {
-        SplitElements::default()
-    }
-
     fn request_size(
         &mut self,
         size: Size<i32, Logical>,

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -1007,13 +1007,14 @@ impl<W: LayoutElement> Tile<W> {
         Point::from((0., y))
     }
 
-    fn render_inner<'a, R: NiriRenderer + 'a>(
-        &'a self,
+    fn render_inner<R: NiriRenderer>(
+        &self,
         renderer: &mut R,
         location: Point<f64, Logical>,
         focus_ring: bool,
         target: RenderTarget,
-    ) -> impl Iterator<Item = TileRenderElement<R>> + 'a {
+        push: &mut dyn FnMut(TileRenderElement<R>),
+    ) {
         let _span = tracy_client::span!("Tile::render_inner");
 
         let scale = Scale::from(self.scale);
@@ -1056,292 +1057,8 @@ impl<W: LayoutElement> Tile<W> {
             .unwrap_or_default()
             .scaled_by(1. - expanded_progress as f32);
 
-        // If we're resizing, try to render a shader, or a fallback.
-        let mut resize_shader = None;
-        let mut resize_popups = None;
-        let mut resize_fallback = None;
-
-        if let Some(resize) = &self.resize_animation {
-            resize_popups = Some(
-                self.window
-                    .render_popups(renderer, window_render_loc, scale, win_alpha, target)
-                    .into_iter()
-                    .map(Into::into),
-            );
-
-            if ResizeRenderElement::has_shader(renderer) {
-                let gles_renderer = renderer.as_gles_renderer();
-
-                if let Some(texture_from) = resize.snapshot.texture(gles_renderer, scale, target) {
-                    let window_elements = self.window.render_normal(
-                        gles_renderer,
-                        Point::from((0., 0.)),
-                        scale,
-                        1.,
-                        target,
-                    );
-
-                    let current = resize
-                        .offscreen
-                        .render(gles_renderer, scale, &window_elements)
-                        .map_err(|err| warn!("error rendering window to texture: {err:?}"))
-                        .ok();
-
-                    // Clip blocked-out resizes unconditionally because they use solid color render
-                    // elements.
-                    let clip_to_geometry = if target
-                        .should_block_out(resize.snapshot.block_out_from)
-                        && target.should_block_out(rules.block_out_from)
-                    {
-                        true
-                    } else {
-                        clip_to_geometry
-                    };
-
-                    if let Some((elem_current, _sync_point, mut data)) = current {
-                        let texture_current = elem_current.texture().clone();
-                        // The offset and size are computed in physical pixels and converted to
-                        // logical with the same `scale`, so converting them back with rounding
-                        // inside the geometry() call gives us the same physical result back.
-                        let texture_current_geo = elem_current.geometry(scale);
-
-                        let elem = ResizeRenderElement::new(
-                            area,
-                            scale,
-                            texture_from.clone(),
-                            resize.snapshot.size,
-                            (texture_current, texture_current_geo),
-                            window_size,
-                            resize.anim.value() as f32,
-                            resize.anim.clamped_value().clamp(0., 1.) as f32,
-                            radius,
-                            clip_to_geometry,
-                            win_alpha,
-                        );
-
-                        // We're drawing the resize shader, not the offscreen directly.
-                        data.id = elem.id().clone();
-
-                        // This is not a problem for split popups as the code will look for them by
-                        // original id when it doesn't find them on the offscreen.
-                        self.window.set_offscreen_data(Some(data));
-                        resize_shader = Some(elem.into());
-                    }
-                }
-            }
-
-            if resize_shader.is_none() {
-                let fallback_buffer = SolidColorBuffer::new(area.size, [1., 0., 0., 1.]);
-                resize_fallback = Some(
-                    SolidColorRenderElement::from_buffer(
-                        &fallback_buffer,
-                        area.loc,
-                        win_alpha,
-                        Kind::Unspecified,
-                    )
-                    .into(),
-                );
-            }
-        }
-
-        // If we're not resizing, render the window itself.
-        let mut window_surface = None;
-        let mut window_popups = None;
-        let mut rounded_corner_damage = None;
-        let has_border_shader = BorderRenderElement::has_shader(renderer);
-        if resize_shader.is_none() && resize_fallback.is_none() {
-            let window = self
-                .window
-                .render(renderer, window_render_loc, scale, win_alpha, target);
-
-            let geo = Rectangle::new(window_render_loc, window_size);
-            let radius = radius.fit_to(window_size.w as f32, window_size.h as f32);
-
-            let clip_shader = ClippedSurfaceRenderElement::shader(renderer).cloned();
-
-            if clip_to_geometry && clip_shader.is_some() {
-                let damage = self.rounded_corner_damage.element();
-                rounded_corner_damage = Some(damage.with_location(window_render_loc).into());
-            }
-
-            window_surface = Some(window.normal.into_iter().map(move |elem| match elem {
-                LayoutElementRenderElement::Wayland(elem) => {
-                    // If we should clip to geometry, render a clipped window.
-                    if clip_to_geometry {
-                        if let Some(shader) = clip_shader.clone() {
-                            if ClippedSurfaceRenderElement::will_clip(&elem, scale, geo, radius) {
-                                return ClippedSurfaceRenderElement::new(
-                                    elem,
-                                    scale,
-                                    geo,
-                                    shader.clone(),
-                                    radius,
-                                )
-                                .into();
-                            }
-                        }
-                    }
-
-                    // Otherwise, render it normally.
-                    LayoutElementRenderElement::Wayland(elem).into()
-                }
-                LayoutElementRenderElement::SolidColor(elem) => {
-                    // In this branch we're rendering a blocked-out window with a solid
-                    // color. We need to render it with a rounded corner shader even if
-                    // clip_to_geometry is false, because in this case we're assuming that
-                    // the unclipped window CSD already has corners rounded to the
-                    // user-provided radius, so our blocked-out rendering should match that
-                    // radius.
-                    if radius != CornerRadius::default() && has_border_shader {
-                        return BorderRenderElement::new(
-                            geo.size,
-                            Rectangle::from_size(geo.size),
-                            GradientInterpolation::default(),
-                            Color::from_color32f(elem.color()),
-                            Color::from_color32f(elem.color()),
-                            0.,
-                            Rectangle::from_size(geo.size),
-                            0.,
-                            radius,
-                            scale.x as f32,
-                            1.,
-                        )
-                        .with_location(geo.loc)
-                        .into();
-                    }
-
-                    // Otherwise, render the solid color as is.
-                    LayoutElementRenderElement::SolidColor(elem).into()
-                }
-            }));
-
-            window_popups = Some(window.popups.into_iter().map(Into::into));
-        }
-
-        let rv = resize_popups
-            .into_iter()
-            .flatten()
-            .chain(resize_shader)
-            .chain(resize_fallback)
-            .chain(window_popups.into_iter().flatten())
-            .chain(rounded_corner_damage)
-            .chain(window_surface.into_iter().flatten());
-
-        let elem = (fullscreen_progress > 0.).then(|| {
-            let alpha = fullscreen_progress as f32;
-
-            // During the un/fullscreen animation, render a border element in order to use the
-            // animated corner radius.
-            if fullscreen_progress < 1. && has_border_shader {
-                let border_width = self.visual_border_width().unwrap_or(0.);
-                let radius = rules
-                    .geometry_corner_radius
-                    .map_or(CornerRadius::default(), |radius| {
-                        radius.expanded_by(border_width as f32)
-                    })
-                    .scaled_by(1. - expanded_progress as f32);
-
-                let size = self.fullscreen_backdrop.size();
-                let color = self.fullscreen_backdrop.color();
-                BorderRenderElement::new(
-                    size,
-                    Rectangle::from_size(size),
-                    GradientInterpolation::default(),
-                    Color::from_color32f(color),
-                    Color::from_color32f(color),
-                    0.,
-                    Rectangle::from_size(size),
-                    0.,
-                    radius,
-                    scale.x as f32,
-                    alpha,
-                )
-                .with_location(location)
-                .into()
-            } else {
-                SolidColorRenderElement::from_buffer(
-                    &self.fullscreen_backdrop,
-                    location,
-                    alpha,
-                    Kind::Unspecified,
-                )
-                .into()
-            }
-        });
-        let rv = rv.chain(elem);
-
-        let elem = self.visual_border_width().map(|width| {
-            self.border
-                .render(renderer, location + Point::from((width, width)))
-                .map(Into::into)
-        });
-        let rv = rv.chain(elem.into_iter().flatten());
-
-        // Hide the focus ring when maximized/fullscreened. It's not normally visible anyway due to
-        // being outside the monitor or obscured by a solid colored bar, but it is visible under
-        // semitransparent bars in maximized state (which is a bit weird) and in the overview (also
-        // a bit weird).
-        let elem = (focus_ring && expanded_progress < 1.)
-            .then(|| self.focus_ring.render(renderer, location).map(Into::into));
-        let rv = rv.chain(elem.into_iter().flatten());
-
-        let elem = (expanded_progress < 1.)
-            .then(|| self.shadow.render(renderer, location).map(Into::into));
-        rv.chain(elem.into_iter().flatten())
-    }
-
-    fn render_push_inner<R: NiriRenderer>(
-        &self,
-        renderer: &mut R,
-        location: Point<f64, Logical>,
-        focus_ring: bool,
-        target: RenderTarget,
-        push: &mut dyn FnMut(TileRenderElement<R>),
-    ) {
-        let _span = tracy_client::span!("Tile::render_push_inner");
-
-        let scale = Scale::from(self.scale);
-        let fullscreen_progress = self.fullscreen_progress();
-        let expanded_progress = self.expanded_progress();
-
-        let win_alpha = if self.window.is_ignoring_opacity_window_rule() {
-            1.
-        } else {
-            let alpha = self.window.rules().opacity.unwrap_or(1.).clamp(0., 1.);
-
-            // Interpolate towards alpha = 1. at fullscreen.
-            let p = fullscreen_progress as f32;
-            alpha * (1. - p) + 1. * p
-        };
-
-        // This is here rather than in render_offset() because render_offset() is currently assumed
-        // by the code to be temporary. So, for example, interactive move will try to "grab" the
-        // tile at its current render offset and reset the render offset to zero by cancelling the
-        // tile move animations. On the other hand, bob_offset() is not resettable, so adding it in
-        // render_offset() would cause obvious animation glitches.
-        //
-        // This isn't to say that adding it here is perfect; indeed, it kind of breaks view_rect
-        // passed to update_render_elements(). But, it works well enough for what it is.
-        let location = location + self.bob_offset();
-
-        let window_loc = self.window_loc();
-        let window_size = self.window_size().to_f64();
-        let animated_window_size = self.animated_window_size();
-        let window_render_loc = location + window_loc;
-        let area = Rectangle::new(window_render_loc, animated_window_size);
-
-        let rules = self.window.rules();
-
-        // Clip to geometry including during the fullscreen animation to help with buggy clients
-        // that submit a full-sized buffer before acking the fullscreen state (Firefox).
-        let clip_to_geometry = fullscreen_progress < 1. && rules.clip_to_geometry == Some(true);
-        let radius = rules
-            .geometry_corner_radius
-            .unwrap_or_default()
-            .scaled_by(1. - expanded_progress as f32);
-
         // Popups go on top, whether it's resize or not.
-        self.window.render_push_popups(
+        self.window.render_popups(
             renderer,
             window_render_loc,
             scale,
@@ -1358,7 +1075,7 @@ impl<W: LayoutElement> Tile<W> {
 
                 if let Some(texture_from) = resize.snapshot.texture(gles_renderer, scale, target) {
                     let mut window_elements = Vec::new();
-                    self.window.render_push_normal(
+                    self.window.render_normal(
                         gles_renderer,
                         Point::from((0., 0.)),
                         scale,
@@ -1493,7 +1210,7 @@ impl<W: LayoutElement> Tile<W> {
                 push(damage.with_location(window_render_loc).into());
             }
 
-            self.window.render_push_normal(
+            self.window.render_normal(
                 renderer,
                 window_render_loc,
                 scale,
@@ -1546,7 +1263,7 @@ impl<W: LayoutElement> Tile<W> {
         }
 
         if let Some(width) = self.visual_border_width() {
-            self.border.render_push(
+            self.border.render(
                 renderer,
                 location + Point::from((width, width)),
                 &mut |elem| push(elem.into()),
@@ -1559,86 +1276,16 @@ impl<W: LayoutElement> Tile<W> {
         // a bit weird).
         if focus_ring && expanded_progress < 1. {
             self.focus_ring
-                .render_push(renderer, location, &mut |elem| push(elem.into()));
+                .render(renderer, location, &mut |elem| push(elem.into()));
         }
 
         if expanded_progress < 1. {
             self.shadow
-                .render_push(renderer, location, &mut |elem| push(elem.into()));
+                .render(renderer, location, &mut |elem| push(elem.into()));
         }
     }
 
-    pub fn render<'a, R: NiriRenderer + 'a>(
-        &'a self,
-        renderer: &mut R,
-        location: Point<f64, Logical>,
-        focus_ring: bool,
-        target: RenderTarget,
-    ) -> impl Iterator<Item = TileRenderElement<R>> + 'a {
-        let _span = tracy_client::span!("Tile::render");
-
-        let scale = Scale::from(self.scale);
-
-        let tile_alpha = self
-            .alpha_animation
-            .as_ref()
-            .map_or(1., |alpha| alpha.anim.clamped_value()) as f32;
-
-        let mut open_anim_elem = None;
-        let mut alpha_anim_elem = None;
-        let mut window_elems = None;
-
-        self.window().set_offscreen_data(None);
-
-        if let Some(open) = &self.open_animation {
-            let renderer = renderer.as_gles_renderer();
-            let elements = self.render_inner(renderer, Point::from((0., 0.)), focus_ring, target);
-            let elements = elements.collect::<Vec<TileRenderElement<_>>>();
-            match open.render(
-                renderer,
-                &elements,
-                self.animated_tile_size(),
-                location,
-                scale,
-                tile_alpha,
-            ) {
-                Ok((elem, data)) => {
-                    self.window().set_offscreen_data(Some(data));
-                    open_anim_elem = Some(elem.into());
-                }
-                Err(err) => {
-                    warn!("error rendering window opening animation: {err:?}");
-                }
-            }
-        } else if let Some(alpha) = &self.alpha_animation {
-            let renderer = renderer.as_gles_renderer();
-            let elements = self.render_inner(renderer, Point::from((0., 0.)), focus_ring, target);
-            let elements = elements.collect::<Vec<TileRenderElement<_>>>();
-            match alpha.offscreen.render(renderer, scale, &elements) {
-                Ok((elem, _sync, data)) => {
-                    let offset = elem.offset();
-                    let elem = elem.with_alpha(tile_alpha).with_offset(location + offset);
-
-                    self.window().set_offscreen_data(Some(data));
-                    alpha_anim_elem = Some(elem.into());
-                }
-                Err(err) => {
-                    warn!("error rendering tile to offscreen for alpha animation: {err:?}");
-                }
-            }
-        }
-
-        if open_anim_elem.is_none() && alpha_anim_elem.is_none() {
-            window_elems = Some(self.render_inner(renderer, location, focus_ring, target));
-        }
-
-        open_anim_elem
-            .into_iter()
-            .chain(alpha_anim_elem)
-            .chain(window_elems.into_iter().flatten())
-    }
-
-    pub fn render_push<R: NiriRenderer>(
+    pub fn render<R: NiriRenderer>(
         &self,
         renderer: &mut R,
         location: Point<f64, Logical>,
@@ -1646,7 +1293,7 @@ impl<W: LayoutElement> Tile<W> {
         target: RenderTarget,
         push: &mut dyn FnMut(TileRenderElement<R>),
     ) {
-        let _span = tracy_client::span!("Tile::render_push");
+        let _span = tracy_client::span!("Tile::render");
 
         let scale = Scale::from(self.scale);
 
@@ -1661,7 +1308,7 @@ impl<W: LayoutElement> Tile<W> {
         if let Some(open) = &self.open_animation {
             let renderer = renderer.as_gles_renderer();
             let mut elements = Vec::new();
-            self.render_push_inner(
+            self.render_inner(
                 renderer,
                 Point::from((0., 0.)),
                 focus_ring,
@@ -1688,7 +1335,7 @@ impl<W: LayoutElement> Tile<W> {
         } else if let Some(alpha) = &self.alpha_animation {
             let renderer = renderer.as_gles_renderer();
             let mut elements = Vec::new();
-            self.render_push_inner(
+            self.render_inner(
                 renderer,
                 Point::from((0., 0.)),
                 focus_ring,
@@ -1711,7 +1358,7 @@ impl<W: LayoutElement> Tile<W> {
         }
 
         if !pushed {
-            self.render_push_inner(renderer, location, focus_ring, target, &mut |elem| {
+            self.render_inner(renderer, location, focus_ring, target, &mut |elem| {
                 push(elem)
             });
         }
@@ -1728,19 +1375,28 @@ impl<W: LayoutElement> Tile<W> {
     fn render_snapshot(&self, renderer: &mut GlesRenderer) -> TileRenderSnapshot {
         let _span = tracy_client::span!("Tile::render_snapshot");
 
-        let contents = self.render(renderer, Point::from((0., 0.)), false, RenderTarget::Output);
+        let mut contents = Vec::new();
+        self.render(
+            renderer,
+            Point::from((0., 0.)),
+            false,
+            RenderTarget::Output,
+            &mut |elem| contents.push(elem),
+        );
 
         // A bit of a hack to render blocked out as for screencast, but I think it's fine here.
-        let blocked_out_contents = self.render(
+        let mut blocked_out_contents = Vec::new();
+        self.render(
             renderer,
             Point::from((0., 0.)),
             false,
             RenderTarget::Screencast,
+            &mut |elem| blocked_out_contents.push(elem),
         );
 
         RenderSnapshot {
-            contents: contents.collect(),
-            blocked_out_contents: blocked_out_contents.collect(),
+            contents,
+            blocked_out_contents,
             block_out_from: self.window.rules().block_out_from,
             size: self.animated_tile_size(),
             texture: Default::default(),

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1624,35 +1624,7 @@ impl<W: LayoutElement> Workspace<W> {
         }
     }
 
-    pub fn render_elements<R: NiriRenderer>(
-        &self,
-        renderer: &mut R,
-        target: RenderTarget,
-        focus_ring: bool,
-    ) -> (
-        impl Iterator<Item = WorkspaceRenderElement<R>>,
-        impl Iterator<Item = WorkspaceRenderElement<R>>,
-    ) {
-        let scrolling_focus_ring = focus_ring && !self.floating_is_active();
-        let scrolling = self
-            .scrolling
-            .render_elements(renderer, target, scrolling_focus_ring);
-        let scrolling = scrolling.into_iter().map(WorkspaceRenderElement::from);
-
-        let floating_focus_ring = focus_ring && self.floating_is_active();
-        let floating = self.is_floating_visible().then(|| {
-            let view_rect = Rectangle::from_size(self.view_size);
-            let floating =
-                self.floating
-                    .render_elements(renderer, view_rect, target, floating_focus_ring);
-            floating.into_iter().map(WorkspaceRenderElement::from)
-        });
-        let floating = floating.into_iter().flatten();
-
-        (floating, scrolling)
-    }
-
-    pub fn render_push_scrolling<R: NiriRenderer>(
+    pub fn render_scrolling<R: NiriRenderer>(
         &self,
         renderer: &mut R,
         target: RenderTarget,
@@ -1661,12 +1633,12 @@ impl<W: LayoutElement> Workspace<W> {
     ) {
         let scrolling_focus_ring = focus_ring && !self.floating_is_active();
         self.scrolling
-            .render_push(renderer, target, scrolling_focus_ring, &mut |elem| {
+            .render(renderer, target, scrolling_focus_ring, &mut |elem| {
                 push(elem.into())
             });
     }
 
-    pub fn render_push_floating<R: NiriRenderer>(
+    pub fn render_floating<R: NiriRenderer>(
         &self,
         renderer: &mut R,
         target: RenderTarget,
@@ -1679,7 +1651,7 @@ impl<W: LayoutElement> Workspace<W> {
 
         let view_rect = Rectangle::from_size(self.view_size);
         let floating_focus_ring = focus_ring && self.floating_is_active();
-        self.floating.render_push(
+        self.floating.render(
             renderer,
             view_rect,
             target,
@@ -1691,17 +1663,9 @@ impl<W: LayoutElement> Workspace<W> {
     pub fn render_shadow<R: NiriRenderer>(
         &self,
         renderer: &mut R,
-    ) -> impl Iterator<Item = ShadowRenderElement> + '_ {
-        self.shadow.render(renderer, Point::from((0., 0.)))
-    }
-
-    pub fn render_push_shadow<R: NiriRenderer>(
-        &self,
-        renderer: &mut R,
         push: &mut dyn FnMut(ShadowRenderElement),
     ) {
-        self.shadow
-            .render_push(renderer, Point::from((0., 0.)), push);
+        self.shadow.render(renderer, Point::from((0., 0.)), push);
     }
 
     pub fn render_background(&self) -> SolidColorRenderElement {

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -58,13 +58,6 @@ pub struct BakedBuffer<B> {
     pub dst: Option<Size<i32, Logical>>,
 }
 
-/// Render elements split into normal and popup.
-#[derive(Debug)]
-pub struct SplitElements<E> {
-    pub normal: Vec<E>,
-    pub popups: Vec<E>,
-}
-
 pub trait ToRenderElement {
     type RenderElement;
 
@@ -84,41 +77,6 @@ impl RenderTarget {
             Some(BlockOutFrom::Screencast) => self == RenderTarget::Screencast,
             Some(BlockOutFrom::ScreenCapture) => self != RenderTarget::Output,
         }
-    }
-}
-
-impl<E> Default for SplitElements<E> {
-    fn default() -> Self {
-        Self {
-            normal: Vec::new(),
-            popups: Vec::new(),
-        }
-    }
-}
-
-impl<E> IntoIterator for SplitElements<E> {
-    type Item = E;
-    type IntoIter = std::iter::Chain<std::vec::IntoIter<E>, std::vec::IntoIter<E>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.popups.into_iter().chain(self.normal)
-    }
-}
-
-impl<E> SplitElements<E> {
-    pub fn iter(&self) -> std::iter::Chain<std::slice::Iter<'_, E>, std::slice::Iter<'_, E>> {
-        self.popups.iter().chain(&self.normal)
-    }
-
-    pub fn into_vec(self) -> Vec<E> {
-        let Self { normal, mut popups } = self;
-        popups.extend(normal);
-        popups
-    }
-
-    pub fn extend(&mut self, other: SplitElements<E>) {
-        self.popups.extend(other.popups);
-        self.normal.extend(other.normal);
     }
 }
 

--- a/src/render_helpers/surface.rs
+++ b/src/render_helpers/surface.rs
@@ -84,6 +84,7 @@ pub fn render_snapshot_from_surface_tree(
 pub fn push_elements_from_surface_tree<R>(
     renderer: &mut R,
     surface: &WlSurface,
+    // Fractional scale expects surface buffers to be aligned to physical pixels.
     location: Point<i32, Physical>,
     scale: Scale<f64>,
     alpha: f32,

--- a/src/ui/screenshot_ui.rs
+++ b/src/ui/screenshot_ui.rs
@@ -623,88 +623,9 @@ impl ScreenshotUi {
         &self,
         output: &Output,
         target: RenderTarget,
-    ) -> ArrayVec<ScreenshotUiRenderElement, 11> {
-        let _span = tracy_client::span!("ScreenshotUi::render_output");
-
-        let Self::Open {
-            output_data,
-            show_pointer,
-            button,
-            open_anim,
-            ..
-        } = self
-        else {
-            panic!("screenshot UI must be open to render it");
-        };
-
-        let mut elements = ArrayVec::new();
-
-        let Some(output_data) = output_data.get(output) else {
-            return elements;
-        };
-
-        let scale = output_data.scale;
-        let progress = open_anim.clamped_value().clamp(0., 1.) as f32;
-
-        // The help panel goes on top.
-        if let Some((show, hide)) = &output_data.panel {
-            let buffer = if *show_pointer { hide } else { show };
-            let alpha = if button.is_dragging_selection() {
-                0.3
-            } else {
-                0.9
-            };
-            let location = panel_location(output_data, buffer.texture().size())
-                .to_f64()
-                .to_logical(scale);
-
-            let elem = PrimaryGpuTextureRenderElement(TextureRenderElement::from_texture_buffer(
-                buffer.clone(),
-                location,
-                alpha * progress,
-                None,
-                None,
-                Kind::Unspecified,
-            ));
-            elements.push(elem.into());
-        }
-
-        let buf_loc = zip(&output_data.buffers, &output_data.locations);
-        elements.extend(buf_loc.map(|(buffer, loc)| {
-            SolidColorRenderElement::from_buffer(
-                buffer,
-                loc.to_f64().to_logical(scale),
-                progress,
-                Kind::Unspecified,
-            )
-            .into()
-        }));
-
-        // The screenshot itself goes last.
-        let index = match target {
-            RenderTarget::Output => 0,
-            RenderTarget::Screencast => 1,
-            RenderTarget::ScreenCapture => 2,
-        };
-        let screenshot = &output_data.screenshot[index];
-
-        if *show_pointer {
-            if let Some(pointer) = screenshot.pointer.clone() {
-                elements.push(pointer.into());
-            }
-        }
-        elements.push(screenshot.buffer.clone().into());
-
-        elements
-    }
-
-    pub fn render_push_output(
-        &self,
-        output: &Output,
-        target: RenderTarget,
         push: &mut dyn FnMut(ScreenshotUiRenderElement),
     ) {
-        let _span = tracy_client::span!("ScreenshotUi::render_push_output");
+        let _span = tracy_client::span!("ScreenshotUi::render_output");
 
         let Self::Open {
             output_data,

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -2,9 +2,7 @@ use std::cell::{Cell, Ref, RefCell};
 use std::time::Duration;
 
 use niri_config::{Color, CornerRadius, GradientInterpolation, WindowRule};
-use smithay::backend::renderer::element::surface::{
-    render_elements_from_surface_tree, WaylandSurfaceRenderElement,
-};
+use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::Kind;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::desktop::space::SpaceElement as _;
@@ -38,7 +36,7 @@ use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderEleme
 use crate::render_helpers::surface::{
     push_elements_from_surface_tree, render_snapshot_from_surface_tree,
 };
-use crate::render_helpers::{BakedBuffer, RenderTarget, SplitElements};
+use crate::render_helpers::{BakedBuffer, RenderTarget};
 use crate::utils::id::IdCounter;
 use crate::utils::transaction::Transaction;
 use crate::utils::{
@@ -476,7 +474,8 @@ impl Mapped {
         &self,
         renderer: &mut R,
         scale: Scale<f64>,
-    ) -> impl DoubleEndedIterator<Item = WindowCastRenderElements<R>> {
+        push: &mut dyn FnMut(WindowCastRenderElements<R>),
+    ) {
         let bbox = self.window.bbox_with_popups().to_physical_precise_up(scale);
 
         let has_border_shader = BorderRenderElement::has_shader(renderer);
@@ -488,11 +487,9 @@ impl Mapped {
             .to_physical_precise_round(scale)
             .to_logical(scale);
         let radius = radius.fit_to(window_size.w as f32, window_size.h as f32);
-
         let location = self.window.geometry().loc.to_f64() - bbox.loc.to_logical(scale);
-        let elements = self.render(renderer, location, scale, 1., RenderTarget::Screencast);
 
-        elements.into_iter().map(move |elem| {
+        let use_border = |elem| {
             if let LayoutElementRenderElement::SolidColor(elem) = &elem {
                 // In this branch we're rendering a blocked-out window with a solid color. We need
                 // to render it with a rounded corner shader even if clip_to_geometry is false,
@@ -520,7 +517,16 @@ impl Mapped {
             }
 
             WindowCastRenderElements::from(elem)
-        })
+        };
+
+        self.render(
+            renderer,
+            location,
+            scale,
+            1.,
+            RenderTarget::Screencast,
+            &mut |elem| push(use_border(elem)),
+        );
     }
 
     pub fn get_focus_timestamp(&self) -> Option<Duration> {
@@ -605,81 +611,7 @@ impl LayoutElement for Mapped {
         self.window.is_in_input_region(&surface_local)
     }
 
-    fn render<R: NiriRenderer>(
-        &self,
-        renderer: &mut R,
-        location: Point<f64, Logical>,
-        scale: Scale<f64>,
-        alpha: f32,
-        target: RenderTarget,
-    ) -> SplitElements<LayoutElementRenderElement<R>> {
-        let mut rv = SplitElements::default();
-
-        if target.should_block_out(self.rules.block_out_from) {
-            let mut buffer = self.block_out_buffer.borrow_mut();
-            buffer.resize(self.window.geometry().size.to_f64());
-            let elem =
-                SolidColorRenderElement::from_buffer(&buffer, location, alpha, Kind::Unspecified);
-            rv.normal.push(elem.into());
-        } else {
-            let buf_pos = location - self.window.geometry().loc.to_f64();
-
-            let surface = self.toplevel().wl_surface();
-            for (popup, popup_offset) in PopupManager::popups_for_surface(surface) {
-                let offset = self.window.geometry().loc + popup_offset - popup.geometry().loc;
-
-                rv.popups.extend(render_elements_from_surface_tree(
-                    renderer,
-                    popup.wl_surface(),
-                    (buf_pos + offset.to_f64()).to_physical_precise_round(scale),
-                    scale,
-                    alpha,
-                    Kind::ScanoutCandidate,
-                ));
-            }
-
-            rv.normal = render_elements_from_surface_tree(
-                renderer,
-                surface,
-                buf_pos.to_physical_precise_round(scale),
-                scale,
-                alpha,
-                Kind::ScanoutCandidate,
-            );
-        }
-
-        rv
-    }
-
     fn render_normal<R: NiriRenderer>(
-        &self,
-        renderer: &mut R,
-        location: Point<f64, Logical>,
-        scale: Scale<f64>,
-        alpha: f32,
-        target: RenderTarget,
-    ) -> Vec<LayoutElementRenderElement<R>> {
-        if target.should_block_out(self.rules.block_out_from) {
-            let mut buffer = self.block_out_buffer.borrow_mut();
-            buffer.resize(self.window.geometry().size.to_f64());
-            let elem =
-                SolidColorRenderElement::from_buffer(&buffer, location, alpha, Kind::Unspecified);
-            vec![elem.into()]
-        } else {
-            let buf_pos = location - self.window.geometry().loc.to_f64();
-            let surface = self.toplevel().wl_surface();
-            render_elements_from_surface_tree(
-                renderer,
-                surface,
-                buf_pos.to_physical_precise_round(scale),
-                scale,
-                alpha,
-                Kind::ScanoutCandidate,
-            )
-        }
-    }
-
-    fn render_push_normal<R: NiriRenderer>(
         &self,
         renderer: &mut R,
         location: Point<f64, Logical>,
@@ -711,38 +643,6 @@ impl LayoutElement for Mapped {
     }
 
     fn render_popups<R: NiriRenderer>(
-        &self,
-        renderer: &mut R,
-        location: Point<f64, Logical>,
-        scale: Scale<f64>,
-        alpha: f32,
-        target: RenderTarget,
-    ) -> Vec<LayoutElementRenderElement<R>> {
-        if target.should_block_out(self.rules.block_out_from) {
-            vec![]
-        } else {
-            let mut rv = vec![];
-
-            let buf_pos = location - self.window.geometry().loc.to_f64();
-            let surface = self.toplevel().wl_surface();
-            for (popup, popup_offset) in PopupManager::popups_for_surface(surface) {
-                let offset = self.window.geometry().loc + popup_offset - popup.geometry().loc;
-
-                rv.extend(render_elements_from_surface_tree(
-                    renderer,
-                    popup.wl_surface(),
-                    (buf_pos + offset.to_f64()).to_physical_precise_round(scale),
-                    scale,
-                    alpha,
-                    Kind::ScanoutCandidate,
-                ));
-            }
-
-            rv
-        }
-    }
-
-    fn render_push_popups<R: NiriRenderer>(
         &self,
         renderer: &mut R,
         location: Point<f64, Logical>,


### PR DESCRIPTION
Our current rendering code constructs and returns complex `-> impl Iterator<Item = SomeRenderElement>` types that are collected into a vector at the top level `Niri::render()`. This causes some problems:
- It's hard to write logic around returning iterators. Especially things like conditions, since the returned iterator must have a single type, you can't branch and return different iterators. This will be solved by `gen fn` but alas it's not here yet.
- In many cases, the returned `-> impl Iterator` will borrow from `&self` leading to complex lifetimes. In certain cases, it is also desirable for it to borrow the `&mut NiriRenderer`, which causes a lot of issues because it's exclusive (`&mut`).
- Sometimes those issues are too hard to deal with, leading to the escape hatch of allocating and returning a temporary `Vec<SomeRenderElement>`, like in `Scrolling/FloatingSpace::render_elements()`. These allocations are unfortunate because they are not really necessary.
- It's impossible to use some downstream combinators with this `-> impl Iterator` approach, leading to functions like Smithay's [`render_elements_from_surface_tree()`](https://smithay.github.io/smithay/smithay/backend/renderer/element/surface/fn.render_elements_from_surface_tree.html) returning a Vec. This is extra unfortunate because it results in a temporary allocation per Wayland toplevel/popup.
- It's hard to properly create profiling spans for the rendering functions since the spans are dropped when the (lazy) iterator is returned and not when all the code actually completes.
- The code compiles down to complex state machines in generated iterator types with logic located in `Iterator::next()`, which makes it annoying to follow in debuggers and profiling tools.

This refactor changes the code to push-based iteration: rendering functions receive a `push()` closure that they call to push their render elements. It solves all of the aforementioned problems:
- The logic becomes simpler. Just use conditionals and loops as normal.
- No borrowing and lifetimes since we're not returning anything.
- All temporary Vecs are removed because the problems they worked around no longer exist.
- The new `push_elements_from_surface_tree()` helper is the same as `render_elements_from_surface_tree()` but doesn't allocate a temporary Vec since it's not necessary; the `push()` closure can be passed down.
- Profiling spans work normally since the function returns when it ran all of the logic.
- The code compiles down to normal functions and calls as expected.

Generally, the iterator approach gives these advantages:
- You can wrap the returned items in the upstream logic. This is possible in exactly the same way with the push closure.
- You can decide to cut the iterator short in the upstream logic. This is not possible with push-based iteration, but we don't actually use it anywhere.

I chose the push closure type to be `&mut dyn FnMut(SomeRenderElement)`. It's deliberately not a generic `impl FnMut()` to avoid duplicating the rendering logic when it's called from several different places. But it's still a normal closure that can capture the outside context.

While my original idea for this refactor was to simplify the logic while getting rid of temporary Vecs, it also appears to have brought a consistent 2-3x speedup to the whole render list construction. There's a benchmark hardcoded to run when pressing the `center-visible-columns` action if you check out the first commit of this PR. On an old Eee PC laptop I even observed a 8x speedup.

The refactor also results in smaller binary size, presumably due to removing many iterator combinators and state tracking.

Here's an example Tracy screenshot of the previous rendering vs. new rendering invocation. The orange line at the bottom tracks the allocated memory. You can see that the previous rendering allocates and drops many times, while the new rendering pretty much only grows the output elements vector (the steps are the vector capacity increasing as more elements are added).

<img width="696" height="430" alt="Screenshot from 2025-12-23 12-09-01" src="https://github.com/user-attachments/assets/9b77c61f-6f41-48f2-aedc-c90049611589" />
