### PR TITLE
docs: remove unnecessary clipboard dependencies from Arch installation

### DIFF
--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -12,7 +12,7 @@ systemctl --user add-wants niri.service dms
 Arch Linux (via [paru](https://github.com/morganamilo/paru)):
 ```
 sudo pacman -Syu niri xwayland-satellite xdg-desktop-portal-gnome xdg-desktop-portal-gtk alacritty
-paru -S dms-shell-bin matugen wl-clipboard cliphist cava qt6-multimedia-ffmpeg
+paru -S dms-shell-bin matugen cava qt6-multimedia-ffmpeg
 systemctl --user add-wants niri.service dms
 ```
 


### PR DESCRIPTION
Removes `wl-clipboard` and `cliphist` from the Arch Linux installation instructions.

**Reason:**
`dms` has recently updated to its own zero-dependency clipboard management implementation. Therefore, external clipboard utilities are no longer necessary, and removing them helps keep the installation command minimal.

**More info:**
https://danklinux.com/blog/v1-2-release#native-clipboard-and-history
[https://github.com/AvengeMedia/DankMaterialShell/commit/ec8ab47
](https://github.com/AvengeMedia/DankMaterialShell/commit/ec8ab4746228f53e3885f9319c2a3121d60cc4fe)