### PR TITLE
Stop hardcoding the niri path in niri.service

### DIFF
--- a/resources/niri.service
+++ b/resources/niri.service
@@ -11,4 +11,4 @@ Before=xdg-desktop-autostart.target
 [Service]
 Slice=session.slice
 Type=notify
-ExecStart=/usr/bin/niri --session
+ExecStart=niri --session


### PR DESCRIPTION
From `man systemd.service`:
> Searched directories include /usr/local/bin/, /usr/bin/, and their sbin/ counterparts (only on systems using split bin/ and sbin/).

i.e. `/usr/bin/niri` is redundant: `ExecStart` can already “see” `niri`

The actual benefit of this pr, though, is the idea that you might have a personal niri fork, the binary of which you'll place in `/usr/local/bin/niri`.
Then you can easily use the infrastructure that the system package provides to you, and only worry about your changes towards the niri binary. Very convenient! \
When you do this, though, placing the resulting binary into `/usr/bin/niri`, overriding the package's one, is a bit annoying, because on the next update your patched binary will get **replaced**. \
You might rely on some changes in your fork for niri to start well, and so you may run into an annoyance if it's replaced beneath your feet.

But with this pr, you just blammo it into `/usr/local/bin/niri`, and continue to never worry again 😌 \
Since it comes *before* /usr/bin in both $PATH and in `ExecStart`, it'll correctly override the /usr/bin/niri binary as expected.
