### PR TITLE
doc: Add note about border and included configs

### DIFF
--- a/docs/wiki/Configuration:-Layout.md
+++ b/docs/wiki/Configuration:-Layout.md
@@ -268,6 +268,9 @@ The difference is that the focus ring is drawn only around the active window, wh
 >
 > Alternatively, you can override this behavior with the [`draw-border-with-background` window rule](./Configuration:-Window-Rules.md#draw-border-with-background).
 
+> [!NOTE]
+> If you want to enable borders in an included config you have to explicitly set it to `on` (see [border special case](./Configuration:-Include.md#border-special-case)).
+
 Focus ring and border have the following options.
 
 ```kdl
@@ -276,6 +279,9 @@ layout {
     border {
         // Uncomment this line to disable the border.
         // off
+
+        // You have to explicitly enable borders in an included config
+        // on
 
         // Width of the border in logical pixels.
         width 4


### PR DESCRIPTION
If you split up the config first and then want to enable borders it is super easy to miss that you have to turn them on explicitly. Hence, I think there should be a note in the border documentation.