### PR TITLE
Fix dead surface hook

### DIFF
--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -863,12 +863,13 @@ impl XdgShellHandler for State {
 
         self.niri.window_mru_ui.remove_window(id);
         self.niri.layout.remove_window(&window, transaction.clone());
+
         let surface = surface.wl_surface();
         // This check is necessary because implicit resource destruction is done with
-        // undefined order, so the surface might get destroyed before a toplevel.
+        // undefined order, so the surface might get destroyed before toplevel_destroyed() is
+        // called. In this case, adding the default pre-commit hook here would leak it, since the
+        // place that removes it is WlSurface::destroyed(), which had already been called by now.
         if surface.is_alive() {
-            // Re-add the default dmabuf pre commit hook in case the surface
-            // role is re-used.
             self.add_default_dmabuf_pre_commit_hook(surface);
         }
 


### PR DESCRIPTION
So, it looks like niri ends up adding dmabuf hooks for already destroyed surfaces. I haven't looked too much into why it does this, but my guess is that somehow `toplevel_destroyed` gets called *after* the surface is destroyed. The `toplevel_destoryed` handler does try to install the hook, which will insert the surface in the list for tracking, but might
never get removed again keeping a reference to the last buffer/dmabuf.

I will also open a PR in smithay to prevent this, but that will be a breaking change and might take a bit longer.
So I am opening this PR here first to see if it really fixes the issue and maybe get a short term fix.

fixes #1869

(Draft PR in smithay: https://github.com/Smithay/smithay/pull/1921)