### PR TITLE
Add window stacking order to IPC

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1307,6 +1307,30 @@ pub struct Window {
     ///
     /// The timestamp comes from the monotonic clock.
     pub focus_timestamp: Option<Timestamp>,
+    /// Stacking order of the window, if applicable.
+    pub stacking_order: Option<StackingOrder>,
+}
+
+/// Stacking order group of a [`Window`].
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub enum StackingOrderGroup {
+    /// Normal floating windows.
+    Floating,
+}
+
+/// Stacking order of a [`Window`].
+///
+/// This struct is totally ordered. Windows with a greater [`StackingOrderGroup`] are always stacked
+/// above windows with a lower group. Within each group, windows with a greater index are stacked
+/// above windows with a lower index.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct StackingOrder {
+    /// Group of the window.
+    pub group: StackingOrderGroup,
+    /// Index within the group.
+    pub index: usize,
 }
 
 /// A moment in time.
@@ -1554,6 +1578,11 @@ pub enum Event {
     WindowLayoutsChanged {
         /// Pairs consisting of a window id and new layout information for the window.
         changes: Vec<(u64, WindowLayout)>,
+    },
+    /// The stacking order of one or more windows has changed.
+    WindowStackingOrdersChanged {
+        /// Pairs consisting of a window id and new stacking order for the window.
+        changes: Vec<(u64, StackingOrder)>,
     },
     /// The configured keyboard layouts have changed.
     KeyboardLayoutsChanged {

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -219,6 +219,13 @@ impl EventStreamStatePart for WindowsState {
                     win.layout = update;
                 }
             }
+            Event::WindowStackingOrdersChanged { changes } => {
+                for (id, update) in changes.iter().copied() {
+                    let win = self.windows.get_mut(&id);
+                    let win = win.expect("changed window was missing from the map");
+                    win.stacking_order = Some(update);
+                }
+            }
             event => return Some(event),
         }
         None

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -470,6 +470,9 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
                     Event::WindowLayoutsChanged { changes } => {
                         println!("Window layouts changed: {changes:?}");
                     }
+                    Event::WindowStackingOrdersChanged { changes } => {
+                        println!("Window stacking orders changed: {changes:?}");
+                    }
                     Event::KeyboardLayoutsChanged { keyboard_layouts } => {
                         println!("Keyboard layouts changed: {keyboard_layouts:?}");
                     }

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -323,7 +323,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
         })
     }
 
-    pub fn tiles_with_ipc_layouts(&self) -> impl Iterator<Item = (&Tile<W>, WindowLayout)> {
+    pub fn tiles_ipc(&self) -> impl Iterator<Item = (&Tile<W>, WindowLayout)> {
         let scale = self.scale;
         self.tiles_with_offsets().map(move |(tile, offset)| {
             // Do not include animated render offset here to avoid IPC spam.

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2416,7 +2416,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             })
     }
 
-    pub fn tiles_with_ipc_layouts(&self) -> impl Iterator<Item = (&Tile<W>, WindowLayout)> {
+    pub fn tiles_ipc(&self) -> impl Iterator<Item = (&Tile<W>, WindowLayout)> {
         self.columns
             .iter()
             .enumerate()

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -6,7 +6,9 @@ use niri_config::utils::MergeWith as _;
 use niri_config::{
     CenterFocusedColumn, CornerRadius, OutputName, PresetSize, Workspace as WorkspaceConfig,
 };
-use niri_ipc::{ColumnDisplay, PositionChange, SizeChange, WindowLayout};
+use niri_ipc::{
+    ColumnDisplay, PositionChange, SizeChange, StackingOrder, StackingOrderGroup, WindowLayout,
+};
 use smithay::backend::renderer::element::Kind;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::desktop::{layer_map_for_output, Window};
@@ -1602,9 +1604,20 @@ impl<W: LayoutElement> Workspace<W> {
         floating.chain(scrolling)
     }
 
-    pub fn tiles_with_ipc_layouts(&self) -> impl Iterator<Item = (&Tile<W>, WindowLayout)> {
-        let scrolling = self.scrolling.tiles_with_ipc_layouts();
-        let floating = self.floating.tiles_with_ipc_layouts();
+    pub fn tiles_ipc(
+        &self,
+    ) -> impl Iterator<Item = (&Tile<W>, WindowLayout, Option<StackingOrder>)> {
+        let scrolling = self.scrolling.tiles_ipc().map(|(t, l)| (t, l, None));
+        let floating = self.floating.tiles_ipc().enumerate().map(|(i, (t, l))| {
+            (
+                t,
+                l,
+                Some(StackingOrder {
+                    group: StackingOrderGroup::Floating,
+                    index: usize::MAX - i,
+                }),
+            )
+        });
         floating.chain(scrolling)
     }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2350,7 +2350,7 @@ impl State {
             },
         );
 
-        self.niri.layout.with_windows(|mapped, _, _, _| {
+        self.niri.layout.with_windows(|mapped, _, _, _, _| {
             let id = mapped.id().get();
             let props = with_toplevel_role(mapped.toplevel(), |role| {
                 gnome_shell_introspect::WindowProperties {
@@ -4194,7 +4194,7 @@ impl Niri {
         let mut seen = HashSet::new();
         let mut output_changed = vec![];
 
-        self.layout.with_windows(|mapped, output, _, _| {
+        self.layout.with_windows(|mapped, output, _, _, _| {
             seen.insert(mapped.window.clone());
 
             let Some(output) = output else {

--- a/src/protocols/foreign_toplevel.rs
+++ b/src/protocols/foreign_toplevel.rs
@@ -97,7 +97,7 @@ pub fn refresh(state: &mut State) {
     // Save the focused window for last, this way when the focus changes, we will first deactivate
     // the previous window and only then activate the newly focused window.
     let mut focused = None;
-    state.niri.layout.with_windows(|mapped, output, _, _| {
+    state.niri.layout.with_windows(|mapped, output, _, _, _| {
         let toplevel = mapped.toplevel();
         let wl_surface = toplevel.wl_surface();
         with_toplevel_role_and_current(toplevel, |role, cur| {


### PR DESCRIPTION
This implements #2248.

The stacking order is defined by the totally ordered `StackingOrder` struct which contains both a `StackingOrderGroup` and an index, which indicates position within the group. This can be later extended to support always-on-top windows by adding it as a new group. Per convention, a greater index implies a window is more on top. 

When a window's stacking order goes from `None -> Some(...)` or vice versa, the change is observed in the existing `WindowOpenedOrChanged` event. Otherwise, `Some(...) -> Some(...)` changes are batched in the `WindowStackingOrdersChanged` event.