### PR TITLE
Add Ctrl+Space to copy screenshot path to clipboard

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -114,6 +114,7 @@ pub enum Action {
     #[knuffel(skip)]
     ConfirmScreenshot {
         write_to_disk: bool,
+        copy_path: bool,
     },
     #[knuffel(skip)]
     CancelScreenshot,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -747,8 +747,11 @@ impl State {
                     });
                 }
             }
-            Action::ConfirmScreenshot { write_to_disk } => {
-                self.confirm_screenshot(write_to_disk);
+            Action::ConfirmScreenshot {
+                write_to_disk,
+                copy_path,
+            } => {
+                self.confirm_screenshot(write_to_disk, copy_path);
             }
             Action::CancelScreenshot => {
                 if !self.niri.screenshot_ui.is_open() {
@@ -3061,7 +3064,7 @@ impl State {
                 }
             } else if let Some(capture) = self.niri.screenshot_ui.pointer_up(None) {
                 if capture {
-                    self.confirm_screenshot(true);
+                    self.confirm_screenshot(true, false);
                 } else {
                     self.niri.queue_redraw_all();
                 }
@@ -3689,7 +3692,7 @@ impl State {
             TabletToolTipState::Up => {
                 if let Some(capture) = self.niri.screenshot_ui.pointer_up(None) {
                     if capture {
-                        self.confirm_screenshot(true);
+                        self.confirm_screenshot(true, false);
                     } else {
                         self.niri.queue_redraw_all();
                     }
@@ -4219,7 +4222,7 @@ impl State {
 
         if let Some(capture) = self.niri.screenshot_ui.pointer_up(Some(slot)) {
             if capture {
-                self.confirm_screenshot(true);
+                self.confirm_screenshot(true, false);
             } else {
                 self.niri.queue_redraw_all();
             }

--- a/src/ui/screenshot_ui.rs
+++ b/src/ui/screenshot_ui.rs
@@ -38,9 +38,13 @@ const FONT: &str = "sans 14px";
 const BORDER: i32 = 4;
 const TEXT_HIDE_P: &str =
     "Press <span face='mono' bgcolor='#2C2C2C'> Space </span> to save the screenshot.\n\
+     Press <span face='mono' bgcolor='#2C2C2C'> Ctrl+C </span> to copy to clipboard.\n\
+     Press <span face='mono' bgcolor='#2C2C2C'> Ctrl+Space </span> to save and copy path to clipboard.\n\
      Press <span face='mono' bgcolor='#2C2C2C'> P </span> to hide the pointer.";
 const TEXT_SHOW_P: &str =
     "Press <span face='mono' bgcolor='#2C2C2C'> Space </span> to save the screenshot.\n\
+     Press <span face='mono' bgcolor='#2C2C2C'> Ctrl+C </span> to copy to clipboard.\n\
+     Press <span face='mono' bgcolor='#2C2C2C'> Ctrl+Space </span> to save and copy path to clipboard.\n\
      Press <span face='mono' bgcolor='#2C2C2C'> P </span> to show the pointer.";
 
 // Ideally the screenshot UI should support cross-output selections. However, that poses some
@@ -1055,11 +1059,19 @@ fn action(raw: Keysym, mods: ModifiersState) -> Option<Action> {
     if !mods.ctrl && (raw == Keysym::space || raw == Keysym::Return) {
         return Some(Action::ConfirmScreenshot {
             write_to_disk: true,
+            copy_path: false,
         });
     }
     if mods.ctrl && raw == Keysym::c {
         return Some(Action::ConfirmScreenshot {
             write_to_disk: false,
+            copy_path: false,
+        });
+    }
+    if mods.ctrl && raw == Keysym::space {
+        return Some(Action::ConfirmScreenshot {
+            write_to_disk: true,
+            copy_path: true,
         });
     }
 


### PR DESCRIPTION
I'd often want to paste the path to screenshot created rather than the image itself, I've added this under `Ctrl+Space`. Also adds `Ctrl-C` to the help text.