### PR TITLE
Add tablet option map-to-active-output

### DIFF
--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -89,6 +89,7 @@ input {
     tablet {
         // off
         map-to-output "eDP-1"
+        // map-to-focused-output
         // left-handed
         // calibration-matrix 1.0 0.0 0.0 0.0 1.0 0.0
     }
@@ -280,6 +281,10 @@ input {
 Valid output names are the same as the ones used for output configuration.
 
 <sup>Since: 0.1.7</sup> When a tablet is not mapped to any output, it will map to the union of all connected outputs, without aspect ratio correction.
+
+Setting specific to `tablet`:
+
+- `map-to-focused-output`: <sup>Since: next release</sup> will map the tablet to the focused output, takes precedence over `map-to-output`.
 
 ### General Settings
 

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -364,6 +364,8 @@ pub struct Tablet {
     #[knuffel(child, unwrap(argument))]
     pub map_to_output: Option<String>,
     #[knuffel(child)]
+    pub map_to_focused_output: bool,
+    #[knuffel(child)]
     pub left_handed: bool,
 }
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -701,6 +701,7 @@ mod tests {
 
                 tablet {
                     map-to-output "eDP-1"
+                    map-to-focused-output
                     calibration-matrix 1.0 2.0 3.0 \
                                        4.0 5.0 6.0
                 }
@@ -1093,6 +1094,7 @@ mod tests {
                     map_to_output: Some(
                         "eDP-1",
                     ),
+                    map_to_focused_output: true,
                     left_handed: false,
                 },
                 touch: Touch {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -3526,8 +3526,12 @@ impl Niri {
 
     pub fn output_for_tablet(&self) -> Option<&Output> {
         let config = self.config.borrow();
-        let map_to_output = config.input.tablet.map_to_output.as_ref();
-        map_to_output.and_then(|name| self.output_by_name_match(name))
+        if config.input.tablet.map_to_focused_output {
+            self.layout.active_output()
+        } else {
+            let map_to_output = config.input.tablet.map_to_output.as_ref();
+            map_to_output.and_then(|name| self.output_by_name_match(name))
+        }
     }
 
     pub fn output_for_touch(&self) -> Option<&Output> {


### PR DESCRIPTION
Makes it more convenient to use a tablet as a mouse replacement.

Still needs a separate way to change the active output, like using touch/mouse to move the cursor over the edge or with a key binding for example running the action `focus-monitor-next`.