### PR TITLE
allow customizing XDG_CURRENT_DESKTOP

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,19 @@ pub struct Cli {
     /// on a TTY as your non-main compositor instance, to avoid messing up the global environment.
     #[arg(long)]
     pub session: bool,
+    /// Provide a custom value for the `XDG_CURRENT_DESKTOP`
+    /// environment variable (which by default is set to `niri`).
+    ///
+    /// A custom value (such as `GNOME:niri`) may help when dealing
+    /// with third-party software that checks `XDG_CURRENT_DESKTOP`
+    /// for whatever reason and misbehaves when the value is
+    /// unexpected.
+    ///
+    /// This can also be set with the `NIRI_XDG_CURRENT_DESKTOP`
+    /// environment variable.  If both are set, the command line
+    /// argument takes precedence.
+    #[arg(long)]
+    pub xdg_current_desktop: Option<OsString>,
     /// Command to run upon compositor startup.
     #[arg(last = true)]
     pub command: Vec<OsString>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate tracing;
 
+use std::ffi::OsString;
 use std::fmt::Write as _;
 use std::fs::File;
 use std::io::{self, Write};
@@ -90,7 +91,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // Set the current desktop for xdg-desktop-portal.
-        env::set_var("XDG_CURRENT_DESKTOP", "niri");
+        env::set_var("XDG_CURRENT_DESKTOP", xdg_current_desktop(cli.xdg_current_desktop));
+
         // Ensure the session type is set to Wayland for xdg-autostart and Qt apps.
         env::set_var("XDG_SESSION_TYPE", "wayland");
     }
@@ -368,4 +370,9 @@ fn notify_fd() -> anyhow::Result<()> {
     let mut notif = unsafe { File::from_raw_fd(fd) };
     notif.write_all(b"READY=1\n")?;
     Ok(())
+}
+
+fn xdg_current_desktop(cli_value: Option<OsString>) -> OsString {
+    cli_value.or(env::var_os("NIRI_XDG_CURRENT_DESKTOP"))
+        .unwrap_or_else(|| OsString::from("niri"))
 }


### PR DESCRIPTION
Through the CLI (`--xdg-current-desktop`) or environment (`NIRI_XDG_CURRENT_DESKTOP`).
See discussion under #3318 for rationale.