### PR TITLE
Add pinned window support

### DIFF
--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -541,7 +541,7 @@ window-rule {
 }
 ```
 
-Only *floating* pinned windows will be actively pinned to the monitor on workspace switch, so you likely want `open-floating` too.
+Only *floating* pinned windows will remain fixed to the monitor on workspace switch, so you likely want `open-floating` too.
 
 ```kdl
 // Open the Firefox picture-in-picture window as floating and pinned.

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -36,6 +36,7 @@ window-rule {
     match is-floating=true
     match is-window-cast-target=true
     match is-urgent=true
+    match is-pinned=true
     match at-startup=true
 
     // Properties that apply once upon window opening.
@@ -48,6 +49,7 @@ window-rule {
     open-fullscreen true
     open-floating true
     open-focused false
+    open-pinned true
 
     // Properties that apply continuously.
     draw-border-with-background false
@@ -177,7 +179,7 @@ You can find the title and the app ID of a window by running `niri msg pick-wind
 
 > [!TIP]
 > Another way to find the window title and app ID is to configure the `wlr/taskbar` module in [Waybar](https://github.com/Alexays/Waybar) to include them in the tooltip:
-> 
+>
 > ```json
 > "wlr/taskbar": {
 >     "tooltip-format": "{title} | {app_id}",
@@ -298,6 +300,19 @@ Matches windows that request the user's attention.
 ```kdl
 window-rule {
     match is-urgent=true
+}
+```
+
+#### `is-pinned`
+
+<sup>Since: next release</sup>
+
+Can be `true` or `false`.
+Matches windows that are pinned.
+
+```kdl
+window-rule {
+    match is-pinned=true
 }
 ```
 
@@ -508,6 +523,33 @@ window-rule {
     match app-id=r#"^org\.keepassxc\.KeePassXC$"# title="^Unlock Database - KeePassXC$"
 
     open-focused true
+}
+```
+
+#### `open-pinned`
+
+<sup>Since: next release</sup>
+
+Make the window open pinned.
+
+```kdl
+// Open the Firefox picture-in-picture window as pinned.
+window-rule {
+    match app-id="firefox$" title="^Picture-in-Picture$"
+
+    open-pinned true
+}
+```
+
+Only *floating* pinned windows will be actively pinned to the monitor on workspace switch, so you likely want `open-floating` too.
+
+```kdl
+// Open the Firefox picture-in-picture window as floating and pinned.
+window-rule {
+    match app-id="firefox$" title="^Picture-in-Picture$"
+
+    open-floating true
+    open-pinned true
 }
 ```
 

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -333,6 +333,9 @@ pub enum Action {
     ToggleWindowFloating,
     #[knuffel(skip)]
     ToggleWindowFloatingById(u64),
+    ToggleWindowPinned,
+    #[knuffel(skip)]
+    ToggleWindowPinnedById(u64),
     MoveWindowToFloating,
     #[knuffel(skip)]
     MoveWindowToFloatingById(u64),

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -702,6 +702,7 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::ToggleWindowUrgent { id } => Self::ToggleWindowUrgent(id),
             niri_ipc::Action::SetWindowUrgent { id } => Self::SetWindowUrgent(id),
             niri_ipc::Action::UnsetWindowUrgent { id } => Self::UnsetWindowUrgent(id),
+            niri_ipc::Action::ToggleWindowPinned { id } => Self::ToggleWindowPinnedById(id),
             niri_ipc::Action::LoadConfigFile { path } => Self::LoadConfigFile(path),
         }
     }

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -702,7 +702,10 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::ToggleWindowUrgent { id } => Self::ToggleWindowUrgent(id),
             niri_ipc::Action::SetWindowUrgent { id } => Self::SetWindowUrgent(id),
             niri_ipc::Action::UnsetWindowUrgent { id } => Self::UnsetWindowUrgent(id),
-            niri_ipc::Action::ToggleWindowPinned { id } => Self::ToggleWindowPinnedById(id),
+            niri_ipc::Action::ToggleWindowPinned { id: None } => Self::ToggleWindowPinned,
+            niri_ipc::Action::ToggleWindowPinned { id: Some(id) } => {
+                Self::ToggleWindowPinnedById(id)
+            }
             niri_ipc::Action::LoadConfigFile { path } => Self::LoadConfigFile(path),
         }
     }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -837,7 +837,7 @@ mod tests {
                 window-open { off; }
 
                 window-close {
-                    curve "cubic-bezier" 0.05 0.7 0.1 1  
+                    curve "cubic-bezier" 0.05 0.7 0.1 1
                 }
 
                 recent-windows-close {
@@ -867,6 +867,7 @@ mod tests {
                 open-fullscreen false
                 open-floating false
                 open-focused true
+                open-pinned false
                 default-window-height { fixed 500; }
                 default-column-display "tabbed"
                 default-floating-position x=100 y=-200 relative-to="bottom-left"
@@ -1697,6 +1698,7 @@ mod tests {
                             is_focused: None,
                             is_active_in_column: None,
                             is_floating: None,
+                            is_pinned: None,
                             is_window_cast_target: None,
                             is_urgent: None,
                             at_startup: None,
@@ -1716,6 +1718,7 @@ mod tests {
                             is_focused: None,
                             is_active_in_column: None,
                             is_floating: None,
+                            is_pinned: None,
                             is_window_cast_target: None,
                             is_urgent: None,
                             at_startup: None,
@@ -1731,6 +1734,7 @@ mod tests {
                             ),
                             is_active_in_column: None,
                             is_floating: None,
+                            is_pinned: None,
                             is_window_cast_target: None,
                             is_urgent: None,
                             at_startup: None,
@@ -1762,6 +1766,9 @@ mod tests {
                     ),
                     open_focused: Some(
                         true,
+                    ),
+                    open_pinned: Some(
+                        false,
                     ),
                     min_width: None,
                     min_height: None,

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -31,6 +31,8 @@ pub struct WindowRule {
     pub open_floating: Option<bool>,
     #[knuffel(child, unwrap(argument))]
     pub open_focused: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub open_pinned: Option<bool>,
 
     // Rules applied dynamically.
     #[knuffel(child, unwrap(argument))]
@@ -88,6 +90,8 @@ pub struct Match {
     pub is_active_in_column: Option<bool>,
     #[knuffel(property)]
     pub is_floating: Option<bool>,
+    #[knuffel(property)]
+    pub is_pinned: Option<bool>,
     #[knuffel(property)]
     pub is_window_cast_target: Option<bool>,
     #[knuffel(property)]

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -935,8 +935,10 @@ pub enum Action {
     /// Toggle pinned status of a window.
     ToggleWindowPinned {
         /// Id of the window to toggle pinned.
+        ///
+        /// If `None`, uses the focused window.
         #[cfg_attr(feature = "clap", arg(long))]
-        id: u64,
+        id: Option<u64>,
     },
     /// Reload the config file.
     ///

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -932,6 +932,12 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(long))]
         id: u64,
     },
+    /// Toggle pinned status of a window.
+    ToggleWindowPinned {
+        /// Id of the window to toggle pinned.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: u64,
+    },
     /// Reload the config file.
     ///
     /// Can be useful for scripts changing the config file, to avoid waiting the small duration for
@@ -1324,6 +1330,11 @@ pub struct Window {
     pub is_floating: bool,
     /// Whether this window requests your attention.
     pub is_urgent: bool,
+    /// Whether this window is pinned.
+    ///
+    /// If the window is pinned and floating on workspace switch, then it remains fixed to the
+    /// monitor.
+    pub is_pinned: bool,
     /// Position- and size-related properties of the window.
     pub layout: WindowLayout,
     /// Timestamp when the window was most recently focused.
@@ -1648,6 +1659,13 @@ pub enum Event {
         id: u64,
         /// The new urgency state of the window.
         urgent: bool,
+    },
+    /// Window pinned changed.
+    WindowPinnedChanged {
+        /// Id of the window.
+        id: u64,
+        /// The new pinned state of the window.
+        pinned: bool,
     },
     /// The layout of one or more windows has changed.
     WindowLayoutsChanged {

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -224,6 +224,14 @@ impl EventStreamStatePart for WindowsState {
                     }
                 }
             }
+            Event::WindowPinnedChanged { id, pinned } => {
+                for win in self.windows.values_mut() {
+                    if win.id == id {
+                        win.is_pinned = pinned;
+                        break;
+                    }
+                }
+            }
             Event::WindowLayoutsChanged { changes } => {
                 for (id, update) in changes {
                     let win = self.windows.get_mut(&id);

--- a/niri-visual-tests/src/test_window.rs
+++ b/niri-visual-tests/src/test_window.rs
@@ -267,4 +267,8 @@ impl LayoutElement for TestWindow {
     fn is_urgent(&self) -> bool {
         false
     }
+
+    fn is_pinned(&self) -> bool {
+        false
+    }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2120,6 +2120,20 @@ impl State {
                     self.niri.queue_redraw_all();
                 }
             }
+            Action::ToggleWindowPinned => {
+                self.niri.layout.toggle_window_pinned(None);
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
+            Action::ToggleWindowPinnedById(id) => {
+                let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
+                let window = window.map(|(_, m)| m.window.clone());
+                if let Some(window) = window {
+                    self.niri.layout.toggle_window_pinned(Some(&window));
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
             Action::MoveWindowToFloating => {
                 self.niri.layout.set_window_floating(None, true);
                 // FIXME: granular

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2121,15 +2121,25 @@ impl State {
                 }
             }
             Action::ToggleWindowPinned => {
-                self.niri.layout.toggle_window_pinned(None);
-                // FIXME: granular
-                self.niri.queue_redraw_all();
+                if let Some(mapped) = self
+                    .niri
+                    .layout
+                    .active_workspace_mut()
+                    .and_then(|w| w.active_window_mut())
+                {
+                    mapped.set_pinned(!mapped.is_pinned());
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
             }
             Action::ToggleWindowPinnedById(id) => {
-                let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
-                let window = window.map(|(_, m)| m.window.clone());
-                if let Some(window) = window {
-                    self.niri.layout.toggle_window_pinned(Some(&window));
+                let mapped = self
+                    .niri
+                    .layout
+                    .workspaces_mut()
+                    .find_map(|ws| ws.windows_mut().find(|w| w.id().get() == id));
+                if let Some(mapped) = mapped {
+                    mapped.set_pinned(!mapped.is_pinned());
                     // FIXME: granular
                     self.niri.queue_redraw_all();
                 }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -468,6 +468,9 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
                     Event::WindowUrgencyChanged { id, urgent } => {
                         println!("Window {id}: urgency changed to {urgent}");
                     }
+                    Event::WindowPinnedChanged { id, pinned } => {
+                        println!("Window {id}: pinned changed to {pinned}");
+                    }
                     Event::WindowLayoutsChanged { changes } => {
                         println!("Window layouts changed: {changes:?}");
                     }
@@ -672,7 +675,8 @@ fn print_output(output: Output) -> anyhow::Result<()> {
 fn print_window(window: &Window) {
     let focused = if window.is_focused { " (focused)" } else { "" };
     let urgent = if window.is_urgent { " (urgent)" } else { "" };
-    println!("Window ID {}:{focused}{urgent}", window.id);
+    let pinned = if window.is_pinned { " (pinned)" } else { "" };
+    println!("Window ID {}:{focused}{urgent}{pinned}", window.id);
 
     if let Some(title) = &window.title {
         println!("  Title: \"{title}\"");

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -526,6 +526,7 @@ fn make_ipc_window(
         is_focused: mapped.is_focused(),
         is_floating: mapped.is_floating(),
         is_urgent: mapped.is_urgent(),
+        is_pinned: mapped.is_pinned(),
         layout,
         focus_timestamp: mapped.get_focus_timestamp().map(Timestamp::from),
     })
@@ -750,6 +751,11 @@ impl State {
             let urgent = mapped.is_urgent();
             if urgent != ipc_win.is_urgent {
                 events.push(Event::WindowUrgencyChanged { id, urgent })
+            }
+
+            let pinned = mapped.is_pinned();
+            if pinned != ipc_win.is_pinned {
+                events.push(Event::WindowPinnedChanged { id, pinned })
             }
         });
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -3138,6 +3138,24 @@ impl<W: LayoutElement> Layout<W> {
         workspace.toggle_window_floating(window);
     }
 
+    pub fn toggle_window_pinned(&mut self, window: Option<&W::Id>) {
+        let monitor = if let Some(window) = window {
+            Some(
+                self.monitors_mut()
+                    .find(|mon| mon.has_window(window))
+                    .unwrap(),
+            )
+        } else {
+            self.active_monitor()
+        };
+
+        let Some(monitor) = monitor else {
+            return;
+        };
+
+        monitor.toggle_window_pinned(window);
+    }
+
     pub fn set_window_floating(&mut self, window: Option<&W::Id>, floating: bool) {
         if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
             if window.is_none() || window == Some(move_.tile.window().id()) {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -223,6 +223,7 @@ pub trait LayoutElement {
     fn is_ignoring_opacity_window_rule(&self) -> bool;
 
     fn is_urgent(&self) -> bool;
+    fn is_pinned(&self) -> bool;
 
     fn configure_intent(&self) -> ConfigureIntent;
     fn send_pending_configure(&mut self);
@@ -3137,24 +3138,6 @@ impl<W: LayoutElement> Layout<W> {
             return;
         };
         workspace.toggle_window_floating(window);
-    }
-
-    pub fn toggle_window_pinned(&mut self, window: Option<&W::Id>) {
-        let monitor = if let Some(window) = window {
-            Some(
-                self.monitors_mut()
-                    .find(|mon| mon.has_window(window))
-                    .unwrap(),
-            )
-        } else {
-            self.active_monitor()
-        };
-
-        let Some(monitor) = monitor else {
-            return;
-        };
-
-        monitor.toggle_window_pinned(window);
     }
 
     pub fn set_window_floating(&mut self, window: Option<&W::Id>, floating: bool) {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -447,6 +447,7 @@ pub enum ConfigureIntent {
 }
 
 /// Tile that was just removed from the layout.
+#[derive(Debug)]
 pub struct RemovedTile<W: LayoutElement> {
     tile: Tile<W>,
     /// Width of the column the tile was in.

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -20,6 +20,7 @@ use super::workspace::{
 use super::{compute_overview_zoom, ActivateWindow, HitType, LayoutElement, Options};
 use crate::animation::{Animation, Clock};
 use crate::input::swipe_tracker::SwipeTracker;
+use crate::layout::{RemovedTile, SizeFrac};
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shadow::ShadowRenderElement;
@@ -77,6 +78,8 @@ pub struct Monitor<W: LayoutElement> {
     insert_hint_render_loc: Option<InsertHintRenderLoc>,
     /// Pinned windows.
     pinned_windows: Vec<W::Id>,
+    /// Pending pinned windows to be moved to the new workspace after animation.
+    pending_pinned_windows: Vec<(RemovedTile<W>, bool)>,
     /// Whether the overview is open.
     pub(super) overview_open: bool,
     /// Progress of the overview zoom animation, 1 is fully in overview.
@@ -341,6 +344,7 @@ impl<W: LayoutElement> Monitor<W> {
             insert_hint_element: InsertHintElement::new(options.layout.insert_hint),
             insert_hint_render_loc: None,
             pinned_windows: Vec::new(),
+            pending_pinned_windows: Vec::new(),
             overview_open: false,
             overview_progress: None,
             workspace_switch: None,
@@ -989,7 +993,6 @@ impl<W: LayoutElement> Monitor<W> {
         };
 
         self.move_pinned_windows(new_idx);
-
         self.activate_workspace(new_idx);
     }
 
@@ -1005,7 +1008,6 @@ impl<W: LayoutElement> Monitor<W> {
         };
 
         self.move_pinned_windows(new_idx);
-
         self.activate_workspace(new_idx);
     }
 
@@ -1018,7 +1020,6 @@ impl<W: LayoutElement> Monitor<W> {
         let idx = min(idx, self.workspaces.len() - 1);
 
         self.move_pinned_windows(idx);
-
         self.activate_workspace(idx);
     }
 
@@ -1049,6 +1050,7 @@ impl<W: LayoutElement> Monitor<W> {
             Some(WorkspaceSwitch::Animation(anim)) => {
                 if anim.is_done() {
                     self.workspace_switch = None;
+                    self.finish_pinned_windows_move();
                     self.clean_up_workspaces();
                 }
             }
@@ -1365,12 +1367,47 @@ impl<W: LayoutElement> Monitor<W> {
         }
     }
 
+    fn finish_pinned_windows_move(&mut self) {
+        let pending_pinned_windows = core::mem::take(&mut self.pending_pinned_windows);
+
+        for (removed, activate) in pending_pinned_windows {
+            self.add_tile(
+                removed.tile,
+                MonitorAddWindowTarget::Workspace {
+                    id: self.workspaces[self.active_workspace_idx].id(),
+                    column_idx: None,
+                },
+                if activate {
+                    ActivateWindow::Yes
+                } else {
+                    ActivateWindow::No
+                },
+                true,
+                removed.width,
+                removed.is_full_width,
+                removed.is_floating,
+            );
+        }
+    }
+
     fn move_pinned_windows(&mut self, new_idx: usize) {
+        // No change in workspace
+        if self.active_workspace_idx == new_idx {
+            return;
+        }
+        // Ongoing workspace switch
+        if self.workspace_switch.is_some() {
+            return;
+        }
+
         let mut pinned_windows = core::mem::take(&mut self.pinned_windows);
 
         pinned_windows.retain(|id| {
             if self.active_workspace().is_floating(id) {
-                self.move_to_workspace(Some(id), new_idx, ActivateWindow::Smart);
+                let activate = self.active_window().map(|w| w.id()) == Some(id);
+                let removed =
+                    self.workspaces[self.active_workspace_idx].remove_tile(id, Transaction::new());
+                self.pending_pinned_windows.push((removed, activate));
                 true
             } else {
                 false
@@ -1758,6 +1795,48 @@ impl<W: LayoutElement> Monitor<W> {
                 Relocate::Relative,
             )
         };
+
+        if !self.overview_open {
+            for (tile, activate) in self.pending_pinned_windows.iter() {
+                let geo = Rectangle::from_size(self.view_size);
+                macro_rules! push {
+                    () => {{
+                        &mut |elem| {
+                            let elem =
+                                crate::layout::floating::FloatingSpaceRenderElement::from(elem);
+                            let elem = WorkspaceRenderElement::from(elem);
+                            let elem = CropRenderElement::from_element(elem, scale, crop_bounds);
+                            if let Some(elem) = elem {
+                                let elem = MonitorInnerRenderElement::from(elem);
+                                push(scale_relocate(geo, elem));
+                            }
+                        }
+                    }};
+                }
+
+                // For the active tile, draw the focus ring.
+                let focus_ring = focus_ring && *activate;
+
+                fn scale_by_working_area(
+                    area: Rectangle<f64, Logical>,
+                    pos: Point<f64, SizeFrac>,
+                ) -> Point<f64, Logical> {
+                    let mut logical_pos = Point::from((pos.x, pos.y));
+                    logical_pos.x *= area.size.w;
+                    logical_pos.y *= area.size.h;
+                    logical_pos += area.loc;
+                    logical_pos
+                }
+
+                tile.tile.render(
+                    renderer,
+                    scale_by_working_area(self.working_area, tile.tile.floating_pos.unwrap()),
+                    focus_ring,
+                    target,
+                    push!(),
+                );
+            }
+        }
 
         for (ws, geo) in self.workspaces_with_render_geo() {
             // Macro instead of closure because ws and insert hint have different elem types.

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -276,6 +276,10 @@ impl LayoutElement for TestWindow {
     fn is_urgent(&self) -> bool {
         false
     }
+
+    fn is_pinned(&self) -> bool {
+        false
+    }
 }
 
 fn arbitrary_size() -> impl Strategy<Value = Size<i32, Logical>> {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1818,6 +1818,14 @@ impl<W: LayoutElement> Workspace<W> {
         self.windows().any(|win| win.is_urgent())
     }
 
+    pub fn pinned_windows(&self) -> Vec<W::Id> {
+        self.floating
+            .tiles()
+            .filter(|t| t.window().is_pinned())
+            .map(|t| t.window().id().clone())
+            .collect()
+    }
+
     pub fn activate_window(&mut self, window: &W::Id) -> bool {
         if self.floating.activate_window(window) {
             self.floating_is_active = FloatingActive::Yes;

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -73,6 +73,9 @@ pub struct ResolvedWindowRules {
     /// Whether the window should open focused.
     pub open_focused: Option<bool>,
 
+    /// Whether the window should open pinned.
+    pub open_pinned: Option<bool>,
+
     /// Extra bound on the minimum window width.
     pub min_width: Option<u16>,
     /// Extra bound on the minimum window height.
@@ -165,6 +168,13 @@ impl<'a> WindowRef<'a> {
         }
     }
 
+    pub fn is_pinned(self) -> bool {
+        match self {
+            WindowRef::Unmapped(_) => false,
+            WindowRef::Mapped(mapped) => mapped.is_pinned(),
+        }
+    }
+
     pub fn is_window_cast_target(self) -> bool {
         match self {
             WindowRef::Unmapped(_) => false,
@@ -249,6 +259,10 @@ impl ResolvedWindowRules {
 
                 if let Some(x) = rule.open_focused {
                     resolved.open_focused = Some(x);
+                }
+
+                if let Some(x) = rule.open_pinned {
+                    resolved.open_pinned = Some(x);
                 }
 
                 if let Some(x) = rule.min_width {
@@ -423,6 +437,12 @@ fn window_matches(window: WindowRef, role: &XdgToplevelSurfaceRoleAttributes, m:
 
     if let Some(is_floating) = m.is_floating {
         if window.is_floating() != is_floating {
+            return false;
+        }
+    }
+
+    if let Some(is_pinned) = m.is_pinned {
+        if window.is_pinned() != is_pinned {
             return false;
         }
     }


### PR DESCRIPTION
This attempts to implement #932 based on https://github.com/YaLTeR/niri/issues/932#issuecomment-3634047242, by pinning windows to a monitor across its workspaces. More concretely, this means all pinned windows are moved to the new workspace on switching, without introducing a new `PinnedSpace` or duplicating windows across workspaces. 

**EDIT**: Windows are first moved to a temporary space of the monitor, and fully moved to the new workspace only after animation is done (to appear stationary).

Since pinned windows are just normal windows, navigation between windows remains the same as before. The disadvantage is that pinned windows only appear on the focused workspace in overview, ~~and pinned windows are animated alongside the new workspace on workspace switching~~.

~~Currently, as long as the pinned windows are on the active workspace *and* floating, regardless of their status when pinned, they will be moved to the newly switched workspace, otherwise they will be unpinned.~~

**EDIT**: Pinned windows will keep their latent pinned status even if they are not floating on workspace switch, though they won't be carried to the new workspace. As soon as they become floating, they will remain fixed to the monitor on workspace switch.

Windows can be pinned via the `ToggleWindowPinned` action, e.g.

```
binds {
    Mod+P { toggle-window-pinned; }
    ...
}
```

New window rules `open-pinned` to open a window pinned (orthogonal to `open-floating`) and `is-pinned` to match:

```
window-rule {
    ...

    open-pinned true
}

window-rule {
    match is-pinned=true

    ...
}

```

New IPC action to toggle window pinned status: 

```
niri msg action toggle-window-pinned
niri msg action toggle-window-pinned --id <ID>
```

**NOTE**: This is only *a* solution to pinned windows, but IMO much, much simpler than alternative designs. Please check it out and provide feedback on the design/pinning behaviour logic if you are interested.