### PR TITLE
Allow trackball scrolling in overview

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3255,8 +3255,8 @@ impl State {
         let horizontal_amount = event.amount(Axis::Horizontal);
         let vertical_amount = event.amount(Axis::Vertical);
 
-        // Handle touchpad scroll bindings.
-        if source == AxisSource::Finger {
+        // Handle touchpad and continuous scroll bindings.
+        if source == AxisSource::Finger || source == AxisSource::Continuous {
             let mods = self.niri.seat.get_keyboard().unwrap().modifier_state();
             let modifiers = modifiers_from_state(mods);
 


### PR DESCRIPTION
Simply allows scrolling in the overview with a trackball (on-button-down). Tested on an Arch PC and a Fedora laptop, everything works as expected

Closes #2544

I wanted to also handle `mods_with_finger_scroll_binds` (mod+scroll in main view), but that seems pretty coupled with `horizontal_finger_scroll_tracker` so I'm leaving it for now.

Not sure which sensitivity is used here, but when #2844 is merged we can probably use that value

![Recording 2025-12-25 at 22 20 30](https://github.com/user-attachments/assets/8e44c882-d4b6-4a91-95cf-fadc5ba46a01)
