### PR TITLE
feat(spawning): make niri spawning work better with PR_SET_PDEATHSIG

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsString;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
@@ -28,7 +27,7 @@ pub struct Cli {
     pub session: bool,
     /// Command to run upon compositor startup.
     #[arg(last = true)]
-    pub command: Vec<OsString>,
+    pub command: Vec<String>,
 
     #[command(subcommand)]
     pub subcommand: Option<Sub>,


### PR DESCRIPTION
`PR_SET_PDEATHSIG` as commonly used by bubblewrap (`--die-with-parent`) which nixos in turn uses to wrap `steam` and `heroic` appears to keep track not only of the reaper process but also the thread that spawned the command.

This is extremely unfortunate, but this seems reasonably straightforward to make better on `niri` side. I quickly whipped this up and confirmed that niri with this change now can spawn `steam` or `heroic` on my system.

Having just one thread with a channel may also be ever-so-slightly faster compared to creating a full thread on every command invocation, but it has required me to pick a concrete type to represent the commands. If we want to support arbitrary `OsString`s, that's also possible, although it would require reallocation of the command strings for every non-initial command.