### PR TITLE
Add active-window-* as options for floating window relative-to rule

### DIFF
--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -651,7 +651,9 @@ Afterward, the window will remember its last floating position.
 By default, new floating windows open at the center of the screen, and windows from the tiling layout open close to their visual screen position.
 
 The position uses logical coordinates relative to the working area.
-By default, they are relative to the top-left corner of the working area, but you can change this by setting `relative-to` to one of these values: `top-left`, `top-right`, `bottom-left`, `bottom-right`, `top`, `bottom`, `left`, or `right`.
+By default, they are relative to the top-left corner of the working area, but you can change this by setting `relative-to` to one of these values: `top-left`, `top-right`, `bottom-left`, `bottom-right`, `top`, `bottom`, `left`, `right`, `active-window-center`, `active-window-top-left`, `active-window-top-right`, `active-window-bottom-left`, `active-window-bottom-right`, `active-window-top`, `active-window-bottom`, `active-window-left`, or `active-window-right`.
+
+The `active-window-*` values align the matching point of the floating window with that point on the active window.
 
 For example, if you have a bar at the top, then `x=0 y=0` will put the top-left corner of the window directly below the bar.
 If instead you write `x=0 y=0 relative-to="top-right"`, then the top-right corner of the window will align with the top-right corner of the workspace, also directly below the bar.

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -117,4 +117,13 @@ pub enum RelativeTo {
     Bottom,
     Left,
     Right,
+    ActiveWindowCenter,
+    ActiveWindowTopLeft,
+    ActiveWindowTopRight,
+    ActiveWindowBottomLeft,
+    ActiveWindowBottomRight,
+    ActiveWindowTop,
+    ActiveWindowBottom,
+    ActiveWindowLeft,
+    ActiveWindowRight,
 }


### PR DESCRIPTION
This adds `"active-window-*"` options to the `RelativeTo` enum for `default-floating-position`. These position the new floating window relative to the currently active window. My use case to emulating window parenting for applications` that don't support it, but I could imagine other uses as well.

Demo:

https://github.com/user-attachments/assets/7cba3091-c6e9-4534-94eb-2d4c2190e7c6

If there is no active window the new window goes to the center of the screen.

Considered some alternative approaches, because IMO this enum is a little bloated after this change:

* new option in window-rule like `default-floating-position-relative-to-active-window` that would accept the same `relative-to` options
* hook to an external program that would decide coordinates

but just adding these to the enum seems more straightforward and understandable.

