### PR TITLE
Fix write-after-free in Pipewire stream cleanup

### DIFF
--- a/src/pw_utils.rs
+++ b/src/pw_utils.rs
@@ -72,6 +72,7 @@ pub struct Cast {
     event_loop: LoopHandle<'static, State>,
     pub session_id: usize,
     pub stream_id: usize,
+    // Listener is dropped before Stream to prevent a use-after-free.
     _listener: StreamListener<()>,
     pub stream: StreamRc,
     pub target: CastTarget,


### PR DESCRIPTION
# Description
This fixes a crash observed when stopping a screen cast, confirmed by [ASan output](https://github.com/user-attachments/files/24471855/asan.txt).

Fixes #2864.

The `Cast` struct in [src/pw_utils.rs]() dropped the `stream` field (owning the PipeWire stream) before the `_listener` field (`StreamListener`). The `StreamListener` destructor attempts to unregister itself from the stream. Since fields are dropped in declaration order, the stream was destroyed first, causing `StreamListener::drop` to access freed memory.

# Fix
We reordered the fields in the `Cast` struct so `_listener` is declared before `stream`. This ensures the listener is dropped and unregistered while the stream is still valid.