### PR TITLE
feat(overview): add vim hjkl navigation keys

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4635,10 +4635,10 @@ fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Bind> {
             repeat = false;
             Action::ToggleOverview
         }
-        Keysym::Left => Action::FocusColumnLeft,
-        Keysym::Right => Action::FocusColumnRight,
-        Keysym::Up => Action::FocusWindowOrWorkspaceUp,
-        Keysym::Down => Action::FocusWindowOrWorkspaceDown,
+        Keysym::Left | Keysym::h => Action::FocusColumnLeft,
+        Keysym::Right | Keysym::l => Action::FocusColumnRight,
+        Keysym::Up | Keysym::k => Action::FocusWindowOrWorkspaceUp,
+        Keysym::Down | Keysym::j => Action::FocusWindowOrWorkspaceDown,
         _ => {
             return None;
         }


### PR DESCRIPTION
Add vim-style hjkl navigation keys to overview mode.

#### Changes

- Add `h`, `l` keys for horizontal navigation (alongside Left/Right arrows)
- Add `j`, `k` keys for vertical navigation (alongside Down/Up arrows)
- Non-breaking: existing arrow key navigation preserved

#### Test plan

- [ ] Open overview mode (Super key or configured keybind)
- [ ] Navigate columns with arrow keys Left/Right (existing behavior)
- [ ] Navigate columns with h/l (new behavior)
- [ ] Navigate windows/workspaces with arrow keys Up/Down (existing behavior)
- [ ] Navigate windows/workspaces with j/k (new behavior)
- [ ] Confirm Enter still selects focused window
- [ ] Confirm Escape still closes overview