### PR TITLE
backend/winit: DMA-BUF setup for Nvidia support

### DIFF
--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use niri_config::{Config, OutputName};
 use smithay::backend::allocator::dmabuf::Dmabuf;
+use smithay::backend::egl::EGLDevice;
 use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::backend::renderer::{DebugFlags, ImportDma, ImportEgl, Renderer};
@@ -16,6 +17,7 @@ use smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_pre
 use smithay::reexports::winit::dpi::LogicalSize;
 use smithay::reexports::winit::platform::wayland::WindowAttributesExtWayland;
 use smithay::reexports::winit::window::Window;
+use smithay::wayland::dmabuf::{DmabufFeedbackBuilder, DmabufGlobal};
 use smithay::wayland::presentation::Refresh;
 
 use super::{IpcOutputMap, OutputId, RenderResult};
@@ -29,6 +31,7 @@ pub struct Winit {
     output: Output,
     backend: WinitGraphicsBackend<GlesRenderer>,
     damage_tracker: OutputDamageTracker,
+    dmabuf_global: Option<DmabufGlobal>,
     ipc_outputs: Arc<Mutex<IpcOutputMap>>,
 }
 
@@ -137,6 +140,7 @@ impl Winit {
             output,
             backend,
             damage_tracker,
+            dmabuf_global: None,
             ipc_outputs,
         })
     }
@@ -146,6 +150,35 @@ impl Winit {
         if let Err(err) = renderer.bind_wl_display(&niri.display_handle) {
             warn!("error binding renderer wl_display: {err}");
         }
+
+        // Create the dmabuf global.
+        let render_node = EGLDevice::device_for_display(renderer.egl_context().display())
+            .and_then(|device| device.try_get_render_node());
+
+        let default_feedback = match render_node {
+            Ok(Some(node)) => {
+                let primary_formats = renderer.dmabuf_formats();
+                let default_feedback = DmabufFeedbackBuilder::new(node.dev_id(), primary_formats)
+                    .build()
+                    .unwrap();
+                Some(default_feedback)
+            }
+            Ok(None) | Err(_) => None,
+        };
+
+        // Fallback to dmabuf v3 if we failed to build feedback
+        let dmabuf_global = match default_feedback {
+            Some(feedback) => niri
+                .dmabuf_state
+                .create_global_with_default_feedback::<State>(&niri.display_handle, &feedback),
+            None => {
+                warn!("Failed building default dmabuf feedback, falling back to v3");
+                let primary_formats = renderer.dmabuf_formats();
+                niri.dmabuf_state
+                    .create_global::<State>(&niri.display_handle, primary_formats)
+            }
+        };
+        assert!(self.dmabuf_global.replace(dmabuf_global).is_none());
 
         resources::init(renderer);
         shaders::init(renderer);

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -4,6 +4,7 @@ use std::mem;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+use anyhow::Context as _;
 use niri_config::{Config, OutputName};
 use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::egl::EGLDevice;
@@ -151,35 +152,6 @@ impl Winit {
             warn!("error binding renderer wl_display: {err}");
         }
 
-        // Create the dmabuf global.
-        let render_node = EGLDevice::device_for_display(renderer.egl_context().display())
-            .and_then(|device| device.try_get_render_node());
-
-        let default_feedback = match render_node {
-            Ok(Some(node)) => {
-                let primary_formats = renderer.dmabuf_formats();
-                let default_feedback = DmabufFeedbackBuilder::new(node.dev_id(), primary_formats)
-                    .build()
-                    .unwrap();
-                Some(default_feedback)
-            }
-            Ok(None) | Err(_) => None,
-        };
-
-        // Fallback to dmabuf v3 if we failed to build feedback
-        let dmabuf_global = match default_feedback {
-            Some(feedback) => niri
-                .dmabuf_state
-                .create_global_with_default_feedback::<State>(&niri.display_handle, &feedback),
-            None => {
-                warn!("Failed building default dmabuf feedback, falling back to v3");
-                let primary_formats = renderer.dmabuf_formats();
-                niri.dmabuf_state
-                    .create_global::<State>(&niri.display_handle, primary_formats)
-            }
-        };
-        assert!(self.dmabuf_global.replace(dmabuf_global).is_none());
-
         resources::init(renderer);
         shaders::init(renderer);
 
@@ -197,7 +169,42 @@ impl Winit {
 
         niri.update_shaders();
 
+        self.create_dmabuf_global(niri);
+
         niri.add_output(self.output.clone(), None, false);
+    }
+
+    pub fn create_dmabuf_global(&mut self, niri: &mut Niri) {
+        let renderer = self.backend.renderer();
+
+        let default_feedback = || {
+            let display = renderer.egl_context().display();
+            let device =
+                EGLDevice::device_for_display(display).context("error getting EGL device")?;
+            let node = device
+                .try_get_render_node()
+                .context("error getting EGL device render node")?
+                .context("failed to query EGL device render node")?;
+
+            let primary_formats = renderer.dmabuf_formats();
+            DmabufFeedbackBuilder::new(node.dev_id(), primary_formats)
+                .build()
+                .context("error building dmabuf feedback")
+        };
+
+        // Fallback to dmabuf v3 if we failed to build feedback.
+        let dmabuf_global = match default_feedback() {
+            Ok(feedback) => niri
+                .dmabuf_state
+                .create_global_with_default_feedback::<State>(&niri.display_handle, &feedback),
+            Err(err) => {
+                debug!("failed building default dmabuf feedback, falling back to v3: {err:?}");
+                let primary_formats = renderer.dmabuf_formats();
+                niri.dmabuf_state
+                    .create_global::<State>(&niri.display_handle, primary_formats)
+            }
+        };
+        assert!(self.dmabuf_global.replace(dmabuf_global).is_none());
     }
 
     pub fn seat_name(&self) -> String {


### PR DESCRIPTION
Hello! Thank you for your amazing work on Niri, I moved from PaperWM and haven't looked back.

I wanted to hack on Niri a bit (There's a feature that's been bouncing around my head, I wanted to see if it was feasible first) but when I went to run it using the winit backend (for the quick iteration!) I was met with errors when trying to start any application:

```
2026-01-28T04:26:33.451301Z  WARN niri::render_helpers::surface: failed to import surface: Error accessing the buffer (BufferAccessError::NotManaged)
2026-01-28T04:26:33.452208Z  WARN niri::layout::tile: error rendering window opening animation: error rendering to offscreen buffer

Caused by:
    Failed to bind Framebuffer
2026-01-28T04:26:33.452314Z  WARN niri::layout::scrolling: error creating a closing window animation: error rendering contents

Caused by:
    0: error rendering to texture
    1: error binding texture
    2: Failed to bind Framebuffer
```
To be clear, this **only happens** on the winit backend, the tty backend has been working perfectly for me. I did some looking around and this appears to be due to the lack of a global DMA buffer, NVIDIA will just not work with wl_drm alone.

I tried to match the existing structure of the TTY module as much as possible. The rest of the code is basically [copied directly from Smithay/Anvil](https://github.com/Smithay/smithay/blob/f9d4d7ffd82d743fb89737b3ffaed57505b477d1/anvil/src/winit.rs#L148). I'm not super knowledgeable about this stuff so I tried to play follow the leaders here. 

This fixes the issue on my machine. I also tested in a VM where it follows the fallback code path and works there as well.

Thanks for taking a look! 

Original commit message:
--
Creates a dmabuf global in the same manner as the tty backend. This fixes applications failing to launch on Nvidia when using the winit backend.

This code is adapted from Smithay's Anvil compositor. See smithay/anvil/src/winit.rs