### PR TITLE
Preserve num lock state when loading custom keymap

### DIFF
--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1376,9 +1376,19 @@ impl State {
 
         let keymap = std::fs::read_to_string(xkb_file).context("failed to read xkb_file")?;
 
-        let xkb = self.niri.seat.get_keyboard().unwrap();
-        xkb.set_keymap_from_string(self, keymap)
+        let keyboard = self.niri.seat.get_keyboard().unwrap();
+        let num_lock = keyboard.modifier_state().num_lock;
+
+        keyboard
+            .set_keymap_from_string(self, keymap)
             .context("failed to set keymap")?;
+
+        // Restore num lock to its previous value.
+        let mut mods_state = keyboard.modifier_state();
+        if mods_state.num_lock != num_lock {
+            mods_state.num_lock = num_lock;
+            keyboard.set_modifier_state(mods_state);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Normally when you set a custom keymap, the `numlock` setting stops working. This patch fixes that.

Example config:
```
input {
    keyboard {
        xkb {
            // layout "us"
            file "~/.config/xkb/keymap.xkb"
        }
        numlock // Enable numlock on startup
    }
}
```

Fixes https://github.com/niri-wm/niri/issues/3575