### PR TITLE
Add workspace focus navigation with wrap-around

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -218,6 +218,8 @@ pub enum Action {
     FocusWorkspaceUp,
     #[knuffel(skip)]
     FocusWorkspaceUpUnderMouse,
+    FocusWorkspaceDownOrFirst,
+    FocusWorkspaceUpOrLast,
     FocusWorkspace(#[knuffel(argument)] WorkspaceReference),
     FocusWorkspacePrevious,
     MoveWindowToWorkspaceDown(#[knuffel(property(name = "focus"), default = true)] bool),
@@ -505,6 +507,8 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::CenterVisibleColumns {} => Self::CenterVisibleColumns,
             niri_ipc::Action::FocusWorkspaceDown {} => Self::FocusWorkspaceDown,
             niri_ipc::Action::FocusWorkspaceUp {} => Self::FocusWorkspaceUp,
+            niri_ipc::Action::FocusWorkspaceDownOrFirst {} => Self::FocusWorkspaceDownOrFirst,
+            niri_ipc::Action::FocusWorkspaceUpOrLast {} => Self::FocusWorkspaceUpOrLast,
             niri_ipc::Action::FocusWorkspace { reference } => {
                 Self::FocusWorkspace(WorkspaceReference::from(reference))
             }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -474,6 +474,10 @@ pub enum Action {
     FocusWorkspaceDown {},
     /// Focus the workspace above.
     FocusWorkspaceUp {},
+    /// Focus the workspace below, looping to the first if at the last.
+    FocusWorkspaceDownOrFirst {},
+    /// Focus the workspace above, looping to the last if at the first.
+    FocusWorkspaceUpOrLast {},
     /// Focus a workspace by reference (index or name).
     FocusWorkspace {
         /// Reference (index or name) of the workspace to focus.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1471,6 +1471,20 @@ impl State {
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
+            Action::FocusWorkspaceDownOrFirst => {
+                self.niri.layout.switch_workspace_down_or_first();
+                self.maybe_warp_cursor_to_focus();
+                self.niri.layer_shell_on_demand_focus = None;
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
+            Action::FocusWorkspaceUpOrLast => {
+                self.niri.layout.switch_workspace_up_or_last();
+                self.maybe_warp_cursor_to_focus();
+                self.niri.layer_shell_on_demand_focus = None;
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
             Action::FocusWorkspaceUpUnderMouse => {
                 if let Some(output) = self.niri.output_under_cursor() {
                     if let Some(mon) = self.niri.layout.monitor_for_output_mut(&output) {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2140,6 +2140,20 @@ impl<W: LayoutElement> Layout<W> {
         monitor.switch_workspace_down();
     }
 
+    pub fn switch_workspace_down_or_first(&mut self) {
+        let Some(monitor) = self.active_monitor() else {
+            return;
+        };
+        monitor.switch_workspace_down_or_first();
+    }
+
+    pub fn switch_workspace_up_or_last(&mut self) {
+        let Some(monitor) = self.active_monitor() else {
+            return;
+        };
+        monitor.switch_workspace_up_or_last();
+    }
+
     pub fn switch_workspace(&mut self, idx: usize) {
         let Some(monitor) = self.active_monitor() else {
             return;

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -1002,6 +1002,24 @@ impl<W: LayoutElement> Monitor<W> {
         self.activate_workspace(new_idx);
     }
 
+    pub fn switch_workspace_down_or_first(&mut self) {
+        let new_idx = if self.active_workspace_idx + 1 >= self.workspaces.len() {
+            0 // wrap to first
+        } else {
+            self.active_workspace_idx + 1
+        };
+        self.activate_workspace(new_idx);
+    }
+
+    pub fn switch_workspace_up_or_last(&mut self) {
+        let new_idx = if self.active_workspace_idx == 0 {
+            self.workspaces.len() - 1 // wrap to last
+        } else {
+            self.active_workspace_idx - 1
+        };
+        self.activate_workspace(new_idx);
+    }
+
     fn previous_workspace_idx(&self) -> Option<usize> {
         let id = self.previous_workspace_id?;
         self.workspaces.iter().position(|w| w.id() == id)

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -513,6 +513,8 @@ enum Op {
     CenterVisibleColumns,
     FocusWorkspaceDown,
     FocusWorkspaceUp,
+    FocusWorkspaceDownOrFirst,
+    FocusWorkspaceUpOrLast,
     FocusWorkspace(#[proptest(strategy = "0..=4usize")] usize),
     FocusWorkspaceAutoBackAndForth(#[proptest(strategy = "0..=4usize")] usize),
     FocusWorkspacePrevious,
@@ -1175,6 +1177,8 @@ impl Op {
             Op::CenterVisibleColumns => layout.center_visible_columns(),
             Op::FocusWorkspaceDown => layout.switch_workspace_down(),
             Op::FocusWorkspaceUp => layout.switch_workspace_up(),
+            Op::FocusWorkspaceDownOrFirst => layout.switch_workspace_down_or_first(),
+            Op::FocusWorkspaceUpOrLast => layout.switch_workspace_up_or_last(),
             Op::FocusWorkspace(idx) => layout.switch_workspace(idx),
             Op::FocusWorkspaceAutoBackAndForth(idx) => {
                 layout.switch_workspace_auto_back_and_forth(idx)


### PR DESCRIPTION
Implements FocusWorkspaceDownOrFirst and FocusWorkspaceUpOrLast actions that allow cycling through workspaces with wrap-around behavior when reaching the boundaries.