### PR TITLE
avoid clobbering XDG_CURRENT_DESKTOP

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,8 +89,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        // Set the current desktop for xdg-desktop-portal.
-        env::set_var("XDG_CURRENT_DESKTOP", "niri");
+        if env::var_os("XDG_CURRENT_DESKTOP").is_none() {
+            // Set the current desktop for xdg-desktop-portal.
+            env::set_var("XDG_CURRENT_DESKTOP", "niri");
+        }
         // Ensure the session type is set to Wayland for xdg-autostart and Qt apps.
         env::set_var("XDG_SESSION_TYPE", "wayland");
     }


### PR DESCRIPTION
Don't set `XDG_CURRENT_DESKTOP` to "niri" if it's already set to whatever.

This (plus wrapping the session script to set `XDG_CURRENT_DESKTOP` to "GNOME", specifically) makes a niri session work properly on my corporate laptop (Ubuntu 22.04 plus every piece of enterprise spyware imaginable plus some custom monstrosities courtesy of the IT security dept).  And I really did try doing it Properly (editing `OnlyShowIn` entries in autostart desktop files, monitoring DBus, etc.) -- nothing worked.  But saying "it's totally a GNOME session sir I swear!" just did, so.