### PR TITLE
 nix: fix path replace in SystemD service 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
           postPatch = ''
             patchShebangs resources/niri-session
             substituteInPlace resources/niri.service \
-              --replace-fail '/usr/bin' "$out/bin"
+              --replace-fail 'ExecStart=niri' "ExecStart=$out/bin/niri"
           '';
 
           cargoLock = {


### PR DESCRIPTION
Fix a build error in the Nix flake due to the path change in the just-merged #3187

~~I also changed the Nix workflow to _not_ continue on check errors, so we won't have a false-positive success check in the future like it just happened with this other PR.~~