### PR TITLE
The Blur Pull Request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,7 +3475,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/Smithay/smithay.git#f1d0d2c43e843233119af3dcf76d619e1afff4ee"
+source = "git+https://github.com/Smithay/smithay.git?rev=dce4d34e7421559b661af9c519904f4b24346148#dce4d34e7421559b661af9c519904f4b24346148"
 dependencies = [
  "aliasable",
  "appendlist",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git#f1d0d2c43e843233119af3dcf76d619e1afff4ee"
+source = "git+https://github.com/Smithay/smithay.git?rev=dce4d34e7421559b661af9c519904f4b24346148#dce4d34e7421559b661af9c519904f4b24346148"
 dependencies = [
  "drm",
  "libdisplay-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,14 @@ tracy-client = { version = "0.18.4", default-features = false }
 [workspace.dependencies.smithay]
 # version = "0.4.1"
 git = "https://github.com/Smithay/smithay.git"
+rev = "dce4d34e7421559b661af9c519904f4b24346148"
 # path = "../smithay"
 default-features = false
 
 [workspace.dependencies.smithay-drm-extras]
 # version = "0.1.0"
 git = "https://github.com/Smithay/smithay.git"
+rev = "dce4d34e7421559b661af9c519904f4b24346148"
 # path = "../smithay/smithay-drm-extras"
 
 [package]

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -85,6 +85,7 @@ nav:
     - Xwayland: Xwayland.md
     - Gestures: Gestures.md
     - Fullscreen and Maximize: Fullscreen-and-Maximize.md
+    - Window Effects: Window-Effects.md
     - Packaging niri: Packaging-niri.md
     - Integrating niri: Integrating-niri.md
     - Accessibility: Accessibility.md

--- a/docs/wiki/Configuration:-Layer-Rules.md
+++ b/docs/wiki/Configuration:-Layer-Rules.md
@@ -14,6 +14,7 @@ Here are all matchers and properties that a layer rule could have:
 layer-rule {
     match namespace="waybar"
     match at-startup=true
+    match layer="top"
 
     // Properties that apply continuously.
     opacity 0.5
@@ -66,6 +67,22 @@ layer-rule {
     match at-startup=true
 
     opacity 0.5
+}
+```
+
+#### `layer`
+
+<sup>Since: next release</sup>
+
+Matches surfaces on this layer-shell layer.
+Can be `"background"`, `"bottom"`, `"top"`, or `"overlay"`.
+
+```kdl
+// Make all overlay-layer surfaces FLOAT.
+layer-rule {
+    match layer="overlay"
+
+    baba-is-float true
 }
 ```
 

--- a/docs/wiki/Configuration:-Layer-Rules.md
+++ b/docs/wiki/Configuration:-Layer-Rules.md
@@ -35,6 +35,13 @@ layer-rule {
     geometry-corner-radius 12
     place-within-backdrop true
     baba-is-float true
+
+    background-effect {
+        xray true
+        blur true
+        noise 0.05
+        saturation 3
+    }
 }
 ```
 
@@ -206,5 +213,31 @@ layer-rule {
     match namespace="^launcher$"
 
     baba-is-float true
+}
+```
+
+#### `background-effect`
+
+<sup>Since: next release</sup>
+
+Override the background effect options for this surface.
+
+- `xray`: set to `true` to enable the xray effect, or `false` to disable it.
+- `blur`: set to `true` to enable blur behind this surface, or `false` to force-disable it.
+- `noise`: amount of pixel noise added to the background (helps with color banding from blur).
+- `saturation`: color saturation of the background (`0` is desaturated, `1` is normal, `2` is 200% saturation).
+
+See the [window effects page](./Window-Effects.md) for an overview of background effects.
+
+```kdl
+// Make top and overlay layers use the regular blur (if enabled),
+// while bottom and background layers keep using the efficient xray blur.
+layer-rule {
+    match layer="top"
+    match layer="overlay"
+
+    background-effect {
+        xray false
+    }
 }
 ```

--- a/docs/wiki/Configuration:-Layer-Rules.md
+++ b/docs/wiki/Configuration:-Layer-Rules.md
@@ -42,6 +42,18 @@ layer-rule {
         noise 0.05
         saturation 3
     }
+
+    popups {
+        opacity 0.5
+        geometry-corner-radius 6
+
+        background-effect {
+            xray true
+            blur true
+            noise 0.05
+            saturation 3
+        }
+    }
 }
 ```
 
@@ -241,3 +253,42 @@ layer-rule {
     }
 }
 ```
+
+#### `popups`
+
+<sup>Since: next release</sup>
+
+Override properties for this layer surface's pop-ups (e.g. a menu opened by clicking an item in Waybar).
+
+The properties work the same way as the corresponding layer-rule properties, except that they apply to the layer surface's pop-ups rather than to the layer surface itself.
+
+`opacity` is applied *on top* of the layer surface's own opacity rule, so setting both will make pop-ups more transparent than the surface.
+Other properties apply independently.
+
+> [!NOTE]
+> This block affects only pop-ups created by the app via Wayland's [xdg-popup](https://wayland.app/protocols/xdg-shell#xdg_popup) (which should be most of them).
+>
+> Some desktop shells will emulate pop-ups by drawing something that looks like a pop-up inside a regular layer surface.
+> As far as niri is concerned, those are just layer surfaces and not pop-ups, so this block won't apply to them.
+>
+> This block also does not affect input-method pop-ups, such as Fcitx.
+
+```kdl
+// Blur the background behind Waybar popup menus.
+layer-rule {
+    match namespace="^waybar$"
+
+    popups {
+        // Match the default GTK 3 popup corner radius.
+        geometry-corner-radius 6
+        opacity 0.85
+
+        background-effect {
+            blur true
+        }
+    }
+}
+```
+
+Keep in mind that the background effect will look right only if the pop-up is shaped like a (rounded) rectangle, and the layer surface correctly sets its Wayland geometry to exclude any shadows.
+Pop-ups with custom shapes will need the app to implement the [ext-background-effect protocol](https://wayland.app/protocols/ext-background-effect-v1) to work properly.

--- a/docs/wiki/Configuration:-Miscellaneous.md
+++ b/docs/wiki/Configuration:-Miscellaneous.md
@@ -54,6 +54,14 @@ hotkey-overlay {
 config-notification {
     disable-failed
 }
+
+blur {
+    // off
+    passes 3
+    offset 3.0
+    noise 0.02
+    saturation 1.5
+}
 ```
 
 ### `spawn-at-startup`
@@ -318,5 +326,83 @@ For example, if you have a custom one.
 ```kdl
 config-notification {
     disable-failed
+}
+```
+
+### `blur`
+
+<sup>Since: next release</sup>
+
+Blur configuration that affects all background blur.
+
+See the [window effects page](./Window-Effects.md) for an overview of background effects.
+
+```kdl
+blur {
+    // off
+    passes 3
+    offset 3
+    noise 0.02
+    saturation 1.5
+}
+```
+
+#### `off`
+
+By default, blur is available on request by a window or layer surface (via the `ext-background-effect` protocol).
+You can also enable it manually with the `blur true` background effect [window](./Configuration:-Window-Rules.md#background-effect) or [layer](./Configuration:-Layer-Rules.md#background-effect) rule.
+
+Setting the `off` flag will disable all blur, both requested by the window, and configured in window rules.
+
+```kdl
+blur {
+    off
+}
+```
+
+#### `passes` and `offset`
+
+`passes` contols the number of downsample/upsample passes for dual kawase blur.
+More passes produce a larger, smoother blur, but cost more GPU resources.
+
+`offset` is the pixel offset multiplier for each pass.
+Offset `1` is the original dual kawase blur.
+Larger values produce a smoother blur, at no additional GPU cost.
+
+However, setting `offset` too big will produce visual artifacts.
+You will need to increase `passes` to be able to use a bigger `offset` without artifacts.
+
+When configuring blur, try increasing `offset` first (since it doesn't cause any extra GPU load) until you start getting artifacts.
+Then, if you still need smoother blur, increase `passes` by 1.
+Keep doing this until you get the desired visuals. 
+
+```kdl
+blur {
+    passes 3
+    offset 3.0
+}
+```
+
+#### `noise`
+
+Amount of noise to add on top of the blur.
+
+This is helpful to reduce color banding artifacts.
+
+```kdl
+blur {
+    noise 0.02
+}
+```
+
+#### `saturation`
+
+Color saturation applied to the blurred background.
+
+Values above `1` increase saturation; values below `1` reduce it.
+
+```kdl
+blur {
+    saturation 1.5
 }
 ```

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -100,6 +100,13 @@ window-rule {
     tiled-state true
     baba-is-float true
 
+    background-effect {
+        xray true
+        blur true
+        noise 0.05
+        saturation 3
+    }
+
     min-width 100
     max-width 200
     min-height 300
@@ -908,6 +915,31 @@ window-rule {
 https://github.com/user-attachments/assets/3f4cb1a4-40b2-4766-98b7-eec014c19509
 
 </video>
+
+#### `background-effect`
+
+<sup>Since: next release</sup>
+
+Override the background effect options for this window.
+
+- `xray`: set to `true` to enable the xray effect, or `false` to disable it.
+- `blur`: set to `true` to enable blur behind this window, or `false` to force-disable it.
+- `noise`: amount of pixel noise added to the background (helps with color banding from blur).
+- `saturation`: color saturation of the background (`0` is desaturated, `1` is normal, `2` is 200% saturation).
+
+See the [window effects page](./Window-Effects.md) for an overview of background effects.
+
+```kdl
+// Make floating windows use the regular blur (if enabled),
+// while tiled windows keep using the efficient xray blur.
+window-rule {
+    match is-floating=true
+
+    background-effect {
+        xray false
+    }
+}
+```
 
 #### Size Overrides
 

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -107,6 +107,18 @@ window-rule {
         saturation 3
     }
 
+    popups {
+        opacity 0.5
+        geometry-corner-radius 15
+
+        background-effect {
+            xray true
+            blur true
+            noise 0.05
+            saturation 3
+        }
+    }
+
     min-width 100
     max-width 200
     min-height 300
@@ -940,6 +952,67 @@ window-rule {
     }
 }
 ```
+
+#### `popups`
+
+<sup>Since: next release</sup>
+
+Override properties for this window's pop-ups (menus and tooltips).
+
+The properties work the same way as the corresponding window-rule properties, except that they apply to the window's pop-ups rather than to the window itself.
+
+`opacity` is applied *on top* of the layer surface's own opacity rule, so setting both will make pop-ups more transparent than the surface.
+Other properties apply independently.
+
+> [!NOTE]
+> This block affects only pop-ups created by the app via Wayland's [xdg-popup](https://wayland.app/protocols/xdg-shell#xdg_popup) (which should be most of them).
+>
+> Examples of things that look like pop-ups that won't work:
+>
+> - Fully emulated by the client, i.e. not a pop-up at all, the client just draws something that looks like a pop-up inside its window.
+> These are common in game engines and in web apps, e.g. the right click menu in Google Docs or in Electron apps like Discord.
+>
+> - Uses a wl-subsurface instead of an xdg-popup.
+> Common in older apps using GTK 3, notably Firefox still uses these for some menus.
+> Subsurfaces are an indivisible part of a surface and they aren't usually pop-ups, so it wouldn't make sense for niri to apply these rules to them.
+>
+> These emulated pop-ups come with other downsides: they cannot reliably extend outside their window, and if the app tries to do that, they will be clipped by rules such as `clip-to-geometry`.
+> So most modern apps will correctly use xdg-popup, which is the intended way to show pop-ups on Wayland.
+>
+> This block also does not affect input-method pop-ups, such as Fcitx.
+>
+> For pop-ups created by your desktop shell or desktop components, use the corresponding [layer rule](./Configuration:-Layer-Rules.md#popups).
+
+```kdl
+// Blur the background behind pop-up menus in Nautilus.
+window-rule {
+    match app-id="Nautilus"
+
+    popups {
+        // Matches the default libadwaita pop-up corner radius.
+        geometry-corner-radius 15
+
+        // Note: it'll look better to set background opacity
+        // through your GTK theme CSS and not here.
+        // This is just an example that makes it look obvious.
+        opacity 0.5
+
+        background-effect {
+            blur true
+        }
+    }
+}
+```
+
+Keep in mind that the background effect will look right only if the pop-up is shaped like a (rounded) rectangle, and the window correctly sets its Wayland geometry to exclude any shadows.
+For example, GTK 4 pop-ups with pointing arrows (`has-arrow=true` property) are *not* rounded rectangles—the arrow sticks out—so if you enable blur, it will also stick out of the pop-up.
+
+| Correct                                             | Wrong                                                                          |
+|-----------------------------------------------------|--------------------------------------------------------------------------------|
+| The pop-up is a rounded rectangle. Blur looks fine. | The pop-up is not a rounded rectangle. Blur extends above, where the arrow is. |
+| ![](./img/popup-no-arrow.png)                       | ![](./img/popup-arrow.png)                                                     |
+
+These pop-ups with custom shapes will need the app to implement the [ext-background-effect protocol](https://wayland.app/protocols/ext-background-effect-v1) to work properly.
 
 #### Size Overrides
 

--- a/docs/wiki/Window-Effects.md
+++ b/docs/wiki/Window-Effects.md
@@ -51,3 +51,14 @@ Xray is automatically enabled by default if any other background effect (like bl
 This is because it's much more efficient: with xray active, niri only needs to blur the background once, and then can reuse this blurred version with no extra work (since the wallpaper changes very rarely).
 
 If you have an animated wallpaper, xray will still have to recompute blur every frame, but that happens once and shared among all windows, rather than recomputed separately for each window.
+
+#### Non-xray effects (experimental)
+
+You can disable xray with `xray false` background effect window rule.
+This gives you the normal kind of blur where everything below a window is blurred.
+Keep in mind that non-xray blur and other non-xray effects are more expensive as niri has to recompute them any time you move the window, or the contents underneath change.
+
+Non-xray effects are currently experimental because they have some known limitations.
+
+- They disappear during window open/close animations and while dragging a tiled window.
+Fixing this requries a refactor to the niri rendering code to defer offscreen rendering, and possibly other refactors.

--- a/docs/wiki/Window-Effects.md
+++ b/docs/wiki/Window-Effects.md
@@ -1,0 +1,53 @@
+### Overview
+
+<sup>Since: next release</sup>
+
+You can apply background effects to windows and layer-shell surfaces.
+These include blur, xray, saturation, and noise.
+They can be enabled in the `background-effect {}` section of [window](./Configuration:-Window-Rules.md#background-effect) or [layer](./Configuration:-Layer-Rules.md#background-effect) rules.
+
+The window needs to be semitransparent for you to see the background effect (otherwise it's fully covered by the opaque window).
+Focus ring and border can also cover the background effect, see [this FAQ entry](./FAQ.md#why-are-transparent-windows-tinted-why-is-the-borderfocus-ring-showing-up-through-semitransparent-windows) for how to change this.
+
+### Blur
+
+Windows and layer surfaces can request their background to be blurred via the [`ext-background-effect` protocol](https://wayland.app/protocols/ext-background-effect-v1).
+In this case, the application will usually offer some "background blur" setting that you'll need to enable in its configuration.
+
+You can also enable blur on the niri side with the `blur true` background effect window rule:
+
+```kdl
+// Enable blur behind the foot terminal.
+window-rule {
+    match app-id="^foot$"
+
+    background-effect {
+        blur true
+    }
+}
+
+// Enable blur behind the fuzzel launcher.
+layer-rule {
+    match namespace="^launcher$"
+
+    background-effect {
+        blur true
+    }
+}
+```
+
+Blur enabled via the window rule will follow the window corner radius set via [`geometry-corner-radius`](./Configuration:-Window-Rules.md#geometry-corner-radius).
+On the other hand, blur enabled through `ext-background-effect` will exactly follow the shape requested by the window.
+If the window or layer has clientside rounded corners or other complex shape, it should set a corresponding blur shape through `ext-background-effect`, then it will get correctly shaped background blur without any manual niri configuration.
+
+Global blur settings are configured in the [`blur {}` config section](./Configuration:-Miscellaneous.md#blur) and apply to all background blur.
+
+### Xray
+
+Xray makes the window background "see through" to your wallpaper, ignoring any other windows below.
+You can enable it with `xray true` background effect [window](./Configuration:-Window-Rules.md#background-effect) or [layer](./Configuration:-Layer-Rules.md#background-effect) rule.
+
+Xray is automatically enabled by default if any other background effect (like blur) is active.
+This is because it's much more efficient: with xray active, niri only needs to blur the background once, and then can reuse this blurred version with no extra work (since the wallpaper changes very rarely).
+
+If you have an animated wallpaper, xray will still have to recompute blur every frame, but that happens once and shared among all windows, rather than recomputed separately for each window.

--- a/docs/wiki/Window-Effects.md
+++ b/docs/wiki/Window-Effects.md
@@ -40,6 +40,10 @@ Blur enabled via the window rule will follow the window corner radius set via [`
 On the other hand, blur enabled through `ext-background-effect` will exactly follow the shape requested by the window.
 If the window or layer has clientside rounded corners or other complex shape, it should set a corresponding blur shape through `ext-background-effect`, then it will get correctly shaped background blur without any manual niri configuration.
 
+Windows can also blur their pop-up menus using `ext-background-effect`.
+On the niri side, you can do it with a `popups` block inside [`window-rule`](./Configuration:-Window-Rules.md#popups) and [`layer-rule`](./Configuration:-Layer-Rules.md#popups).
+See those wiki pages for examples and limitations.
+
 Global blur settings are configured in the [`blur {}` config section](./Configuration:-Miscellaneous.md#blur) and apply to all background blur.
 
 ### Xray

--- a/docs/wiki/Window-Effects.md
+++ b/docs/wiki/Window-Effects.md
@@ -62,3 +62,19 @@ Non-xray effects are currently experimental because they have some known limitat
 
 - They disappear during window open/close animations and while dragging a tiled window.
 Fixing this requries a refactor to the niri rendering code to defer offscreen rendering, and possibly other refactors.
+
+### Implementation notes
+
+The `ext-background-effect` protocol supports any wl_surface.
+We currently implement it only for toplevels, layer surfaces, and pop-ups, which should cover the vast majority of what's actually used by applications.
+
+For pop-ups, effects default to *non-xray* because pop-ups generally appear on top of windows.
+
+In particular, the following surface types don't support `ext-background-effect`.
+They can be implemented as the need arises.
+
+- Subsurfaces. Would require implementing `clip-to-geometry` support for background effects.
+- Lock surfaces. Not useful as it would just show our red locked session background.
+- Cursor and drag-and-drop icon.
+The main challenge here will be screencasts where the cursor is rendered separately.
+This is problematic because non-xray effects require rendering the whole scene in one go rather than separately.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -14,6 +14,7 @@
 * [Xwayland](./Xwayland.md)
 * [Gestures](./Gestures.md)
 * [Fullscreen and Maximize](./Fullscreen-and-Maximize.md)
+* [Window Effects](./Window-Effects.md)
 * [Packaging niri](./Packaging-niri.md)
 * [Integrating niri](./Integrating-niri.md)
 * [Accessibility](./Accessibility.md)

--- a/docs/wiki/img/popup-arrow.png
+++ b/docs/wiki/img/popup-arrow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5a63ea3cc2f158e175c00dd058988a2bbf676e2a2aac5c2ef1603bd983589d5
+size 166777

--- a/docs/wiki/img/popup-no-arrow.png
+++ b/docs/wiki/img/popup-no-arrow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bef0c57d617916bf6014fe08e268c8201d7f6ef682e3aea3395e76116b1d0400
+size 56936

--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -1079,7 +1079,8 @@ pub struct BackgroundEffect {
 
     /// Whether to blur the background.
     ///
-    /// - `None`: no blur
+    /// - `None`: blur when the window/layer requests it (e.g. through ext-background-effect
+    ///   protocol)
     /// - `Some(false)`: never blur
     /// - `Some(true)`: always blur
     pub blur: Option<bool>,

--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -1010,6 +1010,10 @@ where
 pub struct BackgroundEffectRule {
     #[knuffel(child, unwrap(argument))]
     pub xray: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub noise: Option<FloatOrInt<0, 1000>>,
+    #[knuffel(child, unwrap(argument))]
+    pub saturation: Option<FloatOrInt<0, 1000>>,
 }
 
 /// Resolved background effect rule.
@@ -1021,11 +1025,22 @@ pub struct BackgroundEffect {
     /// - `Some(false)`: no xray
     /// - `Some(true)`: xray even if no other background effect is active
     pub xray: Option<bool>,
+
+    pub noise: Option<f64>,
+    pub saturation: Option<f64>,
 }
 
 impl MergeWith<BackgroundEffectRule> for BackgroundEffect {
     fn merge_with(&mut self, part: &BackgroundEffectRule) {
         merge_clone_opt!((self, part), xray);
+
+        if let Some(x) = part.noise {
+            self.noise = Some(x.0);
+        }
+
+        if let Some(x) = part.saturation {
+            self.saturation = Some(x.0);
+        }
     }
 }
 

--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -1006,10 +1006,61 @@ where
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Blur {
+    pub off: bool,
+    pub passes: u8,
+    pub offset: f64,
+    pub noise: f64,
+    pub saturation: f64,
+}
+
+impl Default for Blur {
+    fn default() -> Self {
+        Self {
+            off: false,
+            passes: 3,
+            offset: 3.,
+            noise: 0.02,
+            saturation: 1.5,
+        }
+    }
+}
+
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
+pub struct BlurPart {
+    #[knuffel(child)]
+    pub off: bool,
+    #[knuffel(child)]
+    pub on: bool,
+    #[knuffel(child, unwrap(argument))]
+    pub passes: Option<u8>,
+    #[knuffel(child, unwrap(argument))]
+    pub offset: Option<FloatOrInt<0, 100>>,
+    #[knuffel(child, unwrap(argument))]
+    pub noise: Option<FloatOrInt<0, 1000>>,
+    #[knuffel(child, unwrap(argument))]
+    pub saturation: Option<FloatOrInt<0, 1000>>,
+}
+
+impl MergeWith<BlurPart> for Blur {
+    fn merge_with(&mut self, part: &BlurPart) {
+        self.off |= part.off;
+        if part.on {
+            self.off = false;
+        }
+
+        merge_clone!((self, part), passes);
+        merge!((self, part), offset, noise, saturation);
+    }
+}
+
 #[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
 pub struct BackgroundEffectRule {
     #[knuffel(child, unwrap(argument))]
     pub xray: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub blur: Option<bool>,
     #[knuffel(child, unwrap(argument))]
     pub noise: Option<FloatOrInt<0, 1000>>,
     #[knuffel(child, unwrap(argument))]
@@ -1026,13 +1077,20 @@ pub struct BackgroundEffect {
     /// - `Some(true)`: xray even if no other background effect is active
     pub xray: Option<bool>,
 
+    /// Whether to blur the background.
+    ///
+    /// - `None`: no blur
+    /// - `Some(false)`: never blur
+    /// - `Some(true)`: always blur
+    pub blur: Option<bool>,
+
     pub noise: Option<f64>,
     pub saturation: Option<f64>,
 }
 
 impl MergeWith<BackgroundEffectRule> for BackgroundEffect {
     fn merge_with(&mut self, part: &BackgroundEffectRule) {
-        merge_clone_opt!((self, part), xray);
+        merge_clone_opt!((self, part), xray, blur);
 
         if let Some(x) = part.noise {
             self.noise = Some(x.0);

--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -1006,6 +1006,29 @@ where
     }
 }
 
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
+pub struct BackgroundEffectRule {
+    #[knuffel(child, unwrap(argument))]
+    pub xray: Option<bool>,
+}
+
+/// Resolved background effect rule.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct BackgroundEffect {
+    /// Whether to render with xray effect (see through).
+    ///
+    /// - `None`: xray if any background effect is active
+    /// - `Some(false)`: no xray
+    /// - `Some(true)`: xray even if no other background effect is active
+    pub xray: Option<bool>,
+}
+
+impl MergeWith<BackgroundEffectRule> for BackgroundEffect {
+    fn merge_with(&mut self, part: &BackgroundEffectRule) {
+        merge_clone_opt!((self, part), xray);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use insta::{assert_debug_snapshot, assert_snapshot};

--- a/niri-config/src/layer_rule.rs
+++ b/niri-config/src/layer_rule.rs
@@ -1,4 +1,4 @@
-use crate::appearance::{BlockOutFrom, CornerRadius, ShadowRule};
+use crate::appearance::{BackgroundEffectRule, BlockOutFrom, CornerRadius, ShadowRule};
 use crate::utils::RegexEq;
 
 #[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
@@ -20,6 +20,8 @@ pub struct LayerRule {
     pub place_within_backdrop: Option<bool>,
     #[knuffel(child, unwrap(argument))]
     pub baba_is_float: Option<bool>,
+    #[knuffel(child, default)]
+    pub background_effect: BackgroundEffectRule,
 }
 
 #[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]

--- a/niri-config/src/layer_rule.rs
+++ b/niri-config/src/layer_rule.rs
@@ -28,4 +28,6 @@ pub struct Match {
     pub namespace: Option<RegexEq>,
     #[knuffel(property)]
     pub at_startup: Option<bool>,
+    #[knuffel(property, str)]
+    pub layer: Option<niri_ipc::Layer>,
 }

--- a/niri-config/src/layer_rule.rs
+++ b/niri-config/src/layer_rule.rs
@@ -1,5 +1,6 @@
 use crate::appearance::{BackgroundEffectRule, BlockOutFrom, CornerRadius, ShadowRule};
 use crate::utils::RegexEq;
+use crate::window_rule::PopupsRule;
 
 #[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
 pub struct LayerRule {
@@ -22,6 +23,8 @@ pub struct LayerRule {
     pub baba_is_float: Option<bool>,
     #[knuffel(child, default)]
     pub background_effect: BackgroundEffectRule,
+    #[knuffel(child, default)]
+    pub popups: PopupsRule,
 }
 
 #[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1859,6 +1859,7 @@ mod tests {
                                 ),
                             ),
                             at_startup: None,
+                            layer: None,
                         },
                     ],
                     excludes: [],

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1864,6 +1864,13 @@ mod tests {
                     },
                     popups: PopupsRule {
                         opacity: None,
+                        geometry_corner_radius: None,
+                        background_effect: BackgroundEffectRule {
+                            xray: None,
+                            blur: None,
+                            noise: None,
+                            saturation: None,
+                        },
                     },
                 },
             ],
@@ -1908,6 +1915,13 @@ mod tests {
                     },
                     popups: PopupsRule {
                         opacity: None,
+                        geometry_corner_radius: None,
+                        background_effect: BackgroundEffectRule {
+                            xray: None,
+                            blur: None,
+                            noise: None,
+                            saturation: None,
+                        },
                     },
                 },
             ],

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -78,6 +78,7 @@ pub struct Config {
     pub hotkey_overlay: HotkeyOverlay,
     pub config_notification: ConfigNotification,
     pub animations: Animations,
+    pub blur: Blur,
     pub gestures: Gestures,
     pub overview: Overview,
     pub environment: Environment,
@@ -194,6 +195,7 @@ where
                 "hotkey-overlay" => m_merge!(hotkey_overlay),
                 "config-notification" => m_merge!(config_notification),
                 "animations" => m_merge!(animations),
+                "blur" => m_merge!(blur),
                 "gestures" => m_merge!(gestures),
                 "overview" => m_merge!(overview),
                 "xwayland-satellite" => m_merge!(xwayland_satellite),
@@ -1616,6 +1618,13 @@ mod tests {
                     },
                 ),
             },
+            blur: Blur {
+                off: false,
+                passes: 3,
+                offset: 3.0,
+                noise: 0.02,
+                saturation: 1.5,
+            },
             gestures: Gestures {
                 dnd_edge_view_scroll: DndEdgeViewScroll {
                     trigger_width: 10.0,
@@ -1847,6 +1856,7 @@ mod tests {
                     tiled_state: None,
                     background_effect: BackgroundEffectRule {
                         xray: None,
+                        blur: None,
                         noise: None,
                         saturation: None,
                     },
@@ -1887,6 +1897,7 @@ mod tests {
                     baba_is_float: None,
                     background_effect: BackgroundEffectRule {
                         xray: None,
+                        blur: None,
                         noise: None,
                         saturation: None,
                     },

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -59,7 +59,9 @@ use crate::recent_windows::RecentWindowsPart;
 pub use crate::recent_windows::{MruDirection, MruFilter, MruPreviews, MruScope, RecentWindows};
 pub use crate::utils::FloatOrInt;
 use crate::utils::{Flag, MergeWith as _};
-pub use crate::window_rule::{FloatingPosition, RelativeTo, WindowRule};
+pub use crate::window_rule::{
+    FloatingPosition, PopupsRule, RelativeTo, ResolvedPopupsRules, WindowRule,
+};
 pub use crate::workspace::{Workspace, WorkspaceLayoutPart};
 
 const RECURSION_LIMIT: u8 = 10;
@@ -1860,6 +1862,9 @@ mod tests {
                         noise: None,
                         saturation: None,
                     },
+                    popups: PopupsRule {
+                        opacity: None,
+                    },
                 },
             ],
             layer_rules: [
@@ -1900,6 +1905,9 @@ mod tests {
                         blur: None,
                         noise: None,
                         saturation: None,
+                    },
+                    popups: PopupsRule {
+                        opacity: None,
                     },
                 },
             ],

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1847,6 +1847,8 @@ mod tests {
                     tiled_state: None,
                     background_effect: BackgroundEffectRule {
                         xray: None,
+                        noise: None,
+                        saturation: None,
                     },
                 },
             ],
@@ -1885,6 +1887,8 @@ mod tests {
                     baba_is_float: None,
                     background_effect: BackgroundEffectRule {
                         xray: None,
+                        noise: None,
+                        saturation: None,
                     },
                 },
             ],

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1845,6 +1845,9 @@ mod tests {
                     ),
                     scroll_factor: None,
                     tiled_state: None,
+                    background_effect: BackgroundEffectRule {
+                        xray: None,
+                    },
                 },
             ],
             layer_rules: [
@@ -1880,6 +1883,9 @@ mod tests {
                     geometry_corner_radius: None,
                     place_within_backdrop: None,
                     baba_is_float: None,
+                    background_effect: BackgroundEffectRule {
+                        xray: None,
+                    },
                 },
             ],
             binds: Binds(

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -1,6 +1,8 @@
 use niri_ipc::ColumnDisplay;
 
-use crate::appearance::{BlockOutFrom, BorderRule, CornerRadius, ShadowRule, TabIndicatorRule};
+use crate::appearance::{
+    BackgroundEffectRule, BlockOutFrom, BorderRule, CornerRadius, ShadowRule, TabIndicatorRule,
+};
 use crate::layout::DefaultPresetSize;
 use crate::utils::RegexEq;
 use crate::FloatOrInt;
@@ -72,6 +74,8 @@ pub struct WindowRule {
     pub scroll_factor: Option<FloatOrInt<0, 100>>,
     #[knuffel(child, unwrap(argument))]
     pub tiled_state: Option<bool>,
+    #[knuffel(child, default)]
+    pub background_effect: BackgroundEffectRule,
 }
 
 #[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -1,7 +1,8 @@
 use niri_ipc::ColumnDisplay;
 
 use crate::appearance::{
-    BackgroundEffectRule, BlockOutFrom, BorderRule, CornerRadius, ShadowRule, TabIndicatorRule,
+    BackgroundEffect, BackgroundEffectRule, BlockOutFrom, BorderRule, CornerRadius, ShadowRule,
+    TabIndicatorRule,
 };
 use crate::layout::DefaultPresetSize;
 use crate::utils::{MergeWith, RegexEq};
@@ -85,6 +86,10 @@ pub struct WindowRule {
 pub struct PopupsRule {
     #[knuffel(child, unwrap(argument))]
     pub opacity: Option<f32>,
+    #[knuffel(child)]
+    pub geometry_corner_radius: Option<CornerRadius>,
+    #[knuffel(child, default)]
+    pub background_effect: BackgroundEffectRule,
 }
 
 /// Resolved popup-specific rules.
@@ -92,6 +97,12 @@ pub struct PopupsRule {
 pub struct ResolvedPopupsRules {
     /// Extra opacity to draw popups with.
     pub opacity: Option<f32>,
+
+    /// Corner radius to assume the popups have.
+    pub geometry_corner_radius: Option<CornerRadius>,
+
+    /// Background effect configuration for popups.
+    pub background_effect: BackgroundEffect,
 }
 
 impl MergeWith<PopupsRule> for ResolvedPopupsRules {
@@ -99,6 +110,10 @@ impl MergeWith<PopupsRule> for ResolvedPopupsRules {
         if let Some(x) = part.opacity {
             self.opacity = Some(x);
         }
+        if let Some(x) = part.geometry_corner_radius {
+            self.geometry_corner_radius = Some(x);
+        }
+        self.background_effect.merge_with(&part.background_effect);
     }
 }
 

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -4,7 +4,7 @@ use crate::appearance::{
     BackgroundEffectRule, BlockOutFrom, BorderRule, CornerRadius, ShadowRule, TabIndicatorRule,
 };
 use crate::layout::DefaultPresetSize;
-use crate::utils::RegexEq;
+use crate::utils::{MergeWith, RegexEq};
 use crate::FloatOrInt;
 
 #[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
@@ -76,6 +76,30 @@ pub struct WindowRule {
     pub tiled_state: Option<bool>,
     #[knuffel(child, default)]
     pub background_effect: BackgroundEffectRule,
+    #[knuffel(child, default)]
+    pub popups: PopupsRule,
+}
+
+/// Rules for popup surfaces.
+#[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
+pub struct PopupsRule {
+    #[knuffel(child, unwrap(argument))]
+    pub opacity: Option<f32>,
+}
+
+/// Resolved popup-specific rules.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct ResolvedPopupsRules {
+    /// Extra opacity to draw popups with.
+    pub opacity: Option<f32>,
+}
+
+impl MergeWith<PopupsRule> for ResolvedPopupsRules {
+    fn merge_with(&mut self, part: &PopupsRule) {
+        if let Some(x) = part.opacity {
+            self.opacity = Some(x);
+        }
+    }
 }
 
 #[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1868,6 +1868,20 @@ impl FromStr for Transform {
     }
 }
 
+impl FromStr for Layer {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "background" => Ok(Self::Background),
+            "bottom" => Ok(Self::Bottom),
+            "top" => Ok(Self::Top),
+            "overlay" => Ok(Self::Overlay),
+            _ => Err("invalid layer, can be \"background\", \"bottom\", \"top\" or \"overlay\""),
+        }
+    }
+}
+
 impl FromStr for ModeToSet {
     type Err = &'static str;
 

--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use niri::animation::Clock;
 use niri::layout::{ActivateWindow, AddWindowTarget, LayoutElement as _, Options, SizingMode};
-use niri::render_helpers::RenderTarget;
+use niri::render_helpers::{RenderCtx, RenderTarget};
 use niri_config::{Color, OutputName, PresetSize};
 use smithay::backend::renderer::element::RenderElement;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -270,12 +270,14 @@ impl TestCase for Layout {
         self.layout.update_render_elements(Some(&self.output));
 
         let mut rv = Vec::new();
+        let ctx = RenderCtx {
+            renderer,
+            target: RenderTarget::Output,
+        };
         self.layout
             .monitor_for_output(&self.output)
             .unwrap()
-            .render_workspaces(renderer, RenderTarget::Output, true, &mut |elem| {
-                rv.push(Box::new(elem) as _)
-            });
+            .render_workspaces(ctx, true, &mut |elem| rv.push(Box::new(elem) as _));
         rv
     }
 }

--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -273,6 +273,7 @@ impl TestCase for Layout {
         let ctx = RenderCtx {
             renderer,
             target: RenderTarget::Output,
+            xray: None,
         };
         self.layout
             .monitor_for_output(&self.output)

--- a/niri-visual-tests/src/cases/tile.rs
+++ b/niri-visual-tests/src/cases/tile.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use niri::layout::Options;
-use niri::render_helpers::RenderTarget;
+use niri::render_helpers::{RenderCtx, RenderTarget};
 use niri_config::Color;
 use smithay::backend::renderer::element::RenderElement;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -121,13 +121,13 @@ impl TestCase for Tile {
         );
 
         let mut rv = Vec::new();
-        self.tile.render(
+        let ctx = RenderCtx {
             renderer,
-            location,
-            true,
-            RenderTarget::Output,
-            &mut |elem| rv.push(Box::new(elem) as _),
-        );
+            target: RenderTarget::Output,
+        };
+        self.tile.render(ctx, location, true, &mut |elem| {
+            rv.push(Box::new(elem) as _)
+        });
         rv
     }
 }

--- a/niri-visual-tests/src/cases/tile.rs
+++ b/niri-visual-tests/src/cases/tile.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use niri::layout::Options;
+use niri::render_helpers::xray::XrayPos;
 use niri::render_helpers::{RenderCtx, RenderTarget};
 use niri_config::Color;
 use smithay::backend::renderer::element::RenderElement;
@@ -124,10 +125,13 @@ impl TestCase for Tile {
         let ctx = RenderCtx {
             renderer,
             target: RenderTarget::Output,
+            xray: None,
         };
-        self.tile.render(ctx, location, true, &mut |elem| {
-            rv.push(Box::new(elem) as _)
-        });
+        let xray_pos = XrayPos::new(location, 1.);
+        self.tile
+            .render(ctx, location, xray_pos, true, &mut |elem| {
+                rv.push(Box::new(elem) as _)
+            });
         rv
     }
 }

--- a/niri-visual-tests/src/cases/window.rs
+++ b/niri-visual-tests/src/cases/window.rs
@@ -56,6 +56,7 @@ impl TestCase for Window {
         let ctx = RenderCtx {
             renderer,
             target: RenderTarget::Output,
+            xray: None,
         };
         self.window
             .render_normal(ctx, location, Scale::from(1.), 1., &mut |elem| {

--- a/niri-visual-tests/src/cases/window.rs
+++ b/niri-visual-tests/src/cases/window.rs
@@ -1,5 +1,5 @@
 use niri::layout::{LayoutElement, SizingMode};
-use niri::render_helpers::RenderTarget;
+use niri::render_helpers::{RenderCtx, RenderTarget};
 use smithay::backend::renderer::element::RenderElement;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Physical, Point, Scale, Size};
@@ -53,14 +53,14 @@ impl TestCase for Window {
             .downscale(2.);
 
         let mut rv = Vec::new();
-        self.window.render_normal(
+        let ctx = RenderCtx {
             renderer,
-            location,
-            Scale::from(1.),
-            1.,
-            RenderTarget::Output,
-            &mut |elem| rv.push(Box::new(elem) as _),
-        );
+            target: RenderTarget::Output,
+        };
+        self.window
+            .render_normal(ctx, location, Scale::from(1.), 1., &mut |elem| {
+                rv.push(Box::new(elem) as _)
+            });
         rv
     }
 }

--- a/niri-visual-tests/src/smithay_view.rs
+++ b/niri-visual-tests/src/smithay_view.rs
@@ -20,6 +20,7 @@ mod imp {
     use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
     use smithay::backend::renderer::{Bind, Color32F, Frame, Offscreen, Renderer};
     use smithay::reexports::gbm::Format as Fourcc;
+    use smithay::utils::user_data::UserDataMap;
     use smithay::utils::{Physical, Rectangle, Scale, Transform};
 
     use super::*;
@@ -206,8 +207,15 @@ mod imp {
 
                 if let Some(mut damage) = rect.intersection(dst) {
                     damage.loc -= dst.loc;
+
+                    let cache = UserDataMap::new();
+                    if element.is_framebuffer_effect() {
+                        element
+                            .capture_framebuffer(&mut frame, src, dst, &cache)
+                            .context("error in capture_framebuffer()")?;
+                    }
                     element
-                        .draw(&mut frame, src, dst, &[damage], &[])
+                        .draw(&mut frame, src, dst, &[damage], &[], Some(&cache))
                         .context("error drawing element")?;
                 }
             }

--- a/niri-visual-tests/src/test_window.rs
+++ b/niri-visual-tests/src/test_window.rs
@@ -9,7 +9,7 @@ use niri::layout::{
 use niri::render_helpers::offscreen::OffscreenData;
 use niri::render_helpers::renderer::NiriRenderer;
 use niri::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
-use niri::render_helpers::RenderTarget;
+use niri::render_helpers::RenderCtx;
 use niri::utils::transaction::Transaction;
 use niri::window::ResolvedWindowRules;
 use smithay::backend::renderer::element::Kind;
@@ -151,11 +151,10 @@ impl LayoutElement for TestWindow {
 
     fn render_normal<R: NiriRenderer>(
         &self,
-        _renderer: &mut R,
+        _ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
         _scale: Scale<f64>,
         alpha: f32,
-        _target: RenderTarget,
         push: &mut dyn FnMut(LayoutElementRenderElement<R>),
     ) {
         let inner = self.inner.borrow();

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -1868,6 +1868,7 @@ impl Tty {
         let ctx = RenderCtx {
             renderer: &mut renderer,
             target: RenderTarget::Output,
+            xray: None,
         };
         let mut elements = niri.render_to_vec(ctx, output, true);
 

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -1869,7 +1869,7 @@ impl Tty {
             renderer: &mut renderer,
             target: RenderTarget::Output,
         };
-        let mut elements = niri.render(ctx, output, true);
+        let mut elements = niri.render_to_vec(ctx, output, true);
 
         // Visualize the damage, if enabled.
         if niri.debug_draw_damage {

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -67,7 +67,7 @@ use crate::frame_clock::FrameClock;
 use crate::niri::{Niri, RedrawState, State};
 use crate::render_helpers::debug::draw_damage;
 use crate::render_helpers::renderer::AsGlesRenderer;
-use crate::render_helpers::{resources, shaders, RenderTarget};
+use crate::render_helpers::{resources, shaders, RenderCtx, RenderTarget};
 use crate::utils::{get_monotonic_time, is_laptop_panel, logical_output, PanelOrientation};
 
 const SUPPORTED_COLOR_FORMATS: [Fourcc; 4] = [
@@ -1865,8 +1865,11 @@ impl Tty {
         };
 
         // Render the elements.
-        let mut elements =
-            niri.render::<TtyRenderer>(&mut renderer, output, true, RenderTarget::Output);
+        let ctx = RenderCtx {
+            renderer: &mut renderer,
+            target: RenderTarget::Output,
+        };
+        let mut elements = niri.render(ctx, output, true);
 
         // Visualize the damage, if enabled.
         if niri.debug_draw_damage {

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -185,6 +185,7 @@ impl Winit {
         let ctx = RenderCtx {
             renderer: self.backend.renderer(),
             target: RenderTarget::Output,
+            xray: None,
         };
         let mut elements = niri.render_to_vec(ctx, output, true);
 

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -186,7 +186,7 @@ impl Winit {
             renderer: self.backend.renderer(),
             target: RenderTarget::Output,
         };
-        let mut elements = niri.render(ctx, output, true);
+        let mut elements = niri.render_to_vec(ctx, output, true);
 
         // Visualize the damage, if enabled.
         if niri.debug_draw_damage {

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -21,7 +21,7 @@ use smithay::wayland::presentation::Refresh;
 use super::{IpcOutputMap, OutputId, RenderResult};
 use crate::niri::{Niri, RedrawState, State};
 use crate::render_helpers::debug::draw_damage;
-use crate::render_helpers::{resources, shaders, RenderTarget};
+use crate::render_helpers::{resources, shaders, RenderCtx, RenderTarget};
 use crate::utils::{get_monotonic_time, logical_output};
 
 pub struct Winit {
@@ -182,12 +182,11 @@ impl Winit {
         let _span = tracy_client::span!("Winit::render");
 
         // Render the elements.
-        let mut elements = niri.render::<GlesRenderer>(
-            self.backend.renderer(),
-            output,
-            true,
-            RenderTarget::Output,
-        );
+        let ctx = RenderCtx {
+            renderer: self.backend.renderer(),
+            target: RenderTarget::Output,
+        };
+        let mut elements = niri.render(ctx, output, true);
 
         // Visualize the damage, if enabled.
         if niri.debug_draw_damage {

--- a/src/handlers/background_effect.rs
+++ b/src/handlers/background_effect.rs
@@ -1,0 +1,123 @@
+use std::sync::{Arc, Mutex};
+
+use smithay::delegate_background_effect;
+use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+use smithay::utils::{Logical, Rectangle};
+use smithay::wayland::background_effect::{
+    self, BackgroundEffectSurfaceCachedState, ExtBackgroundEffectHandler,
+};
+use smithay::wayland::compositor::{
+    add_post_commit_hook, with_states, RegionAttributes, SurfaceData,
+};
+
+use crate::niri::State;
+use crate::utils::region::region_to_non_overlapping_rects;
+
+/// Per-surface cache for processed blur region (non-overlapping rects).
+#[derive(Default)]
+struct CachedBlurRegionUserData(Mutex<CachedBlurRegionInner>);
+
+#[derive(Default)]
+struct CachedBlurRegionInner {
+    /// Whether a region change is pending to be committed.
+    pending_dirty: bool,
+    /// Whether the region must be recomputed.
+    dirty: bool,
+    /// Whether the post-commit hook has been registered for this surface.
+    hook_registered: bool,
+    /// Cached non-overlapping rects in surface-local coordinates.
+    ///
+    /// `None` means there's no blur region.
+    rects: Option<Arc<Vec<Rectangle<i32, Logical>>>>,
+}
+
+/// Gets the cached blur region for a surface, lazily recomputing if dirty.
+pub fn get_cached_blur_region(states: &SurfaceData) -> Option<Arc<Vec<Rectangle<i32, Logical>>>> {
+    let cache = states
+        .data_map
+        .get_or_insert_threadsafe(CachedBlurRegionUserData::default);
+    let mut guard = cache.0.lock().unwrap();
+
+    if guard.dirty {
+        guard.dirty = false;
+        recompute_blur_region(states, &mut guard);
+    }
+
+    guard.rects.clone()
+}
+
+fn recompute_blur_region(states: &SurfaceData, inner: &mut CachedBlurRegionInner) {
+    let cached = &states.cached_state;
+
+    let rects = if let Some(arc) = &mut inner.rects {
+        if Arc::strong_count(arc) > 1 {
+            debug!("cloning rects due to non-unique reference");
+        }
+        arc
+    } else {
+        inner.rects.insert(Arc::new(Vec::new()))
+    };
+    let rects = Arc::make_mut(rects);
+
+    if cached.has::<BackgroundEffectSurfaceCachedState>() {
+        let mut guard = cached.get::<BackgroundEffectSurfaceCachedState>();
+        if let Some(region) = &guard.current().blur_region {
+            region_to_non_overlapping_rects(region, rects);
+        } else {
+            inner.rects = None;
+        }
+        return;
+    }
+
+    inner.rects = None;
+}
+
+fn mark_blur_region_pending_dirty(wl_surface: &WlSurface) {
+    let register_hook = with_states(wl_surface, |states| {
+        let cache = states
+            .data_map
+            .get_or_insert_threadsafe(CachedBlurRegionUserData::default);
+        let mut guard = cache.0.lock().unwrap();
+        guard.pending_dirty = true;
+
+        if guard.hook_registered {
+            false
+        } else {
+            guard.hook_registered = true;
+            true
+        }
+    });
+
+    if register_hook {
+        add_post_commit_hook::<State, _>(wl_surface, |_state, _dh, surface| {
+            with_states(surface, |states| {
+                if let Some(cache) = states.data_map.get::<CachedBlurRegionUserData>() {
+                    let mut guard = cache.0.lock().unwrap();
+                    if guard.pending_dirty {
+                        guard.pending_dirty = false;
+                        guard.dirty = true;
+
+                        crate::render_helpers::background_effect::damage_surface(states);
+                    }
+                } else {
+                    error!("unexpected missing CachedBlurRegionUserData");
+                }
+            });
+        });
+    }
+}
+
+impl ExtBackgroundEffectHandler for State {
+    fn capabilities(&self) -> background_effect::Capability {
+        background_effect::Capability::Blur
+    }
+
+    fn set_blur_region(&mut self, wl_surface: WlSurface, _region: RegionAttributes) {
+        mark_blur_region_pending_dirty(&wl_surface);
+    }
+
+    fn unset_blur_region(&mut self, wl_surface: WlSurface) {
+        mark_blur_region_pending_dirty(&wl_surface);
+    }
+}
+delegate_background_effect!(State);

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -486,11 +486,10 @@ impl CompositorHandler for State {
         // subsurface is destroyed; in the case of alacritty, this is the top CSD shadow. But, it
         // gets most of the job done.
         if let Some(root) = self.niri.root_surface.get(surface) {
-            if let Some((mapped, _)) = self.niri.layout.find_window_and_output(root) {
+            if let Some((mapped, output)) = self.niri.layout.find_window_and_output(root) {
                 let window = mapped.window.clone();
-                self.backend.with_primary_renderer(|renderer| {
-                    self.niri.layout.store_unmap_snapshot(renderer, &window);
-                });
+                let output = output.cloned();
+                self.store_unmap_snapshot(&window, output.as_ref());
             }
         }
 

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -195,7 +195,10 @@ impl CompositorHandler for State {
                     // The mapped pre-commit hook deals with dma-bufs on its own.
                     self.remove_default_dmabuf_pre_commit_hook(surface);
                     let hook = add_mapped_toplevel_pre_commit_hook(toplevel);
-                    let mapped = Mapped::new(window, rules, hook);
+                    let mapped = {
+                        let config = self.niri.config.borrow();
+                        Mapped::new(window, rules, hook, &config)
+                    };
                     let window = mapped.window.clone();
 
                     let target = if let Some(p) = &parent {

--- a/src/handlers/layer_shell.rs
+++ b/src/handlers/layer_shell.rs
@@ -3,10 +3,10 @@ use smithay::desktop::{layer_map_for_output, LayerSurface, PopupKind, WindowSurf
 use smithay::output::Output;
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
-use smithay::wayland::compositor::{get_parent, with_states};
+use smithay::wayland::compositor::{add_pre_commit_hook, get_parent, with_states, HookId};
 use smithay::wayland::shell::wlr_layer::{
-    self, Layer, LayerSurface as WlrLayerSurface, LayerSurfaceData, WlrLayerShellHandler,
-    WlrLayerShellState,
+    self, Layer, LayerSurface as WlrLayerSurface, LayerSurfaceCachedState, LayerSurfaceData,
+    WlrLayerShellHandler, WlrLayerShellState,
 };
 use smithay::wayland::shell::xdg::PopupSurface;
 
@@ -126,8 +126,10 @@ impl State {
                 let output_size = output_size(&output);
                 let scale = output.current_scale().fractional_scale();
 
+                let hook = add_mapped_layer_pre_commit_hook(layer);
                 let mapped = MappedLayer::new(
                     layer.clone(),
+                    hook,
                     rules,
                     output_size,
                     scale,
@@ -141,6 +143,21 @@ impl State {
                     .insert(layer.clone(), mapped);
                 if prev.is_some() {
                     error!("MappedLayer was present for an unmapped surface");
+                }
+            } else {
+                // The surface remains mapped.
+                if let Some(mapped) = self.niri.mapped_layer_surfaces.get_mut(layer) {
+                    // Check if the layer changed.
+                    if mapped.take_recompute_rules_on_commit() {
+                        let config = self.niri.config.borrow();
+                        if mapped
+                            .recompute_layer_rules(&config.layer_rules, self.niri.is_at_startup)
+                        {
+                            mapped.update_config(&config);
+                        }
+                    }
+                } else {
+                    error!("MappedLayer missing for a mapped surface");
                 }
             }
 
@@ -203,4 +220,24 @@ impl State {
 
         true
     }
+}
+
+fn add_mapped_layer_pre_commit_hook(layer: &LayerSurface) -> HookId {
+    add_pre_commit_hook::<State, _>(layer.wl_surface(), move |state, _dh, surface| {
+        let layer_changed = with_states(surface, |states| {
+            let mut guard = states.cached_state.get::<LayerSurfaceCachedState>();
+            let pending_layer = guard.pending().layer;
+            let current_layer = guard.current().layer;
+            pending_layer != current_layer
+        });
+
+        if layer_changed {
+            for mapped in state.niri.mapped_layer_surfaces.values_mut() {
+                if mapped.surface().wl_surface() == surface {
+                    mapped.set_recompute_rules_on_commit();
+                    break;
+                }
+            }
+        }
+    })
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod background_effect;
 mod compositor;
 mod layer_shell;
 mod xdg_shell;

--- a/src/input/pick_color_grab.rs
+++ b/src/input/pick_color_grab.rs
@@ -13,7 +13,7 @@ use smithay::input::SeatHandler;
 use smithay::utils::{Logical, Physical, Point, Scale, Size, Transform};
 
 use crate::niri::State;
-use crate::render_helpers::{render_and_download, RenderTarget};
+use crate::render_helpers::{render_and_download, RenderCtx, RenderTarget};
 
 pub struct PickColorGrab {
     start_data: PointerGrabStartData<State>,
@@ -49,13 +49,12 @@ impl PickColorGrab {
                 let pos = pos_within_output.to_physical_precise_floor(scale);
                 let size = Size::<i32, Physical>::from((1, 1));
 
-                let elements = data.niri.render(
+                let ctx = RenderCtx {
                     renderer,
-                    &output,
-                    false,
                     // This is an interactive operation so we can render without blocking out.
-                    RenderTarget::Output,
-                );
+                    target: RenderTarget::Output,
+                };
+                let elements = data.niri.render(ctx, &output, false);
 
                 let mapping = match render_and_download(
                     renderer,

--- a/src/input/pick_color_grab.rs
+++ b/src/input/pick_color_grab.rs
@@ -53,6 +53,7 @@ impl PickColorGrab {
                     renderer,
                     // This is an interactive operation so we can render without blocking out.
                     target: RenderTarget::Output,
+                    xray: None,
                 };
                 let elements = data.niri.render_to_vec(ctx, &output, false);
 

--- a/src/input/pick_color_grab.rs
+++ b/src/input/pick_color_grab.rs
@@ -54,7 +54,7 @@ impl PickColorGrab {
                     // This is an interactive operation so we can render without blocking out.
                     target: RenderTarget::Output,
                 };
-                let elements = data.niri.render(ctx, &output, false);
+                let elements = data.niri.render_to_vec(ctx, &output, false);
 
                 let mapping = match render_and_download(
                     renderer,

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -42,6 +42,9 @@ pub struct MappedLayer {
     /// The shadow around the surface.
     shadow: Shadow,
 
+    /// The blur config, passed for background effect rendering.
+    blur_config: niri_config::Blur,
+
     /// The view size for the layer surface's output.
     view_size: Size<f64, Logical>,
 
@@ -85,6 +88,7 @@ impl MappedLayer {
             view_size,
             scale,
             shadow: Shadow::new(shadow_config),
+            blur_config: config.blur,
             clock,
         }
     }
@@ -95,6 +99,8 @@ impl MappedLayer {
         shadow_config.on = false;
         shadow_config.merge_with(&self.rules.shadow);
         self.shadow.update_config(shadow_config);
+
+        self.blur_config = config.blur;
     }
 
     pub fn update_shaders(&mut self) {
@@ -234,6 +240,7 @@ impl MappedLayer {
             self.scale,
             false,
             surface,
+            self.blur_config,
             radius,
             self.rules.background_effect,
             xray_pos,

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -224,26 +224,22 @@ impl MappedLayer {
         location: Point<f64, Logical>,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
-        let scale = Scale::from(self.scale);
-        let alpha = self.rules.opacity.unwrap_or(1.).clamp(0., 1.);
-        let location = location + self.bob_offset();
-
         if ctx.target.should_block_out(self.rules.block_out_from) {
             return;
         }
 
-        // Layer surfaces don't have extra geometry like windows.
-        let buf_pos = location;
+        let scale = Scale::from(self.scale);
+        let alpha = self.rules.opacity.unwrap_or(1.).clamp(0., 1.);
+        let location = location + self.bob_offset();
 
         let surface = self.surface.wl_surface();
-        for (popup, popup_offset) in PopupManager::popups_for_surface(surface) {
-            // Layer surfaces don't have extra geometry like windows.
-            let offset = popup_offset - popup.geometry().loc;
+        for (popup, offset) in PopupManager::popups_for_surface(surface) {
+            let surface_loc = location + (offset - popup.geometry().loc).to_f64();
 
             push_elements_from_surface_tree(
                 ctx.renderer,
                 popup.wl_surface(),
-                (buf_pos + offset.to_f64()).to_physical_precise_round(scale),
+                surface_loc.to_physical_precise_round(scale),
                 scale,
                 alpha,
                 Kind::ScanoutCandidate,

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -4,6 +4,7 @@ use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::Kind;
 use smithay::desktop::{LayerSurface, PopupManager};
 use smithay::utils::{Logical, Point, Scale, Size};
+use smithay::wayland::compositor::{remove_pre_commit_hook, HookId};
 use smithay::wayland::shell::wlr_layer::{ExclusiveZone, Layer};
 
 use super::ResolvedLayerRules;
@@ -22,8 +23,16 @@ pub struct MappedLayer {
     /// The surface itself.
     surface: LayerSurface,
 
+    /// Pre-commit hook that we have on all mapped layer surfaces.
+    pre_commit_hook: HookId,
+
     /// Up-to-date rules.
     rules: ResolvedLayerRules,
+
+    /// Whether to recompute layer rules on the next commit.
+    ///
+    /// Set in the pre-commit hook when the layer changes; consumed in the commit handler.
+    recompute_rules_on_commit: bool,
 
     /// Buffer to draw instead of the surface when it should be blocked out.
     block_out_buffer: SolidColorBuffer,
@@ -52,6 +61,7 @@ niri_render_elements! {
 impl MappedLayer {
     pub fn new(
         surface: LayerSurface,
+        pre_commit_hook: HookId,
         rules: ResolvedLayerRules,
         view_size: Size<f64, Logical>,
         scale: f64,
@@ -65,7 +75,9 @@ impl MappedLayer {
 
         Self {
             surface,
+            pre_commit_hook,
             rules,
+            recompute_rules_on_commit: false,
             block_out_buffer: SolidColorBuffer::new((0., 0.), [0., 0., 0., 1.]),
             view_size,
             scale,
@@ -126,6 +138,14 @@ impl MappedLayer {
 
         self.rules = new_rules;
         true
+    }
+
+    pub fn set_recompute_rules_on_commit(&mut self) {
+        self.recompute_rules_on_commit = true;
+    }
+
+    pub fn take_recompute_rules_on_commit(&mut self) -> bool {
+        std::mem::take(&mut self.recompute_rules_on_commit)
     }
 
     pub fn place_within_backdrop(&self) -> bool {
@@ -230,5 +250,11 @@ impl MappedLayer {
                 &mut |elem| push(elem.into()),
             );
         }
+    }
+}
+
+impl Drop for MappedLayer {
+    fn drop(&mut self) {
+        remove_pre_commit_hook(self.surface.wl_surface(), self.pre_commit_hook.clone());
     }
 }

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -257,7 +257,8 @@ impl MappedLayer {
 
     pub fn render_popups<R: NiriRenderer>(
         &self,
-        ctx: RenderCtx<R>,
+        mut ctx: RenderCtx<R>,
+        ns: Option<usize>,
         location: Point<f64, Logical>,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
@@ -267,19 +268,48 @@ impl MappedLayer {
 
         let scale = Scale::from(self.scale);
         let alpha = self.rules.opacity.unwrap_or(1.).clamp(0., 1.);
-        let location = location + self.bob_offset();
+
+        let bob_offset = self.bob_offset();
+        let location = location + bob_offset;
+        let xray_pos = xray_pos.offset(bob_offset);
 
         let surface = self.surface.wl_surface();
         for (popup, offset) in PopupManager::popups_for_surface(surface) {
-            let surface_loc = location + (offset - popup.geometry().loc).to_f64();
+            let surface = popup.wl_surface();
+            let popup_geo = popup.geometry();
+            let surface_loc = location + (offset - popup_geo.loc).to_f64();
 
             push_elements_from_surface_tree(
                 ctx.renderer,
-                popup.wl_surface(),
+                surface,
                 surface_loc.to_physical_precise_round(scale),
                 scale,
                 alpha,
                 Kind::ScanoutCandidate,
+                &mut |elem| push(elem.into()),
+            );
+
+            let geometry = Rectangle::new(location + offset.to_f64(), popup_geo.size.to_f64());
+            let surface_off = popup_geo.loc.upscale(-1).to_f64();
+            let surface_anim_scale = Scale::from(1.);
+            let effect = niri_config::BackgroundEffect {
+                xray: Some(false),
+                ..Default::default()
+            };
+            background_effect::render_for_tile(
+                ctx.as_gles(),
+                ns,
+                geometry,
+                self.scale,
+                false,
+                surface,
+                surface_off,
+                surface_anim_scale,
+                self.blur_config,
+                niri_config::CornerRadius::default(),
+                effect,
+                false,
+                XrayPos::default(),
                 &mut |elem| push(elem.into()),
             );
         }

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -2,7 +2,7 @@ use niri_config::utils::MergeWith as _;
 use niri_config::{Config, LayerRule};
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::Kind;
-use smithay::desktop::{LayerSurface, PopupManager};
+use smithay::desktop::{LayerSurface, PopupKind, PopupManager};
 use smithay::utils::{Logical, Point, Rectangle, Scale, Size};
 use smithay::wayland::compositor::{remove_pre_commit_hook, HookId};
 use smithay::wayland::shell::wlr_layer::{ExclusiveZone, Layer};
@@ -275,6 +275,13 @@ impl MappedLayer {
 
         let surface = self.surface.wl_surface();
         for (popup, offset) in PopupManager::popups_for_surface(surface) {
+            let popup_rules = match popup {
+                PopupKind::Xdg(_) => self.rules.popups,
+                // IME popups aren't affected by rules for regular popups.
+                PopupKind::InputMethod(_) => niri_config::ResolvedPopupsRules::default(),
+            };
+            let alpha = alpha * popup_rules.opacity.unwrap_or(1.).clamp(0., 1.);
+
             let surface = popup.wl_surface();
             let popup_geo = popup.geometry();
             let surface_loc = location + (offset - popup_geo.loc).to_f64();

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -3,7 +3,7 @@ use niri_config::{Config, LayerRule};
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::Kind;
 use smithay::desktop::{LayerSurface, PopupManager};
-use smithay::utils::{Logical, Point, Scale, Size};
+use smithay::utils::{Logical, Point, Rectangle, Scale, Size};
 use smithay::wayland::compositor::{remove_pre_commit_hook, HookId};
 use smithay::wayland::shell::wlr_layer::{ExclusiveZone, Layer};
 
@@ -11,11 +11,13 @@ use super::ResolvedLayerRules;
 use crate::animation::Clock;
 use crate::layout::shadow::Shadow;
 use crate::niri_render_elements;
+use crate::render_helpers::background_effect::BackgroundEffectElement;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shadow::ShadowRenderElement;
 use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
 use crate::render_helpers::surface::push_elements_from_surface_tree;
-use crate::render_helpers::RenderCtx;
+use crate::render_helpers::xray::XrayPos;
+use crate::render_helpers::{background_effect, RenderCtx};
 use crate::utils::{baba_is_float_offset, round_logical_in_physical};
 
 #[derive(Debug)]
@@ -55,6 +57,7 @@ niri_render_elements! {
         Wayland = WaylandSurfaceRenderElement<R>,
         SolidColor = SolidColorRenderElement,
         Shadow = ShadowRenderElement,
+        BackgroundEffect = BackgroundEffectElement,
     }
 }
 
@@ -177,15 +180,22 @@ impl MappedLayer {
 
     pub fn render_normal<R: NiriRenderer>(
         &self,
-        ctx: RenderCtx<R>,
+        mut ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
+        xray_pos: XrayPos,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
         let scale = Scale::from(self.scale);
         let alpha = self.rules.opacity.unwrap_or(1.).clamp(0., 1.);
-        let location = location + self.bob_offset();
 
-        if ctx.target.should_block_out(self.rules.block_out_from) {
+        let bob_offset = self.bob_offset();
+        let location = location + bob_offset;
+        let xray_pos = xray_pos.offset(bob_offset);
+
+        let surface = self.surface.wl_surface();
+
+        let should_block_out = ctx.target.should_block_out(self.rules.block_out_from);
+        if should_block_out {
             // Round to physical pixels.
             let location = location.to_physical_precise_round(scale).to_logical(scale);
 
@@ -201,7 +211,6 @@ impl MappedLayer {
             // Layer surfaces don't have extra geometry like windows.
             let buf_pos = location;
 
-            let surface = self.surface.wl_surface();
             push_elements_from_surface_tree(
                 ctx.renderer,
                 surface,
@@ -216,6 +225,20 @@ impl MappedLayer {
         let location = location.to_physical_precise_round(scale).to_logical(scale);
         self.shadow
             .render(ctx.renderer, location, &mut |elem| push(elem.into()));
+
+        let geometry = Rectangle::new(location, self.block_out_buffer.size());
+        let radius = self.rules.geometry_corner_radius.unwrap_or_default();
+        background_effect::render_for_tile(
+            ctx.as_gles(),
+            geometry,
+            self.scale,
+            false,
+            surface,
+            radius,
+            self.rules.background_effect,
+            xray_pos,
+            &mut |elem| push(elem.into()),
+        );
     }
 
     pub fn render_popups<R: NiriRenderer>(

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -260,6 +260,7 @@ impl MappedLayer {
         mut ctx: RenderCtx<R>,
         ns: Option<usize>,
         location: Point<f64, Logical>,
+        xray_pos: XrayPos,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
         if ctx.target.should_block_out(self.rules.block_out_from) {
@@ -299,10 +300,12 @@ impl MappedLayer {
             let geometry = Rectangle::new(location + offset.to_f64(), popup_geo.size.to_f64());
             let surface_off = popup_geo.loc.upscale(-1).to_f64();
             let surface_anim_scale = Scale::from(1.);
-            let effect = niri_config::BackgroundEffect {
-                xray: Some(false),
-                ..Default::default()
-            };
+            let mut effect = popup_rules.background_effect;
+            // Default xray to false for pop-ups since they're always on top of something.
+            if effect.xray.is_none() {
+                effect.xray = Some(false);
+            }
+            let xray_pos = xray_pos.offset(offset.to_f64());
             background_effect::render_for_tile(
                 ctx.as_gles(),
                 ns,
@@ -313,10 +316,10 @@ impl MappedLayer {
                 surface_off,
                 surface_anim_scale,
                 self.blur_config,
-                niri_config::CornerRadius::default(),
+                popup_rules.geometry_corner_radius.unwrap_or_default(),
                 effect,
                 false,
-                XrayPos::default(),
+                xray_pos,
                 &mut |elem| push(elem.into()),
             );
         }

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -233,6 +233,8 @@ impl MappedLayer {
             .render(ctx.renderer, location, &mut |elem| push(elem.into()));
 
         let geometry = Rectangle::new(location, self.block_out_buffer.size());
+        let surface_off = Point::new(0., 0.); // No geometry on layer surfaces.
+        let surface_anim_scale = Scale::from(1.);
         let radius = self.rules.geometry_corner_radius.unwrap_or_default();
         background_effect::render_for_tile(
             ctx.as_gles(),
@@ -240,9 +242,12 @@ impl MappedLayer {
             self.scale,
             false,
             surface,
+            surface_off,
+            surface_anim_scale,
             self.blur_config,
             radius,
             self.rules.background_effect,
+            should_block_out,
             xray_pos,
             &mut |elem| push(elem.into()),
         );

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -187,6 +187,7 @@ impl MappedLayer {
     pub fn render_normal<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
+        ns: Option<usize>,
         location: Point<f64, Logical>,
         xray_pos: XrayPos,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
@@ -238,6 +239,7 @@ impl MappedLayer {
         let radius = self.rules.geometry_corner_radius.unwrap_or_default();
         background_effect::render_for_tile(
             ctx.as_gles(),
+            ns,
             geometry,
             self.scale,
             false,

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -2,6 +2,7 @@ use niri_config::layer_rule::{LayerRule, Match};
 use niri_config::utils::MergeWith as _;
 use niri_config::{BlockOutFrom, CornerRadius, ShadowRule};
 use smithay::desktop::LayerSurface;
+use smithay::wayland::shell::wlr_layer::Layer;
 
 pub mod mapped;
 pub use mapped::MappedLayer;
@@ -79,6 +80,18 @@ impl ResolvedLayerRules {
 fn surface_matches(surface: &LayerSurface, m: &Match) -> bool {
     if let Some(namespace_re) = &m.namespace {
         if !namespace_re.0.is_match(surface.namespace()) {
+            return false;
+        }
+    }
+
+    if let Some(layer) = m.layer {
+        let surface_layer = match surface.layer() {
+            Layer::Background => niri_ipc::Layer::Background,
+            Layer::Bottom => niri_ipc::Layer::Bottom,
+            Layer::Top => niri_ipc::Layer::Top,
+            Layer::Overlay => niri_ipc::Layer::Overlay,
+        };
+        if layer != surface_layer {
             return false;
         }
     }

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -1,6 +1,6 @@
 use niri_config::layer_rule::{LayerRule, Match};
 use niri_config::utils::MergeWith as _;
-use niri_config::{BlockOutFrom, CornerRadius, ShadowRule};
+use niri_config::{BackgroundEffect, BlockOutFrom, CornerRadius, ShadowRule};
 use smithay::desktop::LayerSurface;
 use smithay::wayland::shell::wlr_layer::Layer;
 
@@ -27,6 +27,9 @@ pub struct ResolvedLayerRules {
 
     /// Whether to bob this window up and down.
     pub baba_is_float: bool,
+
+    /// Background effect configuration.
+    pub background_effect: BackgroundEffect,
 }
 
 impl ResolvedLayerRules {
@@ -71,6 +74,10 @@ impl ResolvedLayerRules {
             }
 
             resolved.shadow.merge_with(&rule.shadow);
+
+            resolved
+                .background_effect
+                .merge_with(&rule.background_effect);
         }
 
         resolved

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -1,6 +1,6 @@
 use niri_config::layer_rule::{LayerRule, Match};
 use niri_config::utils::MergeWith as _;
-use niri_config::{BackgroundEffect, BlockOutFrom, CornerRadius, ShadowRule};
+use niri_config::{BackgroundEffect, BlockOutFrom, CornerRadius, ResolvedPopupsRules, ShadowRule};
 use smithay::desktop::LayerSurface;
 use smithay::wayland::shell::wlr_layer::Layer;
 
@@ -30,6 +30,9 @@ pub struct ResolvedLayerRules {
 
     /// Background effect configuration.
     pub background_effect: BackgroundEffect,
+
+    /// Rules for this layer surface's popups.
+    pub popups: ResolvedPopupsRules,
 }
 
 impl ResolvedLayerRules {
@@ -78,6 +81,8 @@ impl ResolvedLayerRules {
             resolved
                 .background_effect
                 .merge_with(&rule.background_effect);
+
+            resolved.popups.merge_with(&rule.popups);
         }
 
         resolved

--- a/src/layout/closing_window.rs
+++ b/src/layout/closing_window.rs
@@ -21,7 +21,7 @@ use crate::render_helpers::shader_element::ShaderRenderElement;
 use crate::render_helpers::shaders::{mat3_uniform, ProgramType, Shaders};
 use crate::render_helpers::snapshot::RenderSnapshot;
 use crate::render_helpers::texture::{TextureBuffer, TextureRenderElement};
-use crate::render_helpers::{render_to_encompassing_texture, RenderTarget};
+use crate::render_helpers::{render_to_encompassing_texture, RenderCtx};
 use crate::utils::transaction::TransactionBlocker;
 
 #[derive(Debug)]
@@ -159,12 +159,11 @@ impl ClosingWindow {
 
     pub fn render(
         &self,
-        renderer: &mut GlesRenderer,
+        ctx: RenderCtx<GlesRenderer>,
         view_rect: Rectangle<f64, Logical>,
         scale: Scale<f64>,
-        target: RenderTarget,
     ) -> ClosingWindowRenderElement {
-        let (buffer, offset) = if target.should_block_out(self.block_out_from) {
+        let (buffer, offset) = if ctx.target.should_block_out(self.block_out_from) {
             (&self.blocked_out_buffer, self.blocked_out_buffer_offset)
         } else {
             (&self.buffer, self.buffer_offset)
@@ -200,7 +199,10 @@ impl ClosingWindow {
         let progress = anim.value();
         let clamped_progress = anim.clamped_value().clamp(0., 1.);
 
-        if Shaders::get(renderer).program(ProgramType::Close).is_some() {
+        if Shaders::get(ctx.renderer)
+            .program(ProgramType::Close)
+            .is_some()
+        {
             let area_loc = Vec2::new(view_rect.loc.x as f32, view_rect.loc.y as f32);
             let area_size = Vec2::new(view_rect.size.w as f32, view_rect.size.h as f32);
 

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -18,6 +18,7 @@ use super::{
 use crate::animation::{Animation, Clock};
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
+use crate::render_helpers::xray::XrayPos;
 use crate::render_helpers::RenderCtx;
 use crate::utils::transaction::TransactionBlocker;
 use crate::utils::{
@@ -1056,6 +1057,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
     pub fn render<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
+        xray_pos: XrayPos,
         view_rect: Rectangle<f64, Logical>,
         focus_ring: bool,
         push: &mut dyn FnMut(FloatingSpaceRenderElement<R>),
@@ -1075,7 +1077,10 @@ impl<W: LayoutElement> FloatingSpace<W> {
             // For the active tile, draw the focus ring.
             let focus_ring = focus_ring && Some(tile.window().id()) == active.as_ref();
 
-            tile.render(ctx.r(), tile_pos, focus_ring, &mut |elem| push(elem.into()));
+            let xray_pos = xray_pos.offset(tile_pos);
+            tile.render(ctx.r(), tile_pos, xray_pos, focus_ring, &mut |elem| {
+                push(elem.into())
+            });
         }
     }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2729,8 +2729,18 @@ impl<W: LayoutElement> Layout<W> {
         if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
             if output.is_none_or(|output| move_.output == *output) {
                 let pos_within_output = move_.tile_render_location(zoom);
+
+                // We're not on any specific workspace so we can't compute a "workspace view" rect.
+                // Let's instead compute a rect relative to the output.
+                //
+                // FIXME: we could make the colors match up better in the overview by figuring out
+                // where a centered workspace would currently be, and computing the view rect
+                // against that. Since most of the time the dragged window will be on a centered
+                // workspace.
                 let view_rect =
-                    Rectangle::new(pos_within_output.upscale(-1.), output_size(&move_.output));
+                    Rectangle::new(pos_within_output.upscale(-1.), output_size(&move_.output))
+                        .downscale(zoom);
+
                 move_.tile.update_render_elements(true, view_rect);
             }
         }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -166,9 +166,10 @@ pub trait LayoutElement {
         location: Point<f64, Logical>,
         scale: Scale<f64>,
         alpha: f32,
+        xray_pos: XrayPos,
         push: &mut dyn FnMut(LayoutElementRenderElement<R>),
     ) {
-        self.render_popups(ctx.r(), location, scale, alpha, push);
+        self.render_popups(ctx.r(), location, scale, alpha, xray_pos, push);
         self.render_normal(ctx.r(), location, scale, alpha, push);
     }
 
@@ -191,9 +192,10 @@ pub trait LayoutElement {
         location: Point<f64, Logical>,
         scale: Scale<f64>,
         alpha: f32,
+        xray_pos: XrayPos,
         push: &mut dyn FnMut(LayoutElementRenderElement<R>),
     ) {
-        let _ = (ctx, location, scale, alpha, push);
+        let _ = (ctx, location, scale, alpha, xray_pos, push);
     }
 
     /// Renders the background effect behind the main surface of the element.

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -114,6 +114,7 @@ niri_render_elements! {
     LayoutElementRenderElement<R> => {
         Wayland = WaylandSurfaceRenderElement<R>,
         SolidColor = SolidColorRenderElement,
+        BackgroundEffect = BackgroundEffectElement,
     }
 }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -59,11 +59,13 @@ use crate::animation::{Animation, Clock};
 use crate::input::swipe_tracker::SwipeTracker;
 use crate::layout::scrolling::ScrollDirection;
 use crate::niri_render_elements;
+use crate::render_helpers::background_effect::BackgroundEffectElement;
 use crate::render_helpers::offscreen::OffscreenData;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::snapshot::RenderSnapshot;
 use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
 use crate::render_helpers::texture::TextureBuffer;
+use crate::render_helpers::xray::{Xray, XrayPos};
 use crate::render_helpers::{BakedBuffer, RenderCtx};
 use crate::rubber_band::RubberBand;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
@@ -186,6 +188,20 @@ pub trait LayoutElement {
         push: &mut dyn FnMut(LayoutElementRenderElement<R>),
     ) {
         let _ = (ctx, location, scale, alpha, push);
+    }
+
+    /// Renders the background effect behind the main surface of the element.
+    #[allow(clippy::too_many_arguments)]
+    fn render_background_effect(
+        &self,
+        _ctx: RenderCtx<GlesRenderer>,
+        _geometry: Rectangle<f64, Logical>,
+        _scale: f64,
+        _clip_to_geometry: bool,
+        _radius: CornerRadius,
+        _xray_pos: XrayPos,
+        _push: &mut dyn FnMut(BackgroundEffectElement),
+    ) {
     }
 
     /// Requests the element to change its size.
@@ -4605,12 +4621,33 @@ impl<W: LayoutElement> Layout<W> {
         }
     }
 
-    pub fn store_unmap_snapshot(&mut self, renderer: &mut GlesRenderer, window: &W::Id) {
+    pub fn store_unmap_snapshot(
+        &mut self,
+        renderer: &mut GlesRenderer,
+        xray: Option<&mut Xray>,
+        xray_has_blocked_out_layers: bool,
+        window: &W::Id,
+    ) {
         let _span = tracy_client::span!("Layout::store_unmap_snapshot");
+
+        let zoom = self.overview_zoom();
 
         if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
             if move_.tile.window().id() == window {
-                move_.tile.store_unmap_snapshot_if_empty(renderer);
+                let pos_within_output = move_.tile_render_location(zoom);
+
+                // Computation matches update_render_elements().
+                let view_rect =
+                    Rectangle::new(pos_within_output.upscale(-1.), output_size(&move_.output))
+                        .downscale(zoom);
+                move_.tile.update_render_elements(false, view_rect);
+
+                move_.tile.store_unmap_snapshot_if_empty(
+                    renderer,
+                    xray,
+                    xray_has_blocked_out_layers,
+                    XrayPos::new(pos_within_output, zoom),
+                );
                 return;
             }
         }
@@ -4618,9 +4655,15 @@ impl<W: LayoutElement> Layout<W> {
         match &mut self.monitor_set {
             MonitorSet::Normal { monitors, .. } => {
                 for mon in monitors {
-                    for ws in &mut mon.workspaces {
+                    for (ws, geo) in mon.workspaces_with_render_geo_mut(false) {
                         if ws.has_window(window) {
-                            ws.store_unmap_snapshot_if_empty(renderer, window);
+                            ws.store_unmap_snapshot_if_empty(
+                                renderer,
+                                xray,
+                                xray_has_blocked_out_layers,
+                                XrayPos::new(geo.loc, zoom),
+                                window,
+                            );
                             return;
                         }
                     }
@@ -4629,7 +4672,13 @@ impl<W: LayoutElement> Layout<W> {
             MonitorSet::NoOutputs { workspaces, .. } => {
                 for ws in workspaces {
                     if ws.has_window(window) {
-                        ws.store_unmap_snapshot_if_empty(renderer, window);
+                        ws.store_unmap_snapshot_if_empty(
+                            renderer,
+                            xray,
+                            xray_has_blocked_out_layers,
+                            XrayPos::default(),
+                            window,
+                        );
                         return;
                     }
                 }
@@ -4748,14 +4797,18 @@ impl<W: LayoutElement> Layout<W> {
 
         let scale = Scale::from(move_.output.current_scale().fractional_scale());
         let zoom = self.overview_zoom();
-        let location = move_.tile_render_location(zoom);
-        move_.tile.render(ctx, location, true, &mut |elem| {
-            push(RescaleRenderElement::from_element(
-                elem,
-                location.to_physical_precise_round(scale),
-                zoom,
-            ));
-        });
+        let pos_in_backdrop = move_.tile_render_location(zoom);
+        let xray_pos = XrayPos::new(pos_in_backdrop, zoom);
+
+        move_
+            .tile
+            .render(ctx, pos_in_backdrop, xray_pos, true, &mut |elem| {
+                push(RescaleRenderElement::from_element(
+                    elem,
+                    pos_in_backdrop.to_physical_precise_round(scale),
+                    zoom,
+                ));
+            });
     }
 
     pub fn refresh(&mut self, is_active: bool) {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -134,6 +134,11 @@ pub trait LayoutElement {
     /// Unique ID of this element.
     fn id(&self) -> &Self::Id;
 
+    /// Updates the config for the element.
+    fn update_config(&mut self, blur_config: niri_config::Blur) {
+        let _ = blur_config;
+    }
+
     /// Visual size of the element.
     ///
     /// This is what the user would consider the size, i.e. excluding CSD shadows and whatnot.
@@ -364,6 +369,7 @@ pub struct Options {
     pub animations: niri_config::Animations,
     pub gestures: niri_config::Gestures,
     pub overview: niri_config::Overview,
+    pub blur: niri_config::Blur,
     // Debug flags.
     pub disable_resize_throttling: bool,
     pub disable_transactions: bool,
@@ -624,6 +630,7 @@ impl Options {
             animations: config.animations.clone(),
             gestures: config.gestures,
             overview: config.overview,
+            blur: config.blur,
             disable_resize_throttling: config.debug.disable_resize_throttling,
             disable_transactions: config.debug.disable_transactions,
             deactivate_unfocused_windows: config.debug.deactivate_unfocused_windows,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -203,6 +203,7 @@ pub trait LayoutElement {
         _geometry: Rectangle<f64, Logical>,
         _scale: f64,
         _clip_to_geometry: bool,
+        _surface_anim_scale: Scale<f64>,
         _radius: CornerRadius,
         _xray_pos: XrayPos,
         _push: &mut dyn FnMut(BackgroundEffectElement),

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2753,7 +2753,9 @@ impl<W: LayoutElement> Layout<W> {
             ..
         } = &mut self.monitor_set
         else {
-            error!("update_render_elements called with no monitors");
+            if output.is_some() {
+                error!("update_render_elements called with no monitors but Some output");
+            }
             return;
         };
 

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -24,7 +24,7 @@ use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shadow::ShadowRenderElement;
 use crate::render_helpers::solid_color::SolidColorRenderElement;
-use crate::render_helpers::RenderTarget;
+use crate::render_helpers::RenderCtx;
 use crate::rubber_band::RubberBand;
 use crate::utils::transaction::Transaction;
 use crate::utils::{
@@ -1669,8 +1669,7 @@ impl<W: LayoutElement> Monitor<W> {
 
     pub fn render_workspaces<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        mut ctx: RenderCtx<R>,
         focus_ring: bool,
         push: &mut dyn FnMut(MonitorRenderElement<R>),
     ) {
@@ -1734,16 +1733,16 @@ impl<W: LayoutElement> Monitor<W> {
                 }};
             }
 
-            ws.render_floating(renderer, target, focus_ring, push!());
+            ws.render_floating(ctx.r(), focus_ring, push!());
 
             if let Some(loc) = insert_hint_render_loc {
                 if loc.workspace == InsertWorkspace::Existing(ws.id()) {
                     self.insert_hint_element
-                        .render(renderer, loc.location, push!());
+                        .render(ctx.renderer, loc.location, push!());
                 }
             }
 
-            ws.render_scrolling(renderer, target, focus_ring, push!());
+            ws.render_scrolling(ctx.r(), focus_ring, push!());
         }
     }
 

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -24,6 +24,7 @@ use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shadow::ShadowRenderElement;
 use crate::render_helpers::solid_color::SolidColorRenderElement;
+use crate::render_helpers::xray::XrayPos;
 use crate::render_helpers::RenderCtx;
 use crate::rubber_band::RubberBand;
 use crate::utils::transaction::Transaction;
@@ -1733,7 +1734,9 @@ impl<W: LayoutElement> Monitor<W> {
                 }};
             }
 
-            ws.render_floating(ctx.r(), focus_ring, push!());
+            let xray_pos = XrayPos::new(geo.loc, zoom);
+
+            ws.render_floating(ctx.r(), xray_pos, focus_ring, push!());
 
             if let Some(loc) = insert_hint_render_loc {
                 if loc.workspace == InsertWorkspace::Existing(ws.id()) {
@@ -1742,7 +1745,7 @@ impl<W: LayoutElement> Monitor<W> {
                 }
             }
 
-            ws.render_scrolling(ctx.r(), focus_ring, push!());
+            ws.render_scrolling(ctx.r(), xray_pos, focus_ring, push!());
         }
     }
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -21,7 +21,7 @@ use crate::input::swipe_tracker::SwipeTracker;
 use crate::layout::SizingMode;
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
-use crate::render_helpers::RenderTarget;
+use crate::render_helpers::RenderCtx;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::ResizeEdge;
 use crate::window::ResolvedWindowRules;
@@ -2899,8 +2899,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
     pub fn render<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        mut ctx: RenderCtx<R>,
         focus_ring: bool,
         push: &mut dyn FnMut(ScrollingSpaceRenderElement<R>),
     ) {
@@ -2909,7 +2908,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         // Draw the closing windows on top of the other windows.
         let view_rect = Rectangle::new(Point::from((self.view_pos(), 0.)), self.view_size);
         for closing in self.closing_windows.iter().rev() {
-            let elem = closing.render(renderer.as_gles_renderer(), view_rect, scale, target);
+            let elem = closing.render(ctx.as_gles(), view_rect, scale);
             push(elem.into());
         }
 
@@ -2930,7 +2929,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 let pos = view_off + col_off + col_render_off;
                 let pos = pos.to_physical_precise_round(scale).to_logical(scale);
                 col.tab_indicator
-                    .render(renderer, pos, &mut |elem| push(elem.into()));
+                    .render(ctx.renderer, pos, &mut |elem| push(elem.into()));
             }
 
             for (tile, tile_off, visible) in col.tiles_in_render_order() {
@@ -2955,9 +2954,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     continue;
                 }
 
-                tile.render(renderer, tile_pos, focus_ring, target, &mut |elem| {
-                    push(elem.into())
-                });
+                tile.render(ctx.r(), tile_pos, focus_ring, &mut |elem| push(elem.into()));
             }
         }
     }

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -21,6 +21,7 @@ use crate::input::swipe_tracker::SwipeTracker;
 use crate::layout::SizingMode;
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
+use crate::render_helpers::xray::XrayPos;
 use crate::render_helpers::RenderCtx;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::ResizeEdge;
@@ -2900,6 +2901,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     pub fn render<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
+        xray_pos: XrayPos,
         focus_ring: bool,
         push: &mut dyn FnMut(ScrollingSpaceRenderElement<R>),
     ) {
@@ -2954,7 +2956,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     continue;
                 }
 
-                tile.render(ctx.r(), tile_pos, focus_ring, &mut |elem| push(elem.into()));
+                let xray_pos = xray_pos.offset(tile_pos);
+                tile.render(ctx.r(), tile_pos, xray_pos, focus_ring, &mut |elem| {
+                    push(elem.into())
+                });
             }
         }
     }

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -116,10 +116,12 @@ impl TestWindow {
                 if self.0.animate_next_configure.get() {
                     self.0.animation_snapshot.replace(Some(RenderSnapshot {
                         contents: Vec::new(),
+                        contents_with_blocked_out_bg: None,
                         blocked_out_contents: Vec::new(),
                         block_out_from: None,
                         size: self.0.bbox.get().size.to_f64(),
                         texture: OnceCell::new(),
+                        texture_with_blocked_out_bg: Default::default(),
                         blocked_out_texture: OnceCell::new(),
                     }));
                 }

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -403,7 +403,6 @@ impl<W: LayoutElement> Tile<W> {
             .unwrap_or_default()
             .fit_to(window_size.w as f32, window_size.h as f32);
         self.rounded_corner_damage.set_corner_radius(radius);
-        self.rounded_corner_damage.set_size(window_size);
     }
 
     pub fn advance_animations(&mut self) {
@@ -1200,8 +1199,8 @@ impl<W: LayoutElement> Tile<W> {
             };
 
             if clip_to_geometry && clip_shader.is_some() {
-                let damage = self.rounded_corner_damage.element();
-                push(damage.with_location(window_render_loc).into());
+                let damage = self.rounded_corner_damage.render(geo);
+                push(damage.into());
             }
 
             self.window

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -1205,6 +1205,12 @@ impl<W: LayoutElement> Tile<W> {
                     // Otherwise, render the solid color as is.
                     LayoutElementRenderElement::SolidColor(elem).into()
                 }
+                elem @ LayoutElementRenderElement::BackgroundEffect(_) => {
+                    // This is only used on popups for now. If subsurface blur is implemented, this
+                    // will need to be handled somehow.
+                    error!("background effect clipping is unimplemented");
+                    elem.into()
+                }
             };
 
             if clip_to_geometry && clip_shader.is_some() {

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -18,6 +18,7 @@ use super::{
 use crate::animation::{Animation, Clock};
 use crate::layout::SizingMode;
 use crate::niri_render_elements;
+use crate::render_helpers::background_effect::BackgroundEffectElement;
 use crate::render_helpers::border::BorderRenderElement;
 use crate::render_helpers::clipped_surface::{ClippedSurfaceRenderElement, RoundedCornerDamage};
 use crate::render_helpers::damage::ExtraDamage;
@@ -27,6 +28,7 @@ use crate::render_helpers::resize::ResizeRenderElement;
 use crate::render_helpers::shadow::ShadowRenderElement;
 use crate::render_helpers::snapshot::RenderSnapshot;
 use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
+use crate::render_helpers::xray::{Xray, XrayPos};
 use crate::render_helpers::{RenderCtx, RenderTarget};
 use crate::utils::transaction::Transaction;
 use crate::utils::{
@@ -130,6 +132,7 @@ niri_render_elements! {
         ClippedSurface = ClippedSurfaceRenderElement<R>,
         Offscreen = OffscreenRenderElement,
         ExtraDamage = ExtraDamage,
+        BackgroundEffect = BackgroundEffectElement,
     }
 }
 
@@ -1010,6 +1013,7 @@ impl<W: LayoutElement> Tile<W> {
         &self,
         mut ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
+        mut xray_pos: XrayPos,
         focus_ring: bool,
         push: &mut dyn FnMut(TileRenderElement<R>),
     ) {
@@ -1037,13 +1041,16 @@ impl<W: LayoutElement> Tile<W> {
         //
         // This isn't to say that adding it here is perfect; indeed, it kind of breaks view_rect
         // passed to update_render_elements(). But, it works well enough for what it is.
-        let location = location + self.bob_offset();
+        let bob_offset = self.bob_offset();
+        let location = location + bob_offset;
+        xray_pos = xray_pos.offset(bob_offset);
 
         let window_loc = self.window_loc();
         let window_size = self.window_size();
         let animated_window_size = self.animated_window_size();
         let window_render_loc = location + window_loc;
         let area = Rectangle::new(window_render_loc, animated_window_size);
+        xray_pos = xray_pos.offset(window_loc);
 
         let rules = self.window.rules();
 
@@ -1272,12 +1279,23 @@ impl<W: LayoutElement> Tile<W> {
             self.shadow
                 .render(ctx.renderer, location, &mut |elem| push(elem.into()));
         }
+
+        self.window.render_background_effect(
+            ctx.as_gles(),
+            area,
+            self.scale,
+            clip_to_geometry,
+            radius,
+            xray_pos,
+            &mut |elem| push(elem.into()),
+        );
     }
 
     pub fn render<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
+        xray_pos: XrayPos,
         focus_ring: bool,
         push: &mut dyn FnMut(TileRenderElement<R>),
     ) {
@@ -1296,9 +1314,13 @@ impl<W: LayoutElement> Tile<W> {
         if let Some(open) = &self.open_animation {
             let mut ctx = ctx.as_gles();
             let mut elements = Vec::new();
-            self.render_inner(ctx.r(), Point::from((0., 0.)), focus_ring, &mut |elem| {
-                elements.push(elem)
-            });
+            self.render_inner(
+                ctx.r(),
+                Point::new(0., 0.),
+                xray_pos,
+                focus_ring,
+                &mut |elem| elements.push(elem),
+            );
             match open.render(
                 ctx.renderer,
                 &elements,
@@ -1319,9 +1341,13 @@ impl<W: LayoutElement> Tile<W> {
         } else if let Some(alpha) = &self.alpha_animation {
             let mut ctx = ctx.as_gles();
             let mut elements = Vec::new();
-            self.render_inner(ctx.r(), Point::from((0., 0.)), focus_ring, &mut |elem| {
-                elements.push(elem)
-            });
+            self.render_inner(
+                ctx.r(),
+                Point::new(0., 0.),
+                xray_pos,
+                focus_ring,
+                &mut |elem| elements.push(elem),
+            );
             match alpha.offscreen.render(ctx.renderer, scale, &elements) {
                 Ok((elem, _sync, data)) => {
                     let offset = elem.offset();
@@ -1338,50 +1364,137 @@ impl<W: LayoutElement> Tile<W> {
         }
 
         if !pushed {
-            self.render_inner(ctx, location, focus_ring, &mut |elem| push(elem));
+            self.render_inner(ctx, location, xray_pos, focus_ring, &mut |elem| push(elem));
         }
     }
 
-    pub fn store_unmap_snapshot_if_empty(&mut self, renderer: &mut GlesRenderer) {
+    pub fn store_unmap_snapshot_if_empty(
+        &mut self,
+        renderer: &mut GlesRenderer,
+        xray: Option<&mut Xray>,
+        xray_has_blocked_out_layers: bool,
+        xray_pos: XrayPos,
+    ) {
         if self.unmap_snapshot.is_some() {
             return;
         }
 
-        self.unmap_snapshot = Some(self.render_snapshot(renderer));
+        self.unmap_snapshot =
+            Some(self.render_snapshot(renderer, xray, xray_has_blocked_out_layers, xray_pos));
     }
 
-    fn render_snapshot(&self, renderer: &mut GlesRenderer) -> TileRenderSnapshot {
+    fn render_snapshot(
+        &self,
+        renderer: &mut GlesRenderer,
+        mut xray: Option<&mut Xray>,
+        xray_has_blocked_out_layers: bool,
+        xray_pos: XrayPos,
+    ) -> TileRenderSnapshot {
         let _span = tracy_client::span!("Tile::render_snapshot");
 
         let mut contents = Vec::new();
         self.render(
             RenderCtx {
-                renderer,
                 target: RenderTarget::Output,
+                renderer,
+                xray: xray.as_deref(),
             },
             Point::from((0., 0.)),
+            xray_pos,
             false,
             &mut |elem| contents.push(elem),
         );
+
+        let mut contents_with_blocked_out_bg = None;
+
+        // Do a bit of pointer surgery on Xray.
+        //
+        // The idea is to avoid the combinatorial combination of rendering snapshots for target
+        // (Output, Screencast) × Xray target (Output, Screencast, ScreenCapture).
+        //
+        // Our main goals:
+        // - Everything must look unblocked for RenderTarget::Output.
+        // - If anything is potentially blocked-out, it must not show up on any screen capture.
+        //
+        // Right above we rendered a fully-unblocked snapshot for the Output, so that's covered.
+        //
+        // Next, *only if Xray has any blocked-out surfaces* (which is a rare case), we will render
+        // a snapshot where the window itself is unblocked, but the Xray background is blocked. To
+        // do this, we swap the Output target buffers in Xray with the Screencast target buffers
+        // (which were prepared for us higher up the stack).
+        //
+        // Finally, we render a fully blocked-out snapshot. If Xray has blocked-out surfaces, then
+        // Xray's Screencast buffers are already filled-in, but if not, then we swap in the Output
+        // buffers, to avoid an extra render. This is safe since we know there are no blocked
+        // surfaces there.
+        let output_idx = RenderTarget::Output as usize;
+        let screencast_idx = RenderTarget::Screencast as usize;
+        let mut screencast_background = None;
+        let mut screencast_backdrop = None;
+        let mut output_background = None;
+        let mut output_backdrop = None;
+        if let Some(xray) = &mut xray {
+            screencast_background = Some(Rc::clone(&xray.background[screencast_idx]));
+            screencast_backdrop = Some(Rc::clone(&xray.backdrop[screencast_idx]));
+            output_background = Some(Rc::clone(&xray.background[output_idx]));
+            output_backdrop = Some(Rc::clone(&xray.backdrop[output_idx]));
+
+            if xray_has_blocked_out_layers {
+                xray.background[output_idx] = screencast_background.clone().unwrap();
+                xray.backdrop[output_idx] = screencast_backdrop.clone().unwrap();
+
+                let mut contents = Vec::new();
+                self.render(
+                    RenderCtx {
+                        target: RenderTarget::Output,
+                        renderer,
+                        xray: Some(xray),
+                    },
+                    Point::from((0., 0.)),
+                    xray_pos,
+                    false,
+                    &mut |elem| contents.push(elem),
+                );
+                contents_with_blocked_out_bg = Some(contents);
+            } else {
+                xray.background[screencast_idx] = output_background.clone().unwrap();
+                xray.backdrop[screencast_idx] = output_backdrop.clone().unwrap();
+            }
+        }
 
         // A bit of a hack to render blocked out as for screencast, but I think it's fine here.
         let mut blocked_out_contents = Vec::new();
         self.render(
             RenderCtx {
-                renderer,
                 target: RenderTarget::Screencast,
+                renderer,
+                xray: xray.as_deref(),
             },
             Point::from((0., 0.)),
+            xray_pos,
             false,
             &mut |elem| blocked_out_contents.push(elem),
         );
 
+        // Put everything back to normal.
+        if let Some(xray) = &mut xray {
+            if xray_has_blocked_out_layers {
+                xray.background[output_idx] = output_background.take().unwrap();
+                xray.backdrop[output_idx] = output_backdrop.take().unwrap();
+            } else {
+                xray.background[screencast_idx] = screencast_background.take().unwrap();
+                xray.backdrop[screencast_idx] = screencast_backdrop.take().unwrap();
+            }
+        }
+
         RenderSnapshot {
             contents,
+            contents_with_blocked_out_bg,
             blocked_out_contents,
             block_out_from: self.window.rules().block_out_from,
             size: self.animated_tile_size(),
             texture: Default::default(),
+            texture_with_blocked_out_bg: Default::default(),
             blocked_out_texture: Default::default(),
         }
     }

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -1065,10 +1065,14 @@ impl<W: LayoutElement> Tile<W> {
             .scaled_by(1. - expanded_progress as f32);
 
         // Popups go on top, whether it's resize or not.
-        self.window
-            .render_popups(ctx.r(), window_render_loc, scale, win_alpha, &mut |elem| {
-                push(elem.into())
-            });
+        self.window.render_popups(
+            ctx.r(),
+            window_render_loc,
+            scale,
+            win_alpha,
+            xray_pos,
+            &mut |elem| push(elem.into()),
+        );
 
         // If we're resizing, try to render a shader, or a fallback.
         let mut pushed_resize = false;

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -1282,11 +1282,13 @@ impl<W: LayoutElement> Tile<W> {
                 .render(ctx.renderer, location, &mut |elem| push(elem.into()));
         }
 
+        let surface_anim_scale = animated_window_size / window_size;
         self.window.render_background_effect(
             ctx.as_gles(),
             area,
             self.scale,
             clip_to_geometry,
+            surface_anim_scale,
             radius,
             xray_pos,
             &mut |elem| push(elem.into()),

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -251,6 +251,8 @@ impl<W: LayoutElement> Tile<W> {
 
         let shadow_config = self.options.layout.shadow.merged_with(&rules.shadow);
         self.shadow.update_config(shadow_config);
+
+        self.window.update_config(self.options.blur);
     }
 
     pub fn update_shaders(&mut self) {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -32,7 +32,7 @@ use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shadow::ShadowRenderElement;
 use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
-use crate::render_helpers::RenderTarget;
+use crate::render_helpers::RenderCtx;
 use crate::utils::id::IdCounter;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::{
@@ -1626,22 +1626,18 @@ impl<W: LayoutElement> Workspace<W> {
 
     pub fn render_scrolling<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        ctx: RenderCtx<R>,
         focus_ring: bool,
         push: &mut dyn FnMut(WorkspaceRenderElement<R>),
     ) {
         let scrolling_focus_ring = focus_ring && !self.floating_is_active();
         self.scrolling
-            .render(renderer, target, scrolling_focus_ring, &mut |elem| {
-                push(elem.into())
-            });
+            .render(ctx, scrolling_focus_ring, &mut |elem| push(elem.into()));
     }
 
     pub fn render_floating<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        ctx: RenderCtx<R>,
         focus_ring: bool,
         push: &mut dyn FnMut(WorkspaceRenderElement<R>),
     ) {
@@ -1651,13 +1647,10 @@ impl<W: LayoutElement> Workspace<W> {
 
         let view_rect = Rectangle::from_size(self.view_size);
         let floating_focus_ring = focus_ring && self.floating_is_active();
-        self.floating.render(
-            renderer,
-            view_rect,
-            target,
-            floating_focus_ring,
-            &mut |elem| push(elem.into()),
-        );
+        self.floating
+            .render(ctx, view_rect, floating_focus_ring, &mut |elem| {
+                push(elem.into())
+            });
     }
 
     pub fn render_shadow<R: NiriRenderer>(

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -32,6 +32,7 @@ use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shadow::ShadowRenderElement;
 use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
+use crate::render_helpers::xray::{Xray, XrayPos};
 use crate::render_helpers::RenderCtx;
 use crate::utils::id::IdCounter;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
@@ -1627,17 +1628,21 @@ impl<W: LayoutElement> Workspace<W> {
     pub fn render_scrolling<R: NiriRenderer>(
         &self,
         ctx: RenderCtx<R>,
+        xray_pos: XrayPos,
         focus_ring: bool,
         push: &mut dyn FnMut(WorkspaceRenderElement<R>),
     ) {
         let scrolling_focus_ring = focus_ring && !self.floating_is_active();
         self.scrolling
-            .render(ctx, scrolling_focus_ring, &mut |elem| push(elem.into()));
+            .render(ctx, xray_pos, scrolling_focus_ring, &mut |elem| {
+                push(elem.into())
+            });
     }
 
     pub fn render_floating<R: NiriRenderer>(
         &self,
         ctx: RenderCtx<R>,
+        xray_pos: XrayPos,
         focus_ring: bool,
         push: &mut dyn FnMut(WorkspaceRenderElement<R>),
     ) {
@@ -1648,7 +1653,7 @@ impl<W: LayoutElement> Workspace<W> {
         let view_rect = Rectangle::from_size(self.view_size);
         let floating_focus_ring = focus_ring && self.floating_is_active();
         self.floating
-            .render(ctx, view_rect, floating_focus_ring, &mut |elem| {
+            .render(ctx, xray_pos, view_rect, floating_focus_ring, &mut |elem| {
                 push(elem.into())
             });
     }
@@ -1682,14 +1687,27 @@ impl<W: LayoutElement> Workspace<W> {
         ) || !self.render_above_top_layer()
     }
 
-    pub fn store_unmap_snapshot_if_empty(&mut self, renderer: &mut GlesRenderer, window: &W::Id) {
+    pub fn store_unmap_snapshot_if_empty(
+        &mut self,
+        renderer: &mut GlesRenderer,
+        xray: Option<&mut Xray>,
+        xray_has_blocked_out_layers: bool,
+        xray_pos: XrayPos,
+        window: &W::Id,
+    ) {
         let view_size = self.view_size();
         for (tile, tile_pos) in self.tiles_with_render_positions_mut(false) {
             if tile.window().id() == window {
                 let view_pos = Point::from((-tile_pos.x, -tile_pos.y));
                 let view_rect = Rectangle::new(view_pos, view_size);
                 tile.update_render_elements(false, view_rect);
-                tile.store_unmap_snapshot_if_empty(renderer);
+                let xray_pos = xray_pos.offset(tile_pos);
+                tile.store_unmap_snapshot_if_empty(
+                    renderer,
+                    xray,
+                    xray_has_blocked_out_layers,
+                    xray_pos,
+                );
                 return;
             }
         }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -4026,13 +4026,13 @@ impl Niri {
         include_pointer: bool,
     ) -> Vec<OutputRenderElements<R>> {
         let mut elements = Vec::new();
-        self.render_inner(ctx, output, include_pointer, &mut |elem| {
+        self.render(ctx, output, include_pointer, &mut |elem| {
             elements.push(elem)
         });
         elements
     }
 
-    pub fn render_inner<R: NiriRenderer>(
+    pub fn render<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
         output: &Output,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -156,7 +156,7 @@ use crate::render_helpers::surface::push_elements_from_surface_tree;
 use crate::render_helpers::texture::TextureBuffer;
 use crate::render_helpers::{
     encompassing_geo, render_to_dmabuf, render_to_encompassing_texture, render_to_shm,
-    render_to_texture, render_to_vec, shaders, RenderTarget,
+    render_to_texture, render_to_vec, shaders, RenderCtx, RenderTarget,
 };
 #[cfg(feature = "xdp-gnome-screencast")]
 use crate::screencasting::Screencasting;
@@ -4021,13 +4021,12 @@ impl Niri {
 
     pub fn render<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        ctx: RenderCtx<R>,
         output: &Output,
         include_pointer: bool,
-        target: RenderTarget,
     ) -> Vec<OutputRenderElements<R>> {
         let mut elements = Vec::new();
-        self.render_inner(renderer, output, include_pointer, target, &mut |elem| {
+        self.render_inner(ctx, output, include_pointer, &mut |elem| {
             elements.push(elem)
         });
         elements
@@ -4035,17 +4034,16 @@ impl Niri {
 
     pub fn render_inner<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        mut ctx: RenderCtx<R>,
         output: &Output,
         include_pointer: bool,
-        mut target: RenderTarget,
         push: &mut dyn FnMut(OutputRenderElements<R>),
     ) {
         let _span = tracy_client::span!("Niri::render");
 
-        if target == RenderTarget::Output {
+        if ctx.target == RenderTarget::Output {
             if let Some(preview) = self.config.borrow().debug.preview_render {
-                target = match preview {
+                ctx.target = match preview {
                     PreviewRender::Screencast => RenderTarget::Screencast,
                     PreviewRender::ScreenCapture => RenderTarget::ScreenCapture,
                 };
@@ -4065,23 +4063,23 @@ impl Niri {
 
         // The pointer goes on the top.
         if include_pointer && self.pointer_visibility.is_visible() {
-            self.render_pointer(renderer, output, &mut |elem| push(elem.into()));
+            self.render_pointer(ctx.renderer, output, &mut |elem| push(elem.into()));
         }
 
         // Next, the screen transition texture.
         {
             let state = self.output_state.get(output).unwrap();
             if let Some(transition) = &state.screen_transition {
-                push(transition.render(target).into());
+                push(transition.render(ctx.target).into());
             }
         }
 
         // Next, the exit confirm dialog.
         self.exit_confirm_dialog
-            .render(renderer, output, &mut |elem| push(elem.into()));
+            .render(ctx.renderer, output, &mut |elem| push(elem.into()));
 
         // Next, the config error notification too.
-        if let Some(element) = self.config_error_notification.render(renderer, output) {
+        if let Some(element) = self.config_error_notification.render(ctx.renderer, output) {
             push(element.into());
         }
 
@@ -4090,7 +4088,7 @@ impl Niri {
             let state = self.output_state.get(output).unwrap();
             if let Some(surface) = state.lock_surface.as_ref() {
                 push_elements_from_surface_tree(
-                    renderer,
+                    ctx.renderer,
                     surface.wl_surface(),
                     Point::new(0, 0),
                     output_scale,
@@ -4127,7 +4125,7 @@ impl Niri {
         // If the screenshot UI is open, draw it.
         if self.screenshot_ui.is_open() {
             self.screenshot_ui
-                .render_output(output, target, &mut |elem| push(elem.into()));
+                .render_output(output, ctx.target, &mut |elem| push(elem.into()));
 
             // Add the backdrop for outputs that were connected while the screenshot UI was open.
             push(backdrop);
@@ -4136,15 +4134,13 @@ impl Niri {
         }
 
         // Draw the hotkey overlay on top.
-        if let Some(element) = self.hotkey_overlay.render(renderer, output) {
+        if let Some(element) = self.hotkey_overlay.render(ctx.renderer, output) {
             push(element.into());
         }
 
         // Then, the Alt-Tab switcher.
         self.window_mru_ui
-            .render_output(self, output, renderer, target, &mut |elem| {
-                push(elem.into())
-            });
+            .render_output(self, output, ctx.r(), &mut |elem| push(elem.into()));
 
         // Don't draw the focus ring on the workspaces while interactively moving above those
         // workspaces, since the interactively-moved window already has a focus ring.
@@ -4161,7 +4157,7 @@ impl Niri {
         // into different functions).
         macro_rules! push_popups_from_layer {
             ($layer:expr, $backdrop:expr, $push:expr) => {{
-                self.render_layer_popups(renderer, target, &layer_map, $layer, $backdrop, $push);
+                self.render_layer_popups(ctx.r(), &layer_map, $layer, $backdrop, $push);
             }};
             ($layer:expr, true) => {{
                 push_popups_from_layer!($layer, true, &mut |elem| push(elem.into()));
@@ -4175,7 +4171,7 @@ impl Niri {
         }
         macro_rules! push_normal_from_layer {
             ($layer:expr, $backdrop:expr, $push:expr) => {{
-                self.render_layer_normal(renderer, target, &layer_map, $layer, $backdrop, $push);
+                self.render_layer_normal(ctx.r(), &layer_map, $layer, $backdrop, $push);
             }};
             ($layer:expr, true) => {{
                 push_normal_from_layer!($layer, true, &mut |elem| push(elem.into()));
@@ -4196,13 +4192,11 @@ impl Niri {
         // Otherwise, we will render all layer-shell pop-ups and the top layer on top.
         if mon.render_above_top_layer() {
             self.layout
-                .render_interactive_move_for_output(renderer, output, target, &mut |elem| {
-                    push(elem.into())
-                });
+                .render_interactive_move_for_output(ctx.r(), output, &mut |elem| push(elem.into()));
 
-            mon.render_insert_hint_between_workspaces(renderer, &mut |elem| push(elem.into()));
+            mon.render_insert_hint_between_workspaces(ctx.renderer, &mut |elem| push(elem.into()));
 
-            mon.render_workspaces(renderer, target, focus_ring, &mut |elem| push(elem.into()));
+            mon.render_workspaces(ctx.r(), focus_ring, &mut |elem| push(elem.into()));
 
             push_popups_from_layer!(Layer::Top);
             push_normal_from_layer!(Layer::Top);
@@ -4221,11 +4215,9 @@ impl Niri {
             push_normal_from_layer!(Layer::Top);
 
             self.layout
-                .render_interactive_move_for_output(renderer, output, target, &mut |elem| {
-                    push(elem.into())
-                });
+                .render_interactive_move_for_output(ctx.r(), output, &mut |elem| push(elem.into()));
 
-            mon.render_insert_hint_between_workspaces(renderer, &mut |elem| push(elem.into()));
+            mon.render_insert_hint_between_workspaces(ctx.renderer, &mut |elem| push(elem.into()));
 
             // Macro instead of closure to avoid borrowing push().
             macro_rules! process {
@@ -4243,7 +4235,7 @@ impl Niri {
                 push_popups_from_layer!(Layer::Background, process!(geo));
             }
 
-            mon.render_workspaces(renderer, target, focus_ring, &mut |elem| push(elem.into()));
+            mon.render_workspaces(ctx.r(), focus_ring, &mut |elem| push(elem.into()));
 
             for (ws, geo) in mon.workspaces_with_render_geo() {
                 push_normal_from_layer!(Layer::Bottom, process!(geo));
@@ -4253,7 +4245,7 @@ impl Niri {
             }
         }
 
-        mon.render_workspace_shadows(renderer, &mut |elem| push(elem.into()));
+        mon.render_workspace_shadows(ctx.renderer, &mut |elem| push(elem.into()));
 
         // Then the backdrop.
         push_popups_from_layer!(Layer::Background, true);
@@ -4283,29 +4275,27 @@ impl Niri {
 
     fn render_layer_normal<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        mut ctx: RenderCtx<R>,
         layer_map: &LayerMap,
         layer: Layer,
         for_backdrop: bool,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
         for (mapped, geo) in self.layers_in_render_order(layer_map, layer, for_backdrop) {
-            mapped.render_normal(renderer, geo.loc.to_f64(), target, push);
+            mapped.render_normal(ctx.r(), geo.loc.to_f64(), push);
         }
     }
 
     fn render_layer_popups<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        mut ctx: RenderCtx<R>,
         layer_map: &LayerMap,
         layer: Layer,
         for_backdrop: bool,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
         for (mapped, geo) in self.layers_in_render_order(layer_map, layer, for_backdrop) {
-            mapped.render_popups(renderer, geo.loc.to_f64(), target, push);
+            mapped.render_popups(ctx.r(), geo.loc.to_f64(), push);
         }
     }
 
@@ -4929,7 +4919,11 @@ impl Niri {
             if let Some(screencopy) = screencopy {
                 if screencopy.output() == output {
                     let elements = elements.get_or_init(|| {
-                        self.render(renderer, output, true, RenderTarget::ScreenCapture)
+                        let ctx = RenderCtx {
+                            renderer,
+                            target: RenderTarget::ScreenCapture,
+                        };
+                        self.render(ctx, output, true)
                     });
                     // FIXME: skip elements if not including pointers
                     let render_result = Self::render_for_screencopy_internal(
@@ -4992,12 +4986,12 @@ impl Niri {
 
         self.update_render_elements(Some(output));
 
-        let elements = self.render(
+        let ctx = RenderCtx {
             renderer,
-            output,
-            screencopy.overlay_cursor(),
-            RenderTarget::ScreenCapture,
-        );
+            target: RenderTarget::ScreenCapture,
+        };
+        let elements = self.render(ctx, output, screencopy.overlay_cursor());
+
         let Some(damage_tracker) = self.screencopy_state.damage_tracker(manager) else {
             error!("screencopy queue must not be deleted as long as frames exist");
             bail!("screencopy queue missing");
@@ -5120,7 +5114,8 @@ impl Niri {
                 RenderTarget::ScreenCapture,
             ];
             let screenshot = targets.map(|target| {
-                let elements = self.render::<GlesRenderer>(renderer, &output, false, target);
+                let ctx = RenderCtx { renderer, target };
+                let elements = self.render(ctx, &output, false);
                 let elements = elements.iter().rev();
 
                 let res = render_to_texture(
@@ -5197,12 +5192,11 @@ impl Niri {
         let size = transform.transform_size(size);
 
         let scale = Scale::from(output.current_scale().fractional_scale());
-        let elements = self.render::<GlesRenderer>(
+        let ctx = RenderCtx {
             renderer,
-            output,
-            include_pointer,
-            RenderTarget::ScreenCapture,
-        );
+            target: RenderTarget::ScreenCapture,
+        };
+        let elements = self.render(ctx, output, include_pointer);
         let elements = elements.iter().rev();
         let pixels = render_to_vec(
             renderer,
@@ -5252,12 +5246,15 @@ impl Niri {
         }
         let pointer_count = elements.len();
 
-        mapped.render(
+        let ctx = RenderCtx {
             renderer,
+            target: RenderTarget::ScreenCapture,
+        };
+        mapped.render(
+            ctx,
             mapped.window.geometry().loc.to_f64(),
             scale,
             alpha,
-            RenderTarget::ScreenCapture,
             &mut |elem| elements.push(elem.into()),
         );
 
@@ -5413,12 +5410,11 @@ impl Niri {
         let transform = output.current_transform();
         let size = transform.transform_size(size);
 
-        let elements = self.render::<GlesRenderer>(
+        let ctx = RenderCtx {
             renderer,
-            &output,
-            include_pointer,
-            RenderTarget::ScreenCapture,
-        );
+            target: RenderTarget::ScreenCapture,
+        };
+        let elements = self.render(ctx, &output, include_pointer);
         let elements = elements.iter().rev();
         let pixels = render_to_vec(
             renderer,
@@ -5891,7 +5887,8 @@ impl Niri {
                     RenderTarget::ScreenCapture,
                 ];
                 let textures = targets.map(|target| {
-                    let elements = self.render::<GlesRenderer>(renderer, &output, false, target);
+                    let ctx = RenderCtx { renderer, target };
+                    let elements = self.render(ctx, &output, false);
                     let elements = elements.iter().rev();
 
                     let res = render_to_texture(

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -4019,7 +4019,7 @@ impl Niri {
         }
     }
 
-    pub fn render<R: NiriRenderer>(
+    pub fn render_to_vec<R: NiriRenderer>(
         &self,
         ctx: RenderCtx<R>,
         output: &Output,
@@ -4923,7 +4923,7 @@ impl Niri {
                             renderer,
                             target: RenderTarget::ScreenCapture,
                         };
-                        self.render(ctx, output, true)
+                        self.render_to_vec(ctx, output, true)
                     });
                     // FIXME: skip elements if not including pointers
                     let render_result = Self::render_for_screencopy_internal(
@@ -4990,7 +4990,7 @@ impl Niri {
             renderer,
             target: RenderTarget::ScreenCapture,
         };
-        let elements = self.render(ctx, output, screencopy.overlay_cursor());
+        let elements = self.render_to_vec(ctx, output, screencopy.overlay_cursor());
 
         let Some(damage_tracker) = self.screencopy_state.damage_tracker(manager) else {
             error!("screencopy queue must not be deleted as long as frames exist");
@@ -5115,7 +5115,7 @@ impl Niri {
             ];
             let screenshot = targets.map(|target| {
                 let ctx = RenderCtx { renderer, target };
-                let elements = self.render(ctx, &output, false);
+                let elements = self.render_to_vec(ctx, &output, false);
                 let elements = elements.iter().rev();
 
                 let res = render_to_texture(
@@ -5196,7 +5196,7 @@ impl Niri {
             renderer,
             target: RenderTarget::ScreenCapture,
         };
-        let elements = self.render(ctx, output, include_pointer);
+        let elements = self.render_to_vec(ctx, output, include_pointer);
         let elements = elements.iter().rev();
         let pixels = render_to_vec(
             renderer,
@@ -5414,7 +5414,7 @@ impl Niri {
             renderer,
             target: RenderTarget::ScreenCapture,
         };
-        let elements = self.render(ctx, &output, include_pointer);
+        let elements = self.render_to_vec(ctx, &output, include_pointer);
         let elements = elements.iter().rev();
         let pixels = render_to_vec(
             renderer,
@@ -5888,7 +5888,7 @@ impl Niri {
                 ];
                 let textures = targets.map(|target| {
                     let ctx = RenderCtx { renderer, target };
-                    let elements = self.render(ctx, &output, false);
+                    let elements = self.render_to_vec(ctx, &output, false);
                     let elements = elements.iter().rev();
 
                     let res = render_to_texture(

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -4271,17 +4271,29 @@ impl Niri {
         // We use macros instead of closures to avoid borrowing issues (renderer and push() go
         // into different functions).
         macro_rules! push_popups_from_layer {
-            ($layer:expr, $ns:expr, $backdrop:expr, $push:expr) => {{
-                self.render_layer_popups(ctx.r(), $ns, &layer_map, $layer, $backdrop, $push);
+            ($layer:expr, $ns:expr, $xray_pos:expr, $backdrop:expr, $push:expr) => {{
+                self.render_layer_popups(
+                    ctx.r(),
+                    $ns,
+                    &layer_map,
+                    $layer,
+                    $xray_pos,
+                    $backdrop,
+                    $push,
+                );
             }};
             ($layer:expr, true) => {{
-                push_popups_from_layer!($layer, None, true, &mut |elem| push(elem.into()));
+                push_popups_from_layer!($layer, None, XrayPos::default(), true, &mut |elem| push(
+                    elem.into()
+                ));
             }};
-            ($layer:expr, $ns:expr, $push:expr) => {{
-                push_popups_from_layer!($layer, $ns, false, $push);
+            ($layer:expr, $ns:expr, $xray_pos:expr, $push:expr) => {{
+                push_popups_from_layer!($layer, $ns, $xray_pos, false, $push);
             }};
             ($layer:expr) => {{
-                push_popups_from_layer!($layer, None, false, &mut |elem| push(elem.into()));
+                push_popups_from_layer!($layer, None, XrayPos::default(), false, &mut |elem| push(
+                    elem.into()
+                ));
             }};
         }
         macro_rules! push_normal_from_layer {
@@ -4359,8 +4371,9 @@ impl Niri {
 
             for (ws, geo) in mon.workspaces_with_render_geo() {
                 let ns = Some(ws.id().get() as usize);
-                push_popups_from_layer!(Layer::Bottom, ns, process!(geo));
-                push_popups_from_layer!(Layer::Background, ns, process!(geo));
+                let xray_pos = XrayPos::new(geo.loc, zoom);
+                push_popups_from_layer!(Layer::Bottom, ns, xray_pos, process!(geo));
+                push_popups_from_layer!(Layer::Background, ns, xray_pos, process!(geo));
             }
 
             mon.render_workspaces(ctx.r(), focus_ring, &mut |elem| push(elem.into()));
@@ -4515,17 +4528,21 @@ impl Niri {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_layer_popups<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
         ns: Option<usize>,
         layer_map: &LayerMap,
         layer: Layer,
+        xray_pos: XrayPos,
         for_backdrop: bool,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
         for (mapped, geo) in self.layers_in_render_order(layer_map, layer, for_backdrop) {
-            mapped.render_popups(ctx.r(), ns, geo.loc.to_f64(), push);
+            let loc = geo.loc.to_f64();
+            let xray_pos = xray_pos.offset(loc);
+            mapped.render_popups(ctx.r(), ns, loc, xray_pos, push);
         }
     }
 
@@ -5571,6 +5588,7 @@ impl Niri {
             mapped.window.geometry().loc.to_f64(),
             scale,
             alpha,
+            XrayPos::default(),
             &mut |elem| elements.push(elem.into()),
         );
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -38,7 +38,8 @@ use smithay::desktop::utils::{
     bbox_from_surface_tree, output_update, send_dmabuf_feedback_surface_tree,
     send_frames_surface_tree, surface_presentation_feedback_flags_from_states,
     surface_primary_scanout_output, take_presentation_feedback_surface_tree,
-    under_from_surface_tree, update_surface_primary_scanout_output, OutputPresentationFeedback,
+    under_from_surface_tree, update_surface_primary_scanout_output, with_surfaces_surface_tree,
+    OutputPresentationFeedback,
 };
 use smithay::desktop::{
     find_popup_root_surface, layer_map_for_output, LayerMap, LayerSurface, PopupGrab, PopupManager,
@@ -154,6 +155,7 @@ use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
 use crate::render_helpers::surface::push_elements_from_surface_tree;
 use crate::render_helpers::texture::TextureBuffer;
+use crate::render_helpers::xray::{Xray, XrayPos};
 use crate::render_helpers::{
     encompassing_geo, render_to_dmabuf, render_to_encompassing_texture, render_to_shm,
     render_to_texture, render_to_vec, shaders, RenderCtx, RenderTarget,
@@ -471,6 +473,7 @@ pub struct OutputState {
     /// Solid color buffer for the backdrop that we use instead of clearing to avoid damage
     /// tracking issues and make screenshots easier.
     pub backdrop_buffer: SolidColorBuffer,
+    pub xray: Xray,
     pub lock_render_state: LockRenderState,
     pub lock_surface: Option<LockSurface>,
     pub lock_color_buffer: SolidColorBuffer,
@@ -2024,6 +2027,51 @@ impl State {
         self.niri.queue_redraw_all();
     }
 
+    pub fn store_unmap_snapshot(&mut self, window: &Window, output: Option<&Output>) {
+        // The unmapping tile may have an xray background, in which case we will render xray
+        // elements, so they need to be updated.
+        self.niri.update_xray_render_elements(output);
+
+        self.backend.with_primary_renderer(|renderer| {
+            if let Some(output) = output {
+                let mut ctx = RenderCtx {
+                    target: RenderTarget::Output,
+                    renderer,
+                    xray: None,
+                };
+
+                self.niri.fill_xray_elements(ctx.r(), output);
+
+                // If any background layer has block_out_from, also fill the Screencast xray
+                // buffer so the unmap snapshot can render a buffer with blocked-out background.
+                //
+                // This will be used in Tile::render_snapshot().
+                let has_blocked_out = self.niri.has_blocked_out_background_layers(output);
+                if has_blocked_out {
+                    let screencast_ctx = RenderCtx {
+                        target: RenderTarget::Screencast,
+                        ..ctx.r()
+                    };
+                    self.niri.fill_xray_elements(screencast_ctx, output);
+                }
+
+                let state = self.niri.output_state.get_mut(output).unwrap();
+                self.niri.layout.store_unmap_snapshot(
+                    renderer,
+                    Some(&mut state.xray),
+                    has_blocked_out,
+                    window,
+                );
+
+                self.niri.clear_xray_elements(output);
+            } else {
+                self.niri
+                    .layout
+                    .store_unmap_snapshot(renderer, None, false, window);
+            }
+        });
+    }
+
     #[cfg(not(feature = "xdp-gnome-screencast"))]
     pub fn set_dynamic_cast_target(&mut self, _target: CastTarget) {}
 
@@ -2805,6 +2853,7 @@ impl Niri {
             vblank_throttle: VBlankThrottle::new(self.event_loop.clone(), name.connector.clone()),
             frame_callback_sequence: 0,
             backdrop_buffer: SolidColorBuffer::new(size, backdrop_color),
+            xray: Xray::new(),
             lock_render_state,
             lock_surface: None,
             lock_color_buffer: SolidColorBuffer::new(size, CLEAR_COLOR_LOCKED),
@@ -3985,6 +4034,7 @@ impl Niri {
     }
 
     pub fn update_render_elements(&mut self, output: Option<&Output>) {
+        self.update_xray_render_elements(output);
         self.layout.update_render_elements(output);
 
         for (out, state) in self.output_state.iter_mut() {
@@ -3998,6 +4048,46 @@ impl Niri {
 
                 let layer_map = layer_map_for_output(out);
                 for surface in layer_map.layers() {
+                    let Some(mapped) = self.mapped_layer_surfaces.get_mut(surface) else {
+                        continue;
+                    };
+                    let Some(geo) = layer_map.layer_geometry(surface) else {
+                        continue;
+                    };
+
+                    mapped.update_render_elements(geo.size.to_f64());
+                }
+            }
+        }
+    }
+
+    // Updates only those render elements that go in the xray buffer.
+    pub fn update_xray_render_elements(&mut self, output: Option<&Output>) {
+        for (out, state) in self.output_state.iter_mut() {
+            if output.is_none_or(|output| out == output) {
+                let scale = Scale::from(out.current_scale().fractional_scale());
+                let mode = out.current_mode().unwrap();
+                let transform = out.current_transform();
+                let size = transform.transform_size(mode.size);
+
+                state.xray.workspaces.clear();
+                let mon = self.layout.monitor_for_output(out).unwrap();
+                for (ws, geo) in mon.workspaces_with_render_geo() {
+                    let bg_color = ws.render_background().color();
+                    state.xray.workspaces.push((geo, bg_color));
+                }
+                state.xray.backdrop_color = state.backdrop_buffer.color();
+                for buf in &state.xray.background {
+                    let mut buffer = buf.borrow_mut();
+                    buffer.update_size(size, scale);
+                }
+                for buf in &state.xray.backdrop {
+                    let mut buffer = buf.borrow_mut();
+                    buffer.update_size(size, scale);
+                }
+
+                let layer_map = layer_map_for_output(out);
+                for surface in layer_map.layers_on(Layer::Background) {
                     let Some(mapped) = self.mapped_layer_surfaces.get_mut(surface) else {
                         continue;
                     };
@@ -4050,6 +4140,25 @@ impl Niri {
             }
         }
 
+        self.fill_xray_elements(ctx.as_gles(), output);
+
+        // Reborrow to shorten lifetime to be able to put in xray.
+        let mut ctx = ctx.r();
+        let state = self.output_state.get(output).unwrap();
+        ctx.xray = Some(&state.xray);
+
+        self.render_inner(ctx, output, include_pointer, push);
+
+        self.clear_xray_elements(output);
+    }
+
+    fn render_inner<R: NiriRenderer>(
+        &self,
+        mut ctx: RenderCtx<R>,
+        output: &Output,
+        include_pointer: bool,
+        push: &mut dyn FnMut(OutputRenderElements<R>),
+    ) {
         let state = self.output_state.get(output).unwrap();
         let output_scale = Scale::from(output.current_scale().fractional_scale());
 
@@ -4168,17 +4277,21 @@ impl Niri {
             }};
         }
         macro_rules! push_normal_from_layer {
-            ($layer:expr, $backdrop:expr, $push:expr) => {{
-                self.render_layer_normal(ctx.r(), &layer_map, $layer, $backdrop, $push);
+            ($layer:expr, $xray_pos:expr, $backdrop:expr, $push:expr) => {{
+                self.render_layer_normal(ctx.r(), &layer_map, $layer, $xray_pos, $backdrop, $push);
             }};
             ($layer:expr, true) => {{
-                push_normal_from_layer!($layer, true, &mut |elem| push(elem.into()));
+                push_normal_from_layer!($layer, XrayPos::default(), true, &mut |elem| {
+                    push(elem.into())
+                });
             }};
-            ($layer:expr, $push:expr) => {{
-                push_normal_from_layer!($layer, false, $push);
+            ($layer:expr, $xray_pos:expr, $push:expr) => {{
+                push_normal_from_layer!($layer, $xray_pos, false, $push);
             }};
             ($layer:expr) => {{
-                push_normal_from_layer!($layer, false, &mut |elem| push(elem.into()));
+                push_normal_from_layer!($layer, XrayPos::default(), false, &mut |elem| {
+                    push(elem.into())
+                });
             }};
         }
 
@@ -4236,8 +4349,9 @@ impl Niri {
             mon.render_workspaces(ctx.r(), focus_ring, &mut |elem| push(elem.into()));
 
             for (ws, geo) in mon.workspaces_with_render_geo() {
-                push_normal_from_layer!(Layer::Bottom, process!(geo));
-                push_normal_from_layer!(Layer::Background, process!(geo));
+                let xray_pos = XrayPos::new(geo.loc, zoom);
+                push_normal_from_layer!(Layer::Bottom, xray_pos, process!(geo));
+                push_normal_from_layer!(Layer::Background, xray_pos, process!(geo));
 
                 process!(geo)(ws.render_background());
             }
@@ -4250,6 +4364,90 @@ impl Niri {
         push_normal_from_layer!(Layer::Background, true);
 
         push(backdrop);
+    }
+
+    pub fn fill_xray_elements(&self, mut ctx: RenderCtx<GlesRenderer>, output: &Output) {
+        let _span = tracy_client::span!("Niri::fill_xray_elements");
+
+        // Make sure the xrayed elements themselves cannot use xray by mistake.
+        ctx.xray = None;
+
+        let state = self.output_state.get(output).unwrap();
+        let xray = &state.xray;
+        let layer_map = layer_map_for_output(output);
+
+        // FIXME: it would be cool to call this code on-demand. It's even relatively simple to do:
+        // move this function to after the render_inner() call, check if
+        // Rc::strong_count(&xray.background) > 1, and only then construct the elements. This way,
+        // only if something referenced the xray buffer will the elements get constructed.
+        //
+        // Unfortunately, currently this runs into an important limitation: offscreens are rendered
+        // immediately deep inside render_inner(), and when they are, they already need the xray
+        // elements filled.
+        //
+        // Perhaps in the future when offscreen rendering becomes on-demand, this optimization will
+        // be possible.
+
+        let mut buffer = xray.background[ctx.target as usize].borrow_mut();
+        {
+            let elements = buffer.elements();
+            elements.clear();
+            self.render_layer_normal(
+                ctx.r(),
+                &layer_map,
+                Layer::Background,
+                XrayPos::default(),
+                false,
+                &mut |elem| elements.push(elem.into()),
+            );
+            // Avoid unused capacity remaining forever.
+            elements.shrink_to_fit();
+        }
+
+        let mut buffer = xray.backdrop[ctx.target as usize].borrow_mut();
+        {
+            let elements = buffer.elements();
+            elements.clear();
+            self.render_layer_normal(
+                ctx.r(),
+                &layer_map,
+                Layer::Background,
+                XrayPos::default(),
+                true,
+                &mut |elem| elements.push(elem.into()),
+            );
+            // Avoid unused capacity remaining forever.
+            elements.shrink_to_fit();
+        }
+    }
+
+    pub fn clear_xray_elements(&self, output: &Output) {
+        let state = self.output_state.get(output).unwrap();
+        let xray = &state.xray;
+
+        // Clear the xray elements for all render targets after all rendering that could use them
+        // did so.
+        for buf in &xray.background {
+            buf.borrow_mut().elements().clear();
+        }
+        for buf in &xray.backdrop {
+            buf.borrow_mut().elements().clear();
+        }
+    }
+
+    /// Checks if any background layer surface has `block_out_from` set.
+    pub fn has_blocked_out_background_layers(&self, output: &Output) -> bool {
+        let layer_map = layer_map_for_output(output);
+        for for_backdrop in [false, true] {
+            for (mapped, _geo) in
+                self.layers_in_render_order(&layer_map, Layer::Background, for_backdrop)
+            {
+                if mapped.rules().block_out_from.is_some() {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     fn layers_in_render_order<'a>(
@@ -4271,16 +4469,20 @@ impl Niri {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_layer_normal<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
         layer_map: &LayerMap,
         layer: Layer,
+        xray_pos: XrayPos,
         for_backdrop: bool,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
         for (mapped, geo) in self.layers_in_render_order(layer_map, layer, for_backdrop) {
-            mapped.render_normal(ctx.r(), geo.loc.to_f64(), push);
+            let loc = geo.loc.to_f64();
+            let xray_pos = xray_pos.offset(loc);
+            mapped.render_normal(ctx.r(), loc, xray_pos, push);
         }
     }
 
@@ -4558,17 +4760,65 @@ impl Niri {
             });
         }
 
-        for surface in layer_map_for_output(output).layers() {
-            surface.with_surfaces(|surface, states| {
-                update_surface_primary_scanout_output(
-                    surface,
+        let xray = &self.output_state[output].xray;
+        let xray_bg = xray.background[RenderTarget::Output as usize].borrow();
+        let xray_bd = xray.backdrop[RenderTarget::Output as usize].borrow();
+
+        for layer in layer_map_for_output(output).layers() {
+            let surface = layer.wl_surface();
+            let is_background = layer.layer() == Layer::Background;
+
+            with_surfaces_surface_tree(surface, |surface, states| {
+                let primary_scanout_output = states
+                    .data_map
+                    .get_or_insert_threadsafe(Mutex::<PrimaryScanoutOutput>::default);
+                let mut primary_scanout_output = primary_scanout_output.lock().unwrap();
+                let mut id = Id::from_wayland_resource(surface);
+
+                // Background layers may be invisible normally but visible through an xray
+                // background effect. Try to find it and use the xray element's id in this case.
+                //
+                // FIXME: this won't work if there's another layer of offscreen (e.g. window with
+                // an xray background during its opening animation). But hopefully with the
+                // refactor to draw background effects outside offscreens it won't be a problem.
+                if is_background && !render_element_states.element_was_presented(id.clone()) {
+                    // A layer may be present either in background or backdrop, never in both.
+                    if xray_bg
+                        .render_element_states()
+                        .is_some_and(|s| s.element_was_presented(id.clone()))
+                    {
+                        id = xray_bg.id().clone();
+                    } else if xray_bd
+                        .render_element_states()
+                        .is_some_and(|s| s.element_was_presented(id.clone()))
+                    {
+                        id = xray_bd.id().clone();
+                    }
+                }
+
+                primary_scanout_output.update_from_render_element_states(
+                    id,
                     output,
-                    states,
                     render_element_states,
                     // Layer surfaces are shown only on one output at a time.
                     |_, _, output, _| output,
                 );
             });
+
+            // Popups never go into xray buffers.
+            for (popup, _) in PopupManager::popups_for_surface(surface) {
+                let surface = popup.wl_surface();
+                with_surfaces_surface_tree(surface, |surface, states| {
+                    update_surface_primary_scanout_output(
+                        surface,
+                        output,
+                        states,
+                        render_element_states,
+                        // Layer surfaces are shown only on one output at a time.
+                        |_, _, output, _| output,
+                    );
+                });
+            }
         }
 
         if let Some(surface) = &self.output_state[output].lock_surface {
@@ -4920,6 +5170,7 @@ impl Niri {
                         let ctx = RenderCtx {
                             renderer,
                             target: RenderTarget::ScreenCapture,
+                            xray: None,
                         };
                         self.render_to_vec(ctx, output, true)
                     });
@@ -4987,6 +5238,7 @@ impl Niri {
         let ctx = RenderCtx {
             renderer,
             target: RenderTarget::ScreenCapture,
+            xray: None,
         };
         let elements = self.render_to_vec(ctx, output, screencopy.overlay_cursor());
 
@@ -5112,7 +5364,11 @@ impl Niri {
                 RenderTarget::ScreenCapture,
             ];
             let screenshot = targets.map(|target| {
-                let ctx = RenderCtx { renderer, target };
+                let ctx = RenderCtx {
+                    renderer,
+                    target,
+                    xray: None,
+                };
                 let elements = self.render_to_vec(ctx, &output, false);
                 let elements = elements.iter().rev();
 
@@ -5193,6 +5449,7 @@ impl Niri {
         let ctx = RenderCtx {
             renderer,
             target: RenderTarget::ScreenCapture,
+            xray: None,
         };
         let elements = self.render_to_vec(ctx, output, include_pointer);
         let elements = elements.iter().rev();
@@ -5247,6 +5504,7 @@ impl Niri {
         let ctx = RenderCtx {
             renderer,
             target: RenderTarget::ScreenCapture,
+            xray: None,
         };
         mapped.render(
             ctx,
@@ -5411,6 +5669,7 @@ impl Niri {
         let ctx = RenderCtx {
             renderer,
             target: RenderTarget::ScreenCapture,
+            xray: None,
         };
         let elements = self.render_to_vec(ctx, &output, include_pointer);
         let elements = elements.iter().rev();
@@ -5885,7 +6144,11 @@ impl Niri {
                     RenderTarget::ScreenCapture,
                 ];
                 let textures = targets.map(|target| {
-                    let ctx = RenderCtx { renderer, target };
+                    let ctx = RenderCtx {
+                        renderer,
+                        target,
+                        xray: None,
+                    };
                     let elements = self.render_to_vec(ctx, &output, false);
                     let elements = elements.iter().rev();
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -4688,6 +4688,7 @@ impl Niri {
                         surface,
                         output,
                         states,
+                        None,
                         render_element_states,
                         default_primary_scanout_output_compare,
                     );
@@ -4706,6 +4707,7 @@ impl Niri {
                         surface,
                         output,
                         states,
+                        None,
                         render_element_states,
                         default_primary_scanout_output_compare,
                     );
@@ -4762,6 +4764,7 @@ impl Niri {
                 primary_scanout_output.update_from_render_element_states(
                     id,
                     output,
+                    None,
                     render_element_states,
                     |_, _, output, _| output,
                 );
@@ -4807,6 +4810,7 @@ impl Niri {
                 primary_scanout_output.update_from_render_element_states(
                     id,
                     output,
+                    None,
                     render_element_states,
                     // Layer surfaces are shown only on one output at a time.
                     |_, _, output, _| output,
@@ -4821,6 +4825,7 @@ impl Niri {
                         surface,
                         output,
                         states,
+                        None,
                         render_element_states,
                         // Layer surfaces are shown only on one output at a time.
                         |_, _, output, _| output,
@@ -4839,6 +4844,7 @@ impl Niri {
                         surface,
                         output,
                         states,
+                        None,
                         render_element_states,
                         default_primary_scanout_output_compare,
                     );
@@ -5110,7 +5116,11 @@ impl Niri {
                 &mut feedback,
                 surface_primary_scanout_output,
                 |surface, _| {
-                    surface_presentation_feedback_flags_from_states(surface, render_element_states)
+                    surface_presentation_feedback_flags_from_states(
+                        surface,
+                        None,
+                        render_element_states,
+                    )
                 },
             );
         }
@@ -5121,7 +5131,11 @@ impl Niri {
                 &mut feedback,
                 surface_primary_scanout_output,
                 |surface, _| {
-                    surface_presentation_feedback_flags_from_states(surface, render_element_states)
+                    surface_presentation_feedback_flags_from_states(
+                        surface,
+                        None,
+                        render_element_states,
+                    )
                 },
             );
         }
@@ -5131,7 +5145,11 @@ impl Niri {
                 &mut feedback,
                 surface_primary_scanout_output,
                 |surface, _| {
-                    surface_presentation_feedback_flags_from_states(surface, render_element_states)
+                    surface_presentation_feedback_flags_from_states(
+                        surface,
+                        None,
+                        render_element_states,
+                    )
                 },
             )
         }
@@ -5141,7 +5159,11 @@ impl Niri {
                 &mut feedback,
                 surface_primary_scanout_output,
                 |surface, _| {
-                    surface_presentation_feedback_flags_from_states(surface, render_element_states)
+                    surface_presentation_feedback_flags_from_states(
+                        surface,
+                        None,
+                        render_element_states,
+                    )
                 },
             );
         }
@@ -5152,7 +5174,11 @@ impl Niri {
                 &mut feedback,
                 surface_primary_scanout_output,
                 |surface, _| {
-                    surface_presentation_feedback_flags_from_states(surface, render_element_states)
+                    surface_presentation_feedback_flags_from_states(
+                        surface,
+                        None,
+                        render_element_states,
+                    )
                 },
             );
         }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -4271,33 +4271,41 @@ impl Niri {
         // We use macros instead of closures to avoid borrowing issues (renderer and push() go
         // into different functions).
         macro_rules! push_popups_from_layer {
-            ($layer:expr, $backdrop:expr, $push:expr) => {{
-                self.render_layer_popups(ctx.r(), &layer_map, $layer, $backdrop, $push);
+            ($layer:expr, $ns:expr, $backdrop:expr, $push:expr) => {{
+                self.render_layer_popups(ctx.r(), $ns, &layer_map, $layer, $backdrop, $push);
             }};
             ($layer:expr, true) => {{
-                push_popups_from_layer!($layer, true, &mut |elem| push(elem.into()));
+                push_popups_from_layer!($layer, None, true, &mut |elem| push(elem.into()));
             }};
-            ($layer:expr, $push:expr) => {{
-                push_popups_from_layer!($layer, false, $push);
+            ($layer:expr, $ns:expr, $push:expr) => {{
+                push_popups_from_layer!($layer, $ns, false, $push);
             }};
             ($layer:expr) => {{
-                push_popups_from_layer!($layer, false, &mut |elem| push(elem.into()));
+                push_popups_from_layer!($layer, None, false, &mut |elem| push(elem.into()));
             }};
         }
         macro_rules! push_normal_from_layer {
-            ($layer:expr, $xray_pos:expr, $backdrop:expr, $push:expr) => {{
-                self.render_layer_normal(ctx.r(), &layer_map, $layer, $xray_pos, $backdrop, $push);
+            ($layer:expr, $ns:expr, $xray_pos:expr, $backdrop:expr, $push:expr) => {{
+                self.render_layer_normal(
+                    ctx.r(),
+                    $ns,
+                    &layer_map,
+                    $layer,
+                    $xray_pos,
+                    $backdrop,
+                    $push,
+                );
             }};
             ($layer:expr, true) => {{
-                push_normal_from_layer!($layer, XrayPos::default(), true, &mut |elem| {
+                push_normal_from_layer!($layer, None, XrayPos::default(), true, &mut |elem| {
                     push(elem.into())
                 });
             }};
-            ($layer:expr, $xray_pos:expr, $push:expr) => {{
-                push_normal_from_layer!($layer, $xray_pos, false, $push);
+            ($layer:expr, $ns:expr, $xray_pos:expr, $push:expr) => {{
+                push_normal_from_layer!($layer, $ns, $xray_pos, false, $push);
             }};
             ($layer:expr) => {{
-                push_normal_from_layer!($layer, XrayPos::default(), false, &mut |elem| {
+                push_normal_from_layer!($layer, None, XrayPos::default(), false, &mut |elem| {
                     push(elem.into())
                 });
             }};
@@ -4349,17 +4357,27 @@ impl Niri {
                 }};
             }
 
-            for (_ws, geo) in mon.workspaces_with_render_geo() {
-                push_popups_from_layer!(Layer::Bottom, process!(geo));
-                push_popups_from_layer!(Layer::Background, process!(geo));
+            for (ws, geo) in mon.workspaces_with_render_geo() {
+                let ns = Some(ws.id().get() as usize);
+                push_popups_from_layer!(Layer::Bottom, ns, process!(geo));
+                push_popups_from_layer!(Layer::Background, ns, process!(geo));
             }
 
             mon.render_workspaces(ctx.r(), focus_ring, &mut |elem| push(elem.into()));
 
             for (ws, geo) in mon.workspaces_with_render_geo() {
+                // The render element namespace. This will be set to the workspace index for
+                // elements duplicated across workspaces (i.e. background and bottom layers) in
+                // order to have their non-xray framebuffer effects separated from each other.
+                //
+                // This doesn't have to correspond exactly to workspace id or idx, the only
+                // requirement is that there's only one framebuffer effect element with a given id +
+                // namespace on the frame at once. Id + namespace is used as the cache key in the
+                // damage tracker.
+                let ns = Some(ws.id().get() as usize);
                 let xray_pos = XrayPos::new(geo.loc, zoom);
-                push_normal_from_layer!(Layer::Bottom, xray_pos, process!(geo));
-                push_normal_from_layer!(Layer::Background, xray_pos, process!(geo));
+                push_normal_from_layer!(Layer::Bottom, ns, xray_pos, process!(geo));
+                push_normal_from_layer!(Layer::Background, ns, xray_pos, process!(geo));
 
                 process!(geo)(ws.render_background());
             }
@@ -4402,6 +4420,7 @@ impl Niri {
             elements.clear();
             self.render_layer_normal(
                 ctx.r(),
+                None,
                 &layer_map,
                 Layer::Background,
                 XrayPos::default(),
@@ -4418,6 +4437,7 @@ impl Niri {
             elements.clear();
             self.render_layer_normal(
                 ctx.r(),
+                None,
                 &layer_map,
                 Layer::Background,
                 XrayPos::default(),
@@ -4481,6 +4501,7 @@ impl Niri {
     fn render_layer_normal<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
+        ns: Option<usize>,
         layer_map: &LayerMap,
         layer: Layer,
         xray_pos: XrayPos,
@@ -4490,13 +4511,14 @@ impl Niri {
         for (mapped, geo) in self.layers_in_render_order(layer_map, layer, for_backdrop) {
             let loc = geo.loc.to_f64();
             let xray_pos = xray_pos.offset(loc);
-            mapped.render_normal(ctx.r(), loc, xray_pos, push);
+            mapped.render_normal(ctx.r(), ns, loc, xray_pos, push);
         }
     }
 
     fn render_layer_popups<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
+        _ns: Option<usize>,
         layer_map: &LayerMap,
         layer: Layer,
         for_backdrop: bool,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1,4 +1,4 @@
-use std::cell::{Cell, OnceCell, RefCell};
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::os::unix::net::UnixStream;
@@ -28,7 +28,7 @@ use smithay::backend::renderer::element::utils::{
     RescaleRenderElement,
 };
 use smithay::backend::renderer::element::{
-    default_primary_scanout_output_compare, Element, Id, Kind, PrimaryScanoutOutput,
+    default_primary_scanout_output_compare, Element, Id, Kind, PrimaryScanoutOutput, RenderElement,
     RenderElementStates,
 };
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -5194,57 +5194,65 @@ impl Niri {
         let _span = tracy_client::span!("Niri::render_for_screencopy_with_damage");
 
         let mut screencopy_state = mem::take(&mut self.screencopy_state);
-        let elements = OnceCell::new();
 
         screencopy_state.with_queues_mut(|queue| {
             let (damage_tracker, screencopy) = queue.split();
             if let Some(screencopy) = screencopy {
                 if screencopy.output() == output {
-                    let elements = elements.get_or_init(|| {
-                        let ctx = RenderCtx {
-                            renderer,
-                            target: RenderTarget::ScreenCapture,
-                            xray: None,
-                        };
-                        self.render_to_vec(ctx, output, true)
-                    });
-                    // FIXME: skip elements if not including pointers
-                    let render_result = Self::render_for_screencopy_internal(
+                    let ctx = RenderCtx {
                         renderer,
+                        target: RenderTarget::ScreenCapture,
+                        xray: None,
+                    };
+                    let offset = screencopy.region_loc().upscale(-1);
+                    let mut elements = Vec::new();
+                    self.render(ctx, output, screencopy.overlay_cursor(), &mut |elem| {
+                        let elem =
+                            RelocateRenderElement::from_element(elem, offset, Relocate::Relative);
+                        elements.push(elem);
+                    });
+
+                    let (damages, states) = Self::damage_screencopy_internal(
                         output,
-                        elements,
-                        true,
+                        &elements,
                         damage_tracker,
                         screencopy,
                     );
-                    match render_result {
-                        Ok((sync, damages)) => {
-                            if let Some(damages) = damages {
-                                // Convert from Physical coordinates back to Buffer coordinates.
-                                let transform = output.current_transform();
-                                let physical_size =
-                                    transform.transform_size(screencopy.buffer_size());
-                                let damages = damages.iter().map(|dmg| {
-                                    dmg.to_logical(1).to_buffer(
-                                        1,
-                                        transform.invert(),
-                                        &physical_size.to_logical(1),
-                                    )
-                                });
+                    if let Some(damages) = damages {
+                        // Convert from Physical coordinates back to Buffer coordinates.
+                        let transform = output.current_transform();
+                        let physical_size = transform.transform_size(screencopy.buffer_size());
+                        let damages = damages.iter().map(|dmg| {
+                            dmg.to_logical(1).to_buffer(
+                                1,
+                                transform.invert(),
+                                &physical_size.to_logical(1),
+                            )
+                        });
 
-                                screencopy.damage(damages);
+                        screencopy.damage(damages);
+
+                        let render_result = Self::render_for_screencopy_internal(
+                            renderer,
+                            damage_tracker,
+                            &elements,
+                            states,
+                            screencopy,
+                        );
+                        match render_result {
+                            Ok(sync) => {
                                 queue.pop().submit_after_sync(false, sync, &self.event_loop);
-                            } else {
-                                trace!("no damage found, waiting till next redraw");
+                            }
+                            Err(err) => {
+                                // Recreate damage tracker to report full damage next check.
+                                *damage_tracker =
+                                    OutputDamageTracker::new((0, 0), 1.0, Transform::Normal);
+                                queue.pop();
+                                warn!("error rendering for screencopy: {err:?}");
                             }
                         }
-                        Err(err) => {
-                            // Recreate damage tracker to report full damage next check.
-                            *damage_tracker =
-                                OutputDamageTracker::new((0, 0), 1.0, Transform::Normal);
-                            queue.pop();
-                            warn!("error rendering for screencopy: {err:?}");
-                        }
+                    } else {
+                        trace!("no damage found, waiting till next redraw");
                     }
                 };
             }
@@ -5274,24 +5282,28 @@ impl Niri {
             target: RenderTarget::ScreenCapture,
             xray: None,
         };
-        let elements = self.render_to_vec(ctx, output, screencopy.overlay_cursor());
+        let offset = screencopy.region_loc().upscale(-1);
+        let mut elements = Vec::new();
+        self.render(ctx, output, screencopy.overlay_cursor(), &mut |elem| {
+            let elem = RelocateRenderElement::from_element(elem, offset, Relocate::Relative);
+            elements.push(elem);
+        });
 
         let Some(damage_tracker) = self.screencopy_state.damage_tracker(manager) else {
             error!("screencopy queue must not be deleted as long as frames exist");
             bail!("screencopy queue missing");
         };
 
-        let render_result = Self::render_for_screencopy_internal(
+        let (_damages, states) =
+            Self::damage_screencopy_internal(output, &elements, damage_tracker, &screencopy);
+        let res = Self::render_for_screencopy_internal(
             renderer,
-            output,
-            &elements,
-            false,
             damage_tracker,
+            &elements,
+            states,
             &screencopy,
         );
-
-        let res = render_result
-            .map(|(sync, _damage)| screencopy.submit_after_sync(false, sync, &self.event_loop));
+        let res = res.map(|sync| screencopy.submit_after_sync(false, sync, &self.event_loop));
 
         if res.is_err() {
             // Recreate damage tracker to report full damage next check.
@@ -5301,15 +5313,15 @@ impl Niri {
         res
     }
 
-    #[allow(clippy::type_complexity)]
-    fn render_for_screencopy_internal<'a>(
-        renderer: &mut GlesRenderer,
+    fn damage_screencopy_internal<'a>(
         output: &Output,
-        elements: &[OutputRenderElements<GlesRenderer>],
-        with_damage: bool,
+        elements: &[impl Element],
         damage_tracker: &'a mut OutputDamageTracker,
         screencopy: &Screencopy,
-    ) -> anyhow::Result<(Option<SyncPoint>, Option<&'a Vec<Rectangle<i32, Physical>>>)> {
+    ) -> (
+        Option<&'a Vec<Rectangle<i32, Physical>>>,
+        RenderElementStates,
+    ) {
         let OutputModeSource::Static {
             size: last_size,
             scale: last_scale,
@@ -5327,41 +5339,33 @@ impl Niri {
             *damage_tracker = OutputDamageTracker::new(size, scale, transform);
         }
 
-        let region_loc = screencopy.region_loc();
-        let elements = elements
-            .iter()
-            .map(|element| {
-                RelocateRenderElement::from_element(
-                    element,
-                    region_loc.upscale(-1),
-                    Relocate::Relative,
-                )
-            })
-            .collect::<Vec<_>>();
-
         // Just checked damage tracker has static mode
-        let damages = damage_tracker.damage_output(1, &elements).unwrap().0;
-        if with_damage && damages.is_none() {
-            return Ok((None, None));
-        }
+        damage_tracker.damage_output(1, elements).unwrap()
+    }
 
-        let elements = elements.iter().rev();
-
+    #[allow(clippy::type_complexity)]
+    fn render_for_screencopy_internal(
+        renderer: &mut GlesRenderer,
+        damage_tracker: &mut OutputDamageTracker,
+        elements: &[impl RenderElement<GlesRenderer>],
+        states: RenderElementStates,
+        screencopy: &Screencopy,
+    ) -> anyhow::Result<Option<SyncPoint>> {
         let sync = match screencopy.buffer() {
             ScreencopyBuffer::Dmabuf(dmabuf) => {
                 let sync =
-                    render_to_dmabuf(renderer, dmabuf.clone(), size, scale, transform, elements)
+                    render_to_dmabuf(renderer, damage_tracker, dmabuf.clone(), elements, states)
                         .context("error rendering to screencopy dmabuf")?;
                 Some(sync)
             }
             ScreencopyBuffer::Shm(wl_buffer) => {
-                render_to_shm(renderer, wl_buffer, size, scale, transform, elements)
+                render_to_shm(renderer, damage_tracker, wl_buffer, elements, states)
                     .context("error rendering to screencopy shm buffer")?;
                 None
             }
         };
 
-        Ok((sync, damages))
+        Ok(sync)
     }
 
     #[cfg(not(feature = "xdp-gnome-screencast"))]

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -4518,14 +4518,14 @@ impl Niri {
     fn render_layer_popups<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
-        _ns: Option<usize>,
+        ns: Option<usize>,
         layer_map: &LayerMap,
         layer: Layer,
         for_backdrop: bool,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
         for (mapped, geo) in self.layers_in_render_order(layer_map, layer, for_backdrop) {
-            mapped.render_popups(ctx.r(), geo.loc.to_f64(), push);
+            mapped.render_popups(ctx.r(), ns, geo.loc.to_f64(), push);
         }
     }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -71,6 +71,7 @@ use smithay::utils::{
     ClockSource, IsAlive as _, Logical, Monotonic, Physical, Point, Rectangle, Scale, Size,
     Transform, SERIAL_COUNTER,
 };
+use smithay::wayland::background_effect::BackgroundEffectState;
 use smithay::wayland::compositor::{
     with_states, with_surface_tree_downward, CompositorClientState, CompositorHandler,
     CompositorState, HookId, SurfaceData, TraversalAction,
@@ -280,6 +281,7 @@ pub struct Niri {
     pub screencopy_state: ScreencopyManagerState,
     pub output_management_state: OutputManagementManagerState,
     pub viewporter_state: ViewporterState,
+    pub background_effect_state: BackgroundEffectState,
     pub xdg_foreign_state: XdgForeignState,
     pub shm_state: ShmState,
     pub output_manager_state: OutputManagerState,
@@ -2329,6 +2331,7 @@ impl Niri {
         let screencopy_state =
             ScreencopyManagerState::new::<State, _>(&display_handle, client_is_unrestricted);
         let viewporter_state = ViewporterState::new::<State>(&display_handle);
+        let background_effect_state = BackgroundEffectState::new::<State>(&display_handle);
         let xdg_foreign_state = XdgForeignState::new::<State>(&display_handle);
 
         let is_tty = matches!(backend, Backend::Tty(_));
@@ -2512,6 +2515,7 @@ impl Niri {
             output_management_state,
             screencopy_state,
             viewporter_state,
+            background_effect_state,
             xdg_foreign_state,
             text_input_state,
             input_method_state,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -4050,6 +4050,7 @@ impl Niri {
             }
         }
 
+        let state = self.output_state.get(output).unwrap();
         let output_scale = Scale::from(output.current_scale().fractional_scale());
 
         let push = if self.debug_draw_opaque_regions {
@@ -4068,7 +4069,6 @@ impl Niri {
 
         // Next, the screen transition texture.
         {
-            let state = self.output_state.get(output).unwrap();
             if let Some(transition) = &state.screen_transition {
                 push(transition.render(ctx.target).into());
             }
@@ -4085,7 +4085,6 @@ impl Niri {
 
         // If the session is locked, draw the lock surface.
         if self.is_locked() {
-            let state = self.output_state.get(output).unwrap();
             if let Some(surface) = state.lock_surface.as_ref() {
                 push_elements_from_surface_tree(
                     ctx.renderer,
@@ -4113,7 +4112,6 @@ impl Niri {
         }
 
         // Prepare the background elements.
-        let state = self.output_state.get(output).unwrap();
         let backdrop = SolidColorRenderElement::from_buffer(
             &state.backdrop_buffer,
             (0., 0.),

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -149,6 +149,7 @@ use crate::protocols::mutter_x11_interop::MutterX11InteropManagerState;
 use crate::protocols::output_management::OutputManagementManagerState;
 use crate::protocols::screencopy::{Screencopy, ScreencopyBuffer, ScreencopyManagerState};
 use crate::protocols::virtual_pointer::VirtualPointerManagerState;
+use crate::render_helpers::blur::BlurOptions;
 use crate::render_helpers::debug::push_opaque_regions;
 use crate::render_helpers::primary_gpu_texture::PrimaryGpuTextureRenderElement;
 use crate::render_helpers::renderer::NiriRenderer;
@@ -4077,13 +4078,16 @@ impl Niri {
                     state.xray.workspaces.push((geo, bg_color));
                 }
                 state.xray.backdrop_color = state.backdrop_buffer.color();
+                let blur_options = BlurOptions::from(self.config.borrow().blur);
                 for buf in &state.xray.background {
                     let mut buffer = buf.borrow_mut();
                     buffer.update_size(size, scale);
+                    buffer.update_blur_options(blur_options);
                 }
                 for buf in &state.xray.backdrop {
                     let mut buffer = buf.borrow_mut();
                     buffer.update_size(size, scale);
+                    buffer.update_blur_options(blur_options);
                 }
 
                 let layer_map = layer_map_for_output(out);

--- a/src/render_helpers/background_effect.rs
+++ b/src/render_helpers/background_effect.rs
@@ -1,15 +1,18 @@
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use niri_config::CornerRadius;
 use smithay::backend::renderer::gles::GlesRenderer;
-use smithay::utils::{Logical, Rectangle};
+use smithay::utils::{Logical, Point, Rectangle, Scale};
 use smithay::wayland::compositor::{with_states, SurfaceData};
 use wayland_server::protocol::wl_surface::WlSurface;
 
+use crate::handlers::background_effect::get_cached_blur_region;
 use crate::niri_render_elements;
 use crate::render_helpers::damage::ExtraDamage;
 use crate::render_helpers::xray::{XrayElement, XrayPos};
 use crate::render_helpers::RenderCtx;
+use crate::utils::region::TransformedRegion;
+use crate::utils::surface_geo;
 
 #[derive(Debug)]
 pub struct BackgroundEffect {
@@ -46,6 +49,10 @@ impl Options {
 pub struct RenderParams {
     /// Geometry of the background effect.
     pub geometry: Rectangle<f64, Logical>,
+    /// Effect subregion, will be clipped to `geometry`.
+    ///
+    /// `subregion.iter()` should return `geometry`-relative rectangles.
+    pub subregion: Option<TransformedRegion>,
     /// Geometry and radius for clipping in the same coordinate space as `geometry`.
     pub clip: Option<(Rectangle<f64, Logical>, CornerRadius)>,
     /// Scale to use for rounding to physical pixels.
@@ -80,6 +87,11 @@ impl BackgroundEffect {
         }
     }
 
+    /// Damage the background effect, for example when a blur subregion changes.
+    pub fn damage(&mut self) {
+        self.damage.damage_all();
+    }
+
     pub fn update_config(&mut self, config: niri_config::Blur) {
         if self.blur_config == config {
             return;
@@ -93,9 +105,17 @@ impl BackgroundEffect {
         &mut self,
         corner_radius: CornerRadius,
         effect: niri_config::BackgroundEffect,
+        has_blur_region: bool,
     ) {
+        // If the surface explicitly requests a blur region, default blur to true.
+        let blur = if has_blur_region {
+            effect.blur != Some(false)
+        } else {
+            effect.blur == Some(true)
+        };
+
         let mut options = Options {
-            blur: effect.blur == Some(true),
+            blur,
             xray: effect.xray == Some(true),
             noise: effect.noise,
             saturation: effect.saturation,
@@ -171,6 +191,62 @@ impl BackgroundEffect {
     }
 }
 
+fn render_params_for_tile(
+    geometry: Rectangle<f64, Logical>,
+    scale: f64,
+    clip_to_geometry: bool,
+    block_out: bool,
+    blur_region: Option<Arc<Vec<Rectangle<i32, Logical>>>>,
+    surface_geo: Rectangle<f64, Logical>,
+    surface_anim_scale: Scale<f64>,
+) -> Option<RenderParams> {
+    // Effects not requested by the surface itself are drawn to match the geometry.
+    let mut clip = true;
+
+    let mut effect_geometry = geometry;
+    let mut subregion = None;
+    if let Some(rects) = blur_region {
+        if rects.is_empty() {
+            // Surface has a set, but empty blur region.
+            return None;
+        } else {
+            // If the surface itself requests the effects, apply different defaults.
+            clip = clip_to_geometry;
+
+            // Use geometry-shaped blur for blocked-out windows to avoid unintentionally
+            // leaking any surface shapes. We render those windows as geometry-shaped solid
+            // rectangles anyway.
+            if block_out {
+                clip = true;
+            } else {
+                let mut surface_geo = surface_geo.upscale(surface_anim_scale);
+                surface_geo.loc += geometry.loc;
+
+                subregion = Some(TransformedRegion {
+                    rects,
+                    scale: surface_anim_scale,
+                    offset: surface_geo.loc,
+                });
+
+                surface_geo = surface_geo
+                    .to_physical_precise_round(scale)
+                    .to_logical(scale);
+                effect_geometry = surface_geo;
+            }
+        }
+    }
+
+    // This corner radius is reset to self.corner_radius in render().
+    let clip = clip.then_some((geometry, CornerRadius::default()));
+
+    Some(RenderParams {
+        geometry: effect_geometry,
+        subregion,
+        clip,
+        scale,
+    })
+}
+
 /// Per-surface background effect stored in its data map.
 struct SurfaceBackgroundEffect(Mutex<BackgroundEffect>);
 
@@ -179,6 +255,12 @@ impl SurfaceBackgroundEffect {
         states
             .data_map
             .get_or_insert(|| SurfaceBackgroundEffect(Mutex::new(BackgroundEffect::new())))
+    }
+}
+
+pub fn damage_surface(states: &SurfaceData) {
+    if let Some(effect) = states.data_map.get::<SurfaceBackgroundEffect>() {
+        effect.0.lock().unwrap().damage();
     }
 }
 
@@ -191,9 +273,12 @@ pub fn render_for_tile(
     scale: f64,
     clip_to_geometry: bool,
     surface: &WlSurface,
+    surface_off: Point<f64, Logical>,
+    surface_anim_scale: Scale<f64>,
     blur_config: niri_config::Blur,
     radius: CornerRadius,
     effect: niri_config::BackgroundEffect,
+    should_block_out: bool,
     xray_pos: XrayPos,
     push: &mut dyn FnMut(BackgroundEffectElement),
 ) {
@@ -201,19 +286,29 @@ pub fn render_for_tile(
         let background_effect = SurfaceBackgroundEffect::get(states);
         let mut background_effect = background_effect.0.lock().unwrap();
 
+        let blur_region = get_cached_blur_region(states);
+        let has_blur_region = blur_region.as_ref().is_some_and(|r| !r.is_empty());
+
         background_effect.update_config(blur_config);
-        background_effect.update_render_elements(radius, effect);
+        background_effect.update_render_elements(radius, effect, has_blur_region);
 
         if !background_effect.is_visible() {
             return;
         }
 
-        // Effects not requested by the surface itself are drawn to match the geometry.
-        let _ = clip_to_geometry;
-        let params = RenderParams {
+        let mut surface_geo = surface_geo(states).unwrap_or_default().to_f64();
+        surface_geo.loc += surface_off;
+
+        let Some(params) = render_params_for_tile(
             geometry,
-            clip: Some((geometry, CornerRadius::default())),
             scale,
+            clip_to_geometry,
+            should_block_out,
+            blur_region,
+            surface_geo,
+            surface_anim_scale,
+        ) else {
+            return;
         };
 
         let xray_pos = xray_pos.offset(params.geometry.loc - geometry.loc);

--- a/src/render_helpers/background_effect.rs
+++ b/src/render_helpers/background_effect.rs
@@ -20,11 +20,13 @@ pub struct BackgroundEffect {
     /// Stored here in addition to `RenderParams` to damage when it changes.
     // FIXME: would be good to remove this duplication of radius.
     corner_radius: CornerRadius,
+    blur_config: niri_config::Blur,
     options: Options,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Options {
+    pub blur: bool,
     pub xray: bool,
     pub noise: Option<f64>,
     pub saturation: Option<f64>,
@@ -32,7 +34,10 @@ pub struct Options {
 
 impl Options {
     fn is_visible(&self) -> bool {
-        self.xray || self.noise.is_some_and(|x| x > 0.) || self.saturation.is_some_and(|x| x != 1.)
+        self.xray
+            || self.blur
+            || self.noise.is_some_and(|x| x > 0.)
+            || self.saturation.is_some_and(|x| x != 1.)
     }
 }
 
@@ -70,8 +75,18 @@ impl BackgroundEffect {
         Self {
             damage: ExtraDamage::new(),
             corner_radius: CornerRadius::default(),
+            blur_config: niri_config::Blur::default(),
             options: Options::default(),
         }
+    }
+
+    pub fn update_config(&mut self, config: niri_config::Blur) {
+        if self.blur_config == config {
+            return;
+        }
+
+        self.blur_config = config;
+        self.damage.damage_all();
     }
 
     pub fn update_render_elements(
@@ -80,6 +95,7 @@ impl BackgroundEffect {
         effect: niri_config::BackgroundEffect,
     ) {
         let mut options = Options {
+            blur: effect.blur == Some(true),
             xray: effect.xray == Some(true),
             noise: effect.noise,
             saturation: effect.saturation,
@@ -122,8 +138,17 @@ impl BackgroundEffect {
 
         let damage = self.damage.render(params.geometry);
 
-        let noise = self.options.noise.unwrap_or(0.) as f32;
-        let saturation = self.options.saturation.unwrap_or(1.) as f32;
+        // Use noise/saturation from options, falling back to blur defaults if blurred, and
+        // to no effect if not blurred.
+        let blur = self.options.blur && !self.blur_config.off;
+        let noise = if blur { self.blur_config.noise } else { 0. };
+        let noise = self.options.noise.unwrap_or(noise) as f32;
+        let saturation = if blur {
+            self.blur_config.saturation
+        } else {
+            1.
+        };
+        let saturation = self.options.saturation.unwrap_or(saturation) as f32;
 
         if self.options.xray {
             let Some(xray) = ctx.xray else {
@@ -131,9 +156,15 @@ impl BackgroundEffect {
             };
 
             push(damage.into());
-            xray.render(ctx, params, xray_pos, noise, saturation, &mut |elem| {
-                push(elem.into())
-            });
+            xray.render(
+                ctx,
+                params,
+                xray_pos,
+                blur,
+                noise,
+                saturation,
+                &mut |elem| push(elem.into()),
+            );
         } else {
             // Render non-xray effect.
         }
@@ -160,6 +191,7 @@ pub fn render_for_tile(
     scale: f64,
     clip_to_geometry: bool,
     surface: &WlSurface,
+    blur_config: niri_config::Blur,
     radius: CornerRadius,
     effect: niri_config::BackgroundEffect,
     xray_pos: XrayPos,
@@ -169,6 +201,7 @@ pub fn render_for_tile(
         let background_effect = SurfaceBackgroundEffect::get(states);
         let mut background_effect = background_effect.0.lock().unwrap();
 
+        background_effect.update_config(blur_config);
         background_effect.update_render_elements(radius, effect);
 
         if !background_effect.is_visible() {

--- a/src/render_helpers/background_effect.rs
+++ b/src/render_helpers/background_effect.rs
@@ -26,11 +26,13 @@ pub struct BackgroundEffect {
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Options {
     pub xray: bool,
+    pub noise: Option<f64>,
+    pub saturation: Option<f64>,
 }
 
 impl Options {
     fn is_visible(&self) -> bool {
-        self.xray
+        self.xray || self.noise.is_some_and(|x| x > 0.) || self.saturation.is_some_and(|x| x != 1.)
     }
 }
 
@@ -77,9 +79,17 @@ impl BackgroundEffect {
         corner_radius: CornerRadius,
         effect: niri_config::BackgroundEffect,
     ) {
-        let options = Options {
+        let mut options = Options {
             xray: effect.xray == Some(true),
+            noise: effect.noise,
+            saturation: effect.saturation,
         };
+
+        // If we have some background effect but xray wasn't explicitly set, default it to true
+        // since it's cheaper.
+        if options.is_visible() && effect.xray.is_none() {
+            options.xray = true;
+        }
 
         if self.options == options && self.corner_radius == corner_radius {
             return;
@@ -112,13 +122,18 @@ impl BackgroundEffect {
 
         let damage = self.damage.render(params.geometry);
 
+        let noise = self.options.noise.unwrap_or(0.) as f32;
+        let saturation = self.options.saturation.unwrap_or(1.) as f32;
+
         if self.options.xray {
             let Some(xray) = ctx.xray else {
                 return;
             };
 
             push(damage.into());
-            xray.render(ctx, params, xray_pos, &mut |elem| push(elem.into()));
+            xray.render(ctx, params, xray_pos, noise, saturation, &mut |elem| {
+                push(elem.into())
+            });
         } else {
             // Render non-xray effect.
         }

--- a/src/render_helpers/background_effect.rs
+++ b/src/render_helpers/background_effect.rs
@@ -1,0 +1,174 @@
+use std::sync::Mutex;
+
+use niri_config::CornerRadius;
+use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::utils::{Logical, Rectangle};
+use smithay::wayland::compositor::{with_states, SurfaceData};
+use wayland_server::protocol::wl_surface::WlSurface;
+
+use crate::niri_render_elements;
+use crate::render_helpers::damage::ExtraDamage;
+use crate::render_helpers::xray::{XrayElement, XrayPos};
+use crate::render_helpers::RenderCtx;
+
+#[derive(Debug)]
+pub struct BackgroundEffect {
+    /// Damage when options change.
+    damage: ExtraDamage,
+    /// Corner radius for clipping.
+    ///
+    /// Stored here in addition to `RenderParams` to damage when it changes.
+    // FIXME: would be good to remove this duplication of radius.
+    corner_radius: CornerRadius,
+    options: Options,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Options {
+    pub xray: bool,
+}
+
+impl Options {
+    fn is_visible(&self) -> bool {
+        self.xray
+    }
+}
+
+/// Render-time parameters.
+#[derive(Debug)]
+pub struct RenderParams {
+    /// Geometry of the background effect.
+    pub geometry: Rectangle<f64, Logical>,
+    /// Geometry and radius for clipping in the same coordinate space as `geometry`.
+    pub clip: Option<(Rectangle<f64, Logical>, CornerRadius)>,
+    /// Scale to use for rounding to physical pixels.
+    pub scale: f64,
+}
+
+impl RenderParams {
+    fn fit_clip_radius(&mut self) {
+        if let Some((geo, radius)) = &mut self.clip {
+            // HACK: increase radius to avoid slight bleed on rounded corners.
+            *radius = radius.expanded_by(1.);
+
+            *radius = radius.fit_to(geo.size.w as f32, geo.size.h as f32);
+        }
+    }
+}
+
+niri_render_elements! {
+    BackgroundEffectElement => {
+        Xray = XrayElement,
+        ExtraDamage = ExtraDamage,
+    }
+}
+
+impl BackgroundEffect {
+    pub fn new() -> Self {
+        Self {
+            damage: ExtraDamage::new(),
+            corner_radius: CornerRadius::default(),
+            options: Options::default(),
+        }
+    }
+
+    pub fn update_render_elements(
+        &mut self,
+        corner_radius: CornerRadius,
+        effect: niri_config::BackgroundEffect,
+    ) {
+        let options = Options {
+            xray: effect.xray == Some(true),
+        };
+
+        if self.options == options && self.corner_radius == corner_radius {
+            return;
+        }
+
+        self.options = options;
+        self.corner_radius = corner_radius;
+        self.damage.damage_all();
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.options.is_visible()
+    }
+
+    pub fn render(
+        &self,
+        ctx: RenderCtx<GlesRenderer>,
+        mut params: RenderParams,
+        xray_pos: XrayPos,
+        push: &mut dyn FnMut(BackgroundEffectElement),
+    ) {
+        if !self.is_visible() {
+            return;
+        }
+
+        if let Some(clip) = &mut params.clip {
+            clip.1 = self.corner_radius;
+        }
+        params.fit_clip_radius();
+
+        let damage = self.damage.render(params.geometry);
+
+        if self.options.xray {
+            let Some(xray) = ctx.xray else {
+                return;
+            };
+
+            push(damage.into());
+            xray.render(ctx, params, xray_pos, &mut |elem| push(elem.into()));
+        } else {
+            // Render non-xray effect.
+        }
+    }
+}
+
+/// Per-surface background effect stored in its data map.
+struct SurfaceBackgroundEffect(Mutex<BackgroundEffect>);
+
+impl SurfaceBackgroundEffect {
+    fn get(states: &SurfaceData) -> &Self {
+        states
+            .data_map
+            .get_or_insert(|| SurfaceBackgroundEffect(Mutex::new(BackgroundEffect::new())))
+    }
+}
+
+// Silence, Clippy
+// A Smithay user is talking
+#[allow(clippy::too_many_arguments)]
+pub fn render_for_tile(
+    ctx: RenderCtx<GlesRenderer>,
+    geometry: Rectangle<f64, Logical>,
+    scale: f64,
+    clip_to_geometry: bool,
+    surface: &WlSurface,
+    radius: CornerRadius,
+    effect: niri_config::BackgroundEffect,
+    xray_pos: XrayPos,
+    push: &mut dyn FnMut(BackgroundEffectElement),
+) {
+    with_states(surface, |states| {
+        let background_effect = SurfaceBackgroundEffect::get(states);
+        let mut background_effect = background_effect.0.lock().unwrap();
+
+        background_effect.update_render_elements(radius, effect);
+
+        if !background_effect.is_visible() {
+            return;
+        }
+
+        // Effects not requested by the surface itself are drawn to match the geometry.
+        let _ = clip_to_geometry;
+        let params = RenderParams {
+            geometry,
+            clip: Some((geometry, CornerRadius::default())),
+            scale,
+        };
+
+        let xray_pos = xray_pos.offset(params.geometry.loc - geometry.loc);
+        background_effect.render(ctx, params, xray_pos, push);
+    });
+}

--- a/src/render_helpers/background_effect.rs
+++ b/src/render_helpers/background_effect.rs
@@ -8,7 +8,9 @@ use wayland_server::protocol::wl_surface::WlSurface;
 
 use crate::handlers::background_effect::get_cached_blur_region;
 use crate::niri_render_elements;
+use crate::render_helpers::blur::BlurOptions;
 use crate::render_helpers::damage::ExtraDamage;
+use crate::render_helpers::framebuffer_effect::{FramebufferEffect, FramebufferEffectElement};
 use crate::render_helpers::xray::{XrayElement, XrayPos};
 use crate::render_helpers::RenderCtx;
 use crate::utils::region::TransformedRegion;
@@ -16,6 +18,7 @@ use crate::utils::surface_geo;
 
 #[derive(Debug)]
 pub struct BackgroundEffect {
+    nonxray: FramebufferEffect,
     /// Damage when options change.
     damage: ExtraDamage,
     /// Corner radius for clipping.
@@ -72,6 +75,7 @@ impl RenderParams {
 
 niri_render_elements! {
     BackgroundEffectElement => {
+        FramebufferEffect = FramebufferEffectElement,
         Xray = XrayElement,
         ExtraDamage = ExtraDamage,
     }
@@ -80,6 +84,7 @@ niri_render_elements! {
 impl BackgroundEffect {
     pub fn new() -> Self {
         Self {
+            nonxray: FramebufferEffect::new(),
             damage: ExtraDamage::new(),
             corner_radius: CornerRadius::default(),
             blur_config: niri_config::Blur::default(),
@@ -90,6 +95,7 @@ impl BackgroundEffect {
     /// Damage the background effect, for example when a blur subregion changes.
     pub fn damage(&mut self) {
         self.damage.damage_all();
+        self.nonxray.damage();
     }
 
     pub fn update_config(&mut self, config: niri_config::Blur) {
@@ -99,6 +105,7 @@ impl BackgroundEffect {
 
         self.blur_config = config;
         self.damage.damage_all();
+        self.nonxray.damage();
     }
 
     pub fn update_render_elements(
@@ -134,6 +141,7 @@ impl BackgroundEffect {
         self.options = options;
         self.corner_radius = corner_radius;
         self.damage.damage_all();
+        self.nonxray.damage();
     }
 
     pub fn is_visible(&self) -> bool {
@@ -143,6 +151,7 @@ impl BackgroundEffect {
     pub fn render(
         &self,
         ctx: RenderCtx<GlesRenderer>,
+        ns: Option<usize>,
         mut params: RenderParams,
         xray_pos: XrayPos,
         push: &mut dyn FnMut(BackgroundEffectElement),
@@ -161,6 +170,7 @@ impl BackgroundEffect {
         // Use noise/saturation from options, falling back to blur defaults if blurred, and
         // to no effect if not blurred.
         let blur = self.options.blur && !self.blur_config.off;
+        let blur_options = blur.then_some(BlurOptions::from(self.blur_config));
         let noise = if blur { self.blur_config.noise } else { 0. };
         let noise = self.options.noise.unwrap_or(noise) as f32;
         let saturation = if blur {
@@ -187,6 +197,10 @@ impl BackgroundEffect {
             );
         } else {
             // Render non-xray effect.
+            let elem = self
+                .nonxray
+                .render(ns, params, blur_options, noise, saturation);
+            push(elem.into());
         }
     }
 }
@@ -269,6 +283,7 @@ pub fn damage_surface(states: &SurfaceData) {
 #[allow(clippy::too_many_arguments)]
 pub fn render_for_tile(
     ctx: RenderCtx<GlesRenderer>,
+    ns: Option<usize>,
     geometry: Rectangle<f64, Logical>,
     scale: f64,
     clip_to_geometry: bool,
@@ -312,6 +327,6 @@ pub fn render_for_tile(
         };
 
         let xray_pos = xray_pos.offset(params.geometry.loc - geometry.loc);
-        background_effect.render(ctx, params, xray_pos, push);
+        background_effect.render(ctx, ns, params, xray_pos, push);
     });
 }

--- a/src/render_helpers/blur.rs
+++ b/src/render_helpers/blur.rs
@@ -1,0 +1,355 @@
+use std::cmp::max;
+use std::iter::{once, zip};
+use std::rc::Rc;
+
+use anyhow::{ensure, Context as _};
+use smithay::backend::allocator::Fourcc;
+use smithay::backend::renderer::gles::{
+    ffi, link_program, GlesError, GlesFrame, GlesRenderer, GlesTexture,
+};
+use smithay::backend::renderer::{ContextId, Frame as _, Renderer as _, Texture as _};
+use smithay::gpu_span_location;
+use smithay::utils::{Buffer, Size};
+
+use crate::render_helpers::shaders::Shaders;
+
+#[derive(Debug)]
+pub struct Blur {
+    program: BlurProgram,
+    /// Context ID of the renderer that created the program and the textures.
+    renderer_context_id: ContextId<GlesTexture>,
+    /// Output texture followed by intermediate textures, large to small.
+    ///
+    /// Created lazily and stored here to avoid recreating blur textures frequently.
+    textures: Vec<GlesTexture>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct BlurOptions {
+    pub passes: u8,
+    pub offset: f64,
+}
+
+impl From<niri_config::Blur> for BlurOptions {
+    fn from(config: niri_config::Blur) -> Self {
+        Self {
+            passes: config.passes,
+            offset: config.offset,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BlurProgram(Rc<BlurProgramInner>);
+
+#[derive(Debug)]
+struct BlurProgramInner {
+    down: BlurProgramInternal,
+    up: BlurProgramInternal,
+}
+
+#[derive(Debug)]
+struct BlurProgramInternal {
+    program: ffi::types::GLuint,
+    uniform_tex: ffi::types::GLint,
+    uniform_half_pixel: ffi::types::GLint,
+    uniform_offset: ffi::types::GLint,
+    attrib_vert: ffi::types::GLint,
+}
+
+unsafe fn compile_program(gl: &ffi::Gles2, src: &str) -> Result<BlurProgramInternal, GlesError> {
+    let program = unsafe { link_program(gl, include_str!("shaders/blur.vert"), src)? };
+
+    let vert = c"vert";
+    let tex = c"tex";
+    let half_pixel = c"half_pixel";
+    let offset = c"offset";
+
+    Ok(BlurProgramInternal {
+        program,
+        uniform_tex: gl.GetUniformLocation(program, tex.as_ptr()),
+        uniform_half_pixel: gl.GetUniformLocation(program, half_pixel.as_ptr()),
+        uniform_offset: gl.GetUniformLocation(program, offset.as_ptr()),
+        attrib_vert: gl.GetAttribLocation(program, vert.as_ptr()),
+    })
+}
+
+impl BlurProgram {
+    pub fn compile(renderer: &mut GlesRenderer) -> anyhow::Result<Self> {
+        renderer
+            .with_context(move |gl| unsafe {
+                let down = compile_program(gl, include_str!("shaders/blur_down.frag"))
+                    .context("error compiling blur_down shader")?;
+                let up = compile_program(gl, include_str!("shaders/blur_up.frag"))
+                    .context("error compiling blur_up shader")?;
+                Ok(Self(Rc::new(BlurProgramInner { down, up })))
+            })
+            .context("error making GL context current")?
+    }
+
+    pub fn destroy(self, renderer: &mut GlesRenderer) -> Result<(), GlesError> {
+        renderer.with_context(move |gl| unsafe {
+            gl.DeleteProgram(self.0.down.program);
+            gl.DeleteProgram(self.0.up.program);
+        })
+    }
+}
+
+impl Blur {
+    pub fn new(renderer: &mut GlesRenderer) -> Option<Self> {
+        let program = Shaders::get(renderer).blur.clone()?;
+        Some(Self {
+            program,
+            renderer_context_id: renderer.context_id(),
+            textures: Vec::new(),
+        })
+    }
+
+    pub fn context_id(&self) -> ContextId<GlesTexture> {
+        self.renderer_context_id.clone()
+    }
+
+    pub fn prepare_textures(
+        &mut self,
+        mut create_texture: impl FnMut(Fourcc, Size<i32, Buffer>) -> Result<GlesTexture, GlesError>,
+        source: &GlesTexture,
+        options: BlurOptions,
+    ) -> anyhow::Result<()> {
+        let _span = tracy_client::span!("Blur::prepare_textures");
+
+        let passes = options.passes.clamp(1, 31) as usize;
+        let size = source.size();
+
+        if let Some(output) = self.textures.first_mut() {
+            let old_size = output.size();
+            if old_size != size {
+                trace!(
+                    "recreating textures: output size changed from {} × {} to {} × {}",
+                    old_size.w,
+                    old_size.h,
+                    size.w,
+                    size.h
+                );
+                self.textures.clear();
+            } else if !output.is_unique_reference() {
+                debug!("recreating textures: not unique",);
+                // We only need to recreate the output texture here, but this case shouldn't really
+                // happen anyway, and this is simpler.
+                self.textures.clear();
+            }
+        }
+
+        // Create any missing textures.
+        let mut w = size.w;
+        let mut h = size.h;
+        for i in 0..=passes {
+            let size = Size::new(w, h);
+            w = max(1, w / 2);
+            h = max(1, h / 2);
+
+            if self.textures.len() > i {
+                // This texture already exists.
+                continue;
+            }
+
+            // debug!("creating texture for step {i} sized {w} × {h}");
+
+            let texture: GlesTexture =
+                create_texture(Fourcc::Abgr8888, size).context("error creating texture")?;
+            self.textures.push(texture);
+        }
+
+        // Drop any no longer needed textures.
+        self.textures.drain(passes + 1..);
+
+        Ok(())
+    }
+
+    pub fn render(
+        &mut self,
+        frame: &mut GlesFrame,
+        source: &GlesTexture,
+        options: BlurOptions,
+    ) -> anyhow::Result<GlesTexture> {
+        let _span = tracy_client::span!("Blur::render");
+        trace!("rendering blur");
+
+        ensure!(
+            frame.context_id() == self.renderer_context_id,
+            "wrong renderer"
+        );
+
+        let passes = options.passes.clamp(1, 31) as usize;
+        let size = source.size();
+
+        ensure!(
+            self.textures.len() == passes + 1,
+            "wrong textures len: expected {}, got {}",
+            passes + 1,
+            self.textures.len()
+        );
+
+        let output = &mut self.textures[0];
+        ensure!(
+            output.size() == size,
+            "wrong output texture size: expected {size:?}, got {:?}",
+            output.size()
+        );
+
+        ensure!(
+            output.is_unique_reference(),
+            "output texture has a non-unique reference"
+        );
+
+        frame.with_profiled_context(gpu_span_location!("Blur::render"), |gl| unsafe {
+            while gl.GetError() != ffi::NO_ERROR {}
+
+            let mut current_fbo = 0i32;
+            let mut viewport = [0i32; 4];
+            gl.GetIntegerv(ffi::FRAMEBUFFER_BINDING, &mut current_fbo as *mut _);
+            gl.GetIntegerv(ffi::VIEWPORT, viewport.as_mut_ptr());
+
+            gl.Disable(ffi::BLEND);
+            gl.Disable(ffi::SCISSOR_TEST);
+
+            gl.ActiveTexture(ffi::TEXTURE0);
+
+            let mut fbos = [0; 2];
+            gl.GenFramebuffers(fbos.len() as _, fbos.as_mut_ptr());
+            gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, fbos[0]);
+
+            let program = &self.program.0.down;
+            gl.UseProgram(program.program);
+            gl.Uniform1i(program.uniform_tex, 0);
+            gl.Uniform1f(program.uniform_offset, options.offset as f32);
+
+            let vertices: [f32; 12] = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0];
+            gl.EnableVertexAttribArray(program.attrib_vert as u32);
+            gl.BindBuffer(ffi::ARRAY_BUFFER, 0);
+            gl.VertexAttribPointer(
+                program.attrib_vert as u32,
+                2,
+                ffi::FLOAT,
+                ffi::FALSE,
+                0,
+                vertices.as_ptr().cast(),
+            );
+
+            let src = once(source).chain(&self.textures[1..]);
+            let dst = &self.textures[1..];
+            for (src, dst) in zip(src, dst) {
+                let dst_size = dst.size();
+                let w = dst_size.w;
+                let h = dst_size.h;
+                gl.Viewport(0, 0, w, h);
+
+                // During downsampling, half_pixel is half of the destination pixel.
+                gl.Uniform2f(program.uniform_half_pixel, 0.5 / w as f32, 0.5 / h as f32);
+
+                let src = src.tex_id();
+                let dst = dst.tex_id();
+
+                trace!("drawing down {src} to {dst}");
+                gl.FramebufferTexture2D(
+                    ffi::DRAW_FRAMEBUFFER,
+                    ffi::COLOR_ATTACHMENT0,
+                    ffi::TEXTURE_2D,
+                    dst,
+                    0,
+                );
+
+                gl.BindTexture(ffi::TEXTURE_2D, src);
+                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MIN_FILTER, ffi::LINEAR as i32);
+                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MAG_FILTER, ffi::LINEAR as i32);
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_WRAP_S,
+                    ffi::CLAMP_TO_EDGE as i32,
+                );
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_WRAP_T,
+                    ffi::CLAMP_TO_EDGE as i32,
+                );
+
+                gl.DrawArrays(ffi::TRIANGLES, 0, 6);
+            }
+
+            gl.DisableVertexAttribArray(program.attrib_vert as u32);
+
+            // Up
+            let program = &self.program.0.up;
+            gl.UseProgram(program.program);
+            gl.Uniform1i(program.uniform_tex, 0);
+            gl.Uniform1f(program.uniform_offset, options.offset as f32);
+
+            let vertices: [f32; 12] = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0];
+            gl.EnableVertexAttribArray(program.attrib_vert as u32);
+            gl.BindBuffer(ffi::ARRAY_BUFFER, 0);
+            gl.VertexAttribPointer(
+                program.attrib_vert as u32,
+                2,
+                ffi::FLOAT,
+                ffi::FALSE,
+                0,
+                vertices.as_ptr().cast(),
+            );
+
+            let src = self.textures.iter().rev();
+            let dst = self.textures.iter().rev().skip(1);
+            for (src, dst) in zip(src, dst) {
+                let dst_size = dst.size();
+                let w = dst_size.w;
+                let h = dst_size.h;
+                gl.Viewport(0, 0, w, h);
+
+                // During upsampling, half_pixel is half of the source pixel.
+                let src_size = src.size();
+                let src_w = src_size.w as f32;
+                let src_h = src_size.h as f32;
+                gl.Uniform2f(program.uniform_half_pixel, 0.5 / src_w, 0.5 / src_h);
+
+                let src = src.tex_id();
+                let dst = dst.tex_id();
+
+                trace!("drawing up {src} to {dst}");
+                gl.FramebufferTexture2D(
+                    ffi::DRAW_FRAMEBUFFER,
+                    ffi::COLOR_ATTACHMENT0,
+                    ffi::TEXTURE_2D,
+                    dst,
+                    0,
+                );
+
+                gl.BindTexture(ffi::TEXTURE_2D, src);
+                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MIN_FILTER, ffi::LINEAR as i32);
+                gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MAG_FILTER, ffi::LINEAR as i32);
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_WRAP_S,
+                    ffi::CLAMP_TO_EDGE as i32,
+                );
+                gl.TexParameteri(
+                    ffi::TEXTURE_2D,
+                    ffi::TEXTURE_WRAP_T,
+                    ffi::CLAMP_TO_EDGE as i32,
+                );
+
+                gl.DrawArrays(ffi::TRIANGLES, 0, 6);
+            }
+
+            gl.DisableVertexAttribArray(program.attrib_vert as u32);
+
+            gl.BindFramebuffer(ffi::FRAMEBUFFER, 0);
+            gl.DeleteFramebuffers(fbos.len() as _, fbos.as_ptr());
+
+            // Restore state set by GlesFrame that we just modified.
+            gl.Enable(ffi::BLEND);
+            gl.Enable(ffi::SCISSOR_TEST);
+            gl.BindFramebuffer(ffi::FRAMEBUFFER, current_fbo as u32);
+            gl.Viewport(viewport[0], viewport[1], viewport[2], viewport[3]);
+        })?;
+
+        Ok(self.textures[0].clone())
+    }
+}

--- a/src/render_helpers/blur.rs
+++ b/src/render_helpers/blur.rs
@@ -4,10 +4,8 @@ use std::rc::Rc;
 
 use anyhow::{ensure, Context as _};
 use smithay::backend::allocator::Fourcc;
-use smithay::backend::renderer::gles::{
-    ffi, link_program, GlesError, GlesFrame, GlesRenderer, GlesTexture,
-};
-use smithay::backend::renderer::{ContextId, Frame as _, Renderer as _, Texture as _};
+use smithay::backend::renderer::gles::{ffi, link_program, GlesError, GlesRenderer, GlesTexture};
+use smithay::backend::renderer::{ContextId, Renderer as _, Texture as _};
 use smithay::gpu_span_location;
 use smithay::utils::{Buffer, Size};
 
@@ -167,7 +165,7 @@ impl Blur {
 
     pub fn render(
         &mut self,
-        frame: &mut GlesFrame,
+        renderer: &mut GlesRenderer,
         source: &GlesTexture,
         options: BlurOptions,
     ) -> anyhow::Result<GlesTexture> {
@@ -175,7 +173,7 @@ impl Blur {
         trace!("rendering blur");
 
         ensure!(
-            frame.context_id() == self.renderer_context_id,
+            renderer.context_id() == self.renderer_context_id,
             "wrong renderer"
         );
 
@@ -201,13 +199,8 @@ impl Blur {
             "output texture has a non-unique reference"
         );
 
-        frame.with_profiled_context(gpu_span_location!("Blur::render"), |gl| unsafe {
+        renderer.with_profiled_context(gpu_span_location!("Blur::render"), |gl| unsafe {
             while gl.GetError() != ffi::NO_ERROR {}
-
-            let mut current_fbo = 0i32;
-            let mut viewport = [0i32; 4];
-            gl.GetIntegerv(ffi::FRAMEBUFFER_BINDING, &mut current_fbo as *mut _);
-            gl.GetIntegerv(ffi::VIEWPORT, viewport.as_mut_ptr());
 
             gl.Disable(ffi::BLEND);
             gl.Disable(ffi::SCISSOR_TEST);
@@ -340,14 +333,8 @@ impl Blur {
 
             gl.DisableVertexAttribArray(program.attrib_vert as u32);
 
-            gl.BindFramebuffer(ffi::FRAMEBUFFER, 0);
+            gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, 0);
             gl.DeleteFramebuffers(fbos.len() as _, fbos.as_ptr());
-
-            // Restore state set by GlesFrame that we just modified.
-            gl.Enable(ffi::BLEND);
-            gl.Enable(ffi::SCISSOR_TEST);
-            gl.BindFramebuffer(ffi::FRAMEBUFFER, current_fbo as u32);
-            gl.Viewport(viewport[0], viewport[1], viewport[2], viewport[3]);
         })?;
 
         Ok(self.textures[0].clone())

--- a/src/render_helpers/border.rs
+++ b/src/render_helpers/border.rs
@@ -9,6 +9,7 @@ use smithay::backend::renderer::element::{Element, Id, Kind, RenderElement, Unde
 use smithay::backend::renderer::gles::{GlesError, GlesFrame, GlesRenderer, Uniform};
 use smithay::backend::renderer::utils::{CommitCounter, DamageSet, OpaqueRegions};
 use smithay::gpu_span_location;
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
 use super::renderer::NiriRenderer;
@@ -285,6 +286,7 @@ impl RenderElement<GlesRenderer> for BorderRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         let _span = tracy_client::span!("BorderRenderElement::draw");
         frame.with_gpu_span(gpu_span_location!("BorderRenderElement::draw"), |frame| {
@@ -295,6 +297,7 @@ impl RenderElement<GlesRenderer> for BorderRenderElement {
                 dst,
                 damage,
                 opaque_regions,
+                cache,
             )
         })
     }
@@ -312,9 +315,10 @@ impl<'render> RenderElement<TtyRenderer<'render>> for BorderRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), TtyRendererError<'render>> {
         let frame = frame.as_gles_frame();
-        RenderElement::<GlesRenderer>::draw(self, frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(self, frame, src, dst, damage, opaque_regions, cache)?;
         Ok(())
     }
 

--- a/src/render_helpers/clipped_surface.rs
+++ b/src/render_helpers/clipped_surface.rs
@@ -272,10 +272,6 @@ impl<'render> RenderElement<TtyRenderer<'render>>
 }
 
 impl RoundedCornerDamage {
-    pub fn set_size(&mut self, size: Size<f64, Logical>) {
-        self.damage.set_size(size);
-    }
-
     pub fn set_corner_radius(&mut self, corner_radius: CornerRadius) {
         if self.corner_radius == corner_radius {
             return;
@@ -286,7 +282,7 @@ impl RoundedCornerDamage {
         self.damage.damage_all();
     }
 
-    pub fn element(&self) -> ExtraDamage {
-        self.damage.clone()
+    pub fn render(&self, geometry: Rectangle<f64, Logical>) -> ExtraDamage {
+        self.damage.render(geometry)
     }
 }

--- a/src/render_helpers/clipped_surface.rs
+++ b/src/render_helpers/clipped_surface.rs
@@ -6,6 +6,7 @@ use smithay::backend::renderer::gles::{
     GlesError, GlesFrame, GlesRenderer, GlesTexProgram, Uniform,
 };
 use smithay::backend::renderer::utils::{CommitCounter, DamageSet, OpaqueRegions};
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
 use super::damage::ExtraDamage;
@@ -228,9 +229,18 @@ impl RenderElement<GlesRenderer> for ClippedSurfaceRenderElement<GlesRenderer> {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         frame.override_default_tex_program(self.program.clone(), self.compute_uniforms());
-        RenderElement::<GlesRenderer>::draw(&self.inner, frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(
+            &self.inner,
+            frame,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            cache,
+        )?;
         frame.clear_tex_program_override();
         Ok(())
     }
@@ -252,11 +262,12 @@ impl<'render> RenderElement<TtyRenderer<'render>>
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), TtyRendererError<'render>> {
         frame
             .as_gles_frame()
             .override_default_tex_program(self.program.clone(), self.compute_uniforms());
-        RenderElement::draw(&self.inner, frame, src, dst, damage, opaque_regions)?;
+        RenderElement::draw(&self.inner, frame, src, dst, damage, opaque_regions, cache)?;
         frame.as_gles_frame().clear_tex_program_override();
         Ok(())
     }

--- a/src/render_helpers/damage.rs
+++ b/src/render_helpers/damage.rs
@@ -1,7 +1,7 @@
 use smithay::backend::renderer::element::{Element, Id, RenderElement};
 use smithay::backend::renderer::utils::CommitCounter;
 use smithay::backend::renderer::Renderer;
-use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size};
+use smithay::utils::{Buffer, Logical, Physical, Rectangle, Scale, Size};
 
 #[derive(Debug, Clone)]
 pub struct ExtraDamage {
@@ -19,22 +19,14 @@ impl ExtraDamage {
         }
     }
 
-    pub fn set_size(&mut self, size: Size<f64, Logical>) {
-        if self.geometry.size == size {
-            return;
-        }
-
-        self.geometry.size = size;
-        self.commit.increment();
-    }
-
     pub fn damage_all(&mut self) {
         self.commit.increment();
     }
 
-    pub fn with_location(mut self, location: Point<f64, Logical>) -> Self {
-        self.geometry.loc = location;
-        self
+    pub fn render(&self, geometry: Rectangle<f64, Logical>) -> Self {
+        let mut this = self.clone();
+        this.geometry = geometry;
+        this
     }
 }
 

--- a/src/render_helpers/damage.rs
+++ b/src/render_helpers/damage.rs
@@ -1,6 +1,7 @@
 use smithay::backend::renderer::element::{Element, Id, RenderElement};
 use smithay::backend::renderer::utils::CommitCounter;
 use smithay::backend::renderer::Renderer;
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Rectangle, Scale, Size};
 
 #[derive(Debug, Clone)]
@@ -62,6 +63,7 @@ impl<R: Renderer> RenderElement<R> for ExtraDamage {
         _dst: Rectangle<i32, Physical>,
         _damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         Ok(())
     }

--- a/src/render_helpers/effect_buffer.rs
+++ b/src/render_helpers/effect_buffer.rs
@@ -1,10 +1,10 @@
 use std::mem;
 
-use anyhow::Context as _;
+use anyhow::{ensure, Context as _};
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::element::{Id, RenderElementStates};
-use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
+use smithay::backend::renderer::gles::{GlesFrame, GlesRenderer, GlesTexture};
 use smithay::backend::renderer::utils::CommitCounter;
 use smithay::backend::renderer::{
     Bind as _, Color32F, ContextId, Offscreen as _, Renderer as _, Texture,
@@ -12,6 +12,7 @@ use smithay::backend::renderer::{
 use smithay::utils::{Buffer, Logical, Physical, Scale, Size, Transform};
 
 use crate::niri::OutputRenderElements;
+use crate::render_helpers::blur::{Blur, BlurOptions};
 
 #[derive(Debug)]
 pub struct EffectBuffer {
@@ -22,13 +23,17 @@ pub struct EffectBuffer {
     size: Size<i32, Buffer>,
     /// Scale of the effect buffer.
     scale: Scale<f64>,
+    /// Options for blurring.
+    blur_options: BlurOptions,
 
     /// Elements to be rendered on demand.
     elements: Elements,
     /// Offscreen buffer where elements get rendered.
     offscreen: Option<Offscreen>,
+    /// Blurring program, if available.
+    blur: Option<Blur>,
 
-    /// Commit counter for the offscreen texture.
+    /// Commit counter that takes into account both original and blurred texture changes.
     commit_counter: CommitCounter,
 }
 
@@ -55,6 +60,10 @@ struct Offscreen {
     damage: OutputDamageTracker,
     /// Render element states from the last render into the offscreen.
     states: RenderElementStates,
+    /// Rendered blurred version of the texture.
+    ///
+    /// When texture needs to be reblurred, this field must be reset to `None`.
+    blurred: Option<GlesTexture>,
 }
 
 impl Default for Elements {
@@ -69,8 +78,10 @@ impl EffectBuffer {
             id: Id::new(),
             size: Size::default(),
             scale: Scale::from(1.),
+            blur_options: BlurOptions::default(),
             elements: Elements::default(),
             offscreen: None,
+            blur: None,
             commit_counter: CommitCounter::default(),
         }
     }
@@ -100,6 +111,21 @@ impl EffectBuffer {
         self.scale = scale;
     }
 
+    pub fn update_blur_options(&mut self, options: BlurOptions) {
+        if self.blur_options == options {
+            return;
+        }
+
+        self.blur_options = options;
+
+        if let Some(offscreen) = &mut self.offscreen {
+            if offscreen.blurred.is_some() {
+                offscreen.blurred = None;
+                self.commit_counter.increment();
+            }
+        }
+    }
+
     pub fn elements(&mut self) -> &mut Vec<OutputRenderElements<GlesRenderer>> {
         // Assume we're going to insert new elements, switch to New.
         match mem::take(&mut self.elements) {
@@ -113,11 +139,18 @@ impl EffectBuffer {
         elements
     }
 
-    pub fn prepare(&mut self, renderer: &mut GlesRenderer) -> bool {
+    pub fn prepare(&mut self, renderer: &mut GlesRenderer, blur: bool) -> bool {
         if let Err(err) = self.prepare_offscreen(renderer) {
             warn!("error preparing offscreen: {err:?}");
             return false;
         };
+
+        if blur {
+            if let Err(err) = self.prepare_blur(renderer) {
+                warn!("error preparing blur: {err:?}");
+                return false;
+            }
+        }
 
         true
     }
@@ -176,6 +209,7 @@ impl EffectBuffer {
                 scale: self.scale,
                 damage,
                 states: RenderElementStates::default(),
+                blurred: None,
             })
         };
 
@@ -189,6 +223,7 @@ impl EffectBuffer {
             offscreen.damage = OutputDamageTracker::new(buffer_size, self.scale, Transform::Normal);
 
             self.commit_counter.increment();
+            offscreen.blurred = None;
         }
 
         // Render the elements if any.
@@ -215,6 +250,9 @@ impl EffectBuffer {
 
         if res.damage.is_some() {
             self.commit_counter.increment();
+
+            // Original texture changed; reset the blurred texture.
+            offscreen.blurred = None;
         }
 
         // Clear and put the storage back.
@@ -224,8 +262,62 @@ impl EffectBuffer {
         Ok(())
     }
 
-    pub fn render(&mut self) -> anyhow::Result<GlesTexture> {
+    fn prepare_blur(&mut self, renderer: &mut GlesRenderer) -> anyhow::Result<()> {
+        let offscreen = self.offscreen.as_mut().context("missing offscreen")?;
+        if offscreen.blurred.is_some() {
+            // Already rendered.
+            return Ok(());
+        }
+
+        if let Some(blur) = &self.blur {
+            if blur.context_id() != renderer.context_id() {
+                debug!("recreating blur: renderer changed");
+                self.blur = None;
+            }
+        }
+
+        let blur = if let Some(blur) = &mut self.blur {
+            blur
+        } else {
+            let Some(blur) = Blur::new(renderer) else {
+                // Missing blur shader.
+                return Ok(());
+            };
+            self.blur.insert(blur)
+        };
+
+        ensure!(
+            offscreen.renderer_context_id == renderer.context_id(),
+            "wrong renderer context id"
+        );
+
+        blur.prepare_textures(
+            |fourcc, size| renderer.create_buffer(fourcc, size),
+            &offscreen.texture,
+            self.blur_options,
+        )
+        .context("error preparing blur textures")?;
+
+        Ok(())
+    }
+
+    pub fn render(&mut self, frame: &mut GlesFrame, blur: bool) -> anyhow::Result<GlesTexture> {
         let offscreen = self.offscreen.as_mut().context("offscreen is missing")?;
-        Ok(offscreen.texture.clone())
+
+        if !blur {
+            return Ok(offscreen.texture.clone());
+        }
+
+        let texture = if let Some(texture) = &offscreen.blurred {
+            texture.clone()
+        } else {
+            let blur = self.blur.as_mut().context("blur is missing")?;
+            let blurred = blur
+                .render(frame, &offscreen.texture, self.blur_options)
+                .context("error rendering blur")?;
+            offscreen.blurred.insert(blurred).clone()
+        };
+
+        Ok(texture)
     }
 }

--- a/src/render_helpers/effect_buffer.rs
+++ b/src/render_helpers/effect_buffer.rs
@@ -7,7 +7,7 @@ use smithay::backend::renderer::element::{Id, RenderElementStates};
 use smithay::backend::renderer::gles::{GlesFrame, GlesRenderer, GlesTexture};
 use smithay::backend::renderer::utils::CommitCounter;
 use smithay::backend::renderer::{
-    Bind as _, Color32F, ContextId, Offscreen as _, Renderer as _, Texture,
+    Bind as _, Color32F, ContextId, FrameContext as _, Offscreen as _, Renderer as _, Texture,
 };
 use smithay::utils::{Buffer, Logical, Physical, Scale, Size, Transform};
 
@@ -312,8 +312,10 @@ impl EffectBuffer {
             texture.clone()
         } else {
             let blur = self.blur.as_mut().context("blur is missing")?;
+            let mut guard = frame.renderer();
+            let renderer = guard.as_mut();
             let blurred = blur
-                .render(frame, &offscreen.texture, self.blur_options)
+                .render(renderer, &offscreen.texture, self.blur_options)
                 .context("error rendering blur")?;
             offscreen.blurred.insert(blurred).clone()
         };

--- a/src/render_helpers/effect_buffer.rs
+++ b/src/render_helpers/effect_buffer.rs
@@ -1,0 +1,231 @@
+use std::mem;
+
+use anyhow::Context as _;
+use smithay::backend::allocator::Fourcc;
+use smithay::backend::renderer::damage::OutputDamageTracker;
+use smithay::backend::renderer::element::{Id, RenderElementStates};
+use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
+use smithay::backend::renderer::utils::CommitCounter;
+use smithay::backend::renderer::{
+    Bind as _, Color32F, ContextId, Offscreen as _, Renderer as _, Texture,
+};
+use smithay::utils::{Buffer, Logical, Physical, Scale, Size, Transform};
+
+use crate::niri::OutputRenderElements;
+
+#[derive(Debug)]
+pub struct EffectBuffer {
+    /// Id to be used for this effect buffer's elements.
+    id: Id,
+
+    /// Size of the effect buffer.
+    size: Size<i32, Buffer>,
+    /// Scale of the effect buffer.
+    scale: Scale<f64>,
+
+    /// Elements to be rendered on demand.
+    elements: Elements,
+    /// Offscreen buffer where elements get rendered.
+    offscreen: Option<Offscreen>,
+
+    /// Commit counter for the offscreen texture.
+    commit_counter: CommitCounter,
+}
+
+#[derive(Debug)]
+enum Elements {
+    /// Contents remain unchanged.
+    Unchanged(
+        // Storage to avoid reallocating it every time.
+        Vec<OutputRenderElements<GlesRenderer>>,
+    ),
+    /// New contents, need to check damage and render.
+    New(Vec<OutputRenderElements<GlesRenderer>>),
+}
+
+#[derive(Debug)]
+struct Offscreen {
+    /// The texture with the offscreen contents.
+    texture: GlesTexture,
+    /// Id of the renderer context that the texture comes from.
+    renderer_context_id: ContextId<GlesTexture>,
+    /// Scale of the texture.
+    scale: Scale<f64>,
+    /// Damage tracker for drawing to the texture.
+    damage: OutputDamageTracker,
+    /// Render element states from the last render into the offscreen.
+    states: RenderElementStates,
+}
+
+impl Default for Elements {
+    fn default() -> Self {
+        Self::Unchanged(Vec::new())
+    }
+}
+
+impl EffectBuffer {
+    pub fn new() -> Self {
+        Self {
+            id: Id::new(),
+            size: Size::default(),
+            scale: Scale::from(1.),
+            elements: Elements::default(),
+            offscreen: None,
+            commit_counter: CommitCounter::default(),
+        }
+    }
+
+    pub fn id(&self) -> &Id {
+        &self.id
+    }
+
+    pub fn commit(&self) -> CommitCounter {
+        self.commit_counter
+    }
+
+    pub fn logical_size(&self) -> Size<f64, Logical> {
+        self.size.to_f64().to_logical(self.scale, Transform::Normal)
+    }
+
+    pub fn scale(&self) -> Scale<f64> {
+        self.scale
+    }
+
+    pub fn render_element_states(&self) -> Option<&RenderElementStates> {
+        self.offscreen.as_ref().map(|o| &o.states)
+    }
+
+    pub fn update_size(&mut self, size: Size<i32, Physical>, scale: Scale<f64>) {
+        self.size = size.to_logical(1).to_buffer(1, Transform::Normal);
+        self.scale = scale;
+    }
+
+    pub fn elements(&mut self) -> &mut Vec<OutputRenderElements<GlesRenderer>> {
+        // Assume we're going to insert new elements, switch to New.
+        match mem::take(&mut self.elements) {
+            Elements::Unchanged(elements) | Elements::New(elements) => {
+                self.elements = Elements::New(elements);
+            }
+        }
+        let Elements::New(elements) = &mut self.elements else {
+            unreachable!();
+        };
+        elements
+    }
+
+    pub fn prepare(&mut self, renderer: &mut GlesRenderer) -> bool {
+        if let Err(err) = self.prepare_offscreen(renderer) {
+            warn!("error preparing offscreen: {err:?}");
+            return false;
+        };
+
+        true
+    }
+
+    fn prepare_offscreen(&mut self, renderer: &mut GlesRenderer) -> anyhow::Result<()> {
+        let _span = tracy_client::span!("EffectBuffer::prepare_offscreen");
+
+        // Check if we need to create or recreate the texture.
+        let size_string;
+        let mut reason = "";
+        if let Some(Offscreen {
+            texture,
+            renderer_context_id,
+            ..
+        }) = &mut self.offscreen
+        {
+            let old_size = texture.size();
+            if old_size != self.size {
+                size_string = format!(
+                    "size changed from {} × {} to {} × {}",
+                    old_size.w, old_size.h, self.size.w, self.size.h
+                );
+                reason = &size_string;
+
+                self.offscreen = None;
+            } else if !texture.is_unique_reference() {
+                reason = "not unique";
+
+                self.offscreen = None;
+            } else if *renderer_context_id != renderer.context_id() {
+                reason = "renderer id changed";
+
+                self.offscreen = None;
+            }
+        } else {
+            reason = "first render";
+        }
+
+        let offscreen = if let Some(offscreen) = &mut self.offscreen {
+            offscreen
+        } else {
+            debug!("creating new offscreen texture: {reason}");
+            let span = tracy_client::span!("creating effect offscreen texture");
+            span.emit_text(reason);
+
+            let texture: GlesTexture = renderer
+                .create_buffer(Fourcc::Abgr8888, self.size)
+                .context("error creating texture")?;
+
+            let buffer_size = self.size.to_logical(1, Transform::Normal).to_physical(1);
+            let damage = OutputDamageTracker::new(buffer_size, self.scale, Transform::Normal);
+
+            self.offscreen.insert(Offscreen {
+                texture,
+                renderer_context_id: renderer.context_id(),
+                scale: self.scale,
+                damage,
+                states: RenderElementStates::default(),
+            })
+        };
+
+        // Recreate the damage tracker if the scale changes. We already recreate it for buffer size
+        // changes, and transform is always Normal.
+        if offscreen.scale != self.scale {
+            offscreen.scale = self.scale;
+
+            trace!("recreating damage tracker due to scale change");
+            let buffer_size = self.size.to_logical(1, Transform::Normal).to_physical(1);
+            offscreen.damage = OutputDamageTracker::new(buffer_size, self.scale, Transform::Normal);
+
+            self.commit_counter.increment();
+        }
+
+        // Render the elements if any.
+        let mut elements = match mem::take(&mut self.elements) {
+            Elements::New(elements) => elements,
+            x @ Elements::Unchanged(_) => {
+                // No redrawing necessary.
+                self.elements = x;
+                return Ok(());
+            }
+        };
+
+        let res = {
+            let mut target = renderer
+                .bind(&mut offscreen.texture)
+                .context("error binding texture")?;
+            offscreen
+                .damage
+                .render_output(renderer, &mut target, 1, &elements, Color32F::TRANSPARENT)
+                .context("error rendering")?
+        };
+
+        offscreen.states = res.states;
+
+        if res.damage.is_some() {
+            self.commit_counter.increment();
+        }
+
+        // Clear and put the storage back.
+        elements.clear();
+        self.elements = Elements::Unchanged(elements);
+
+        Ok(())
+    }
+
+    pub fn render(&mut self) -> anyhow::Result<GlesTexture> {
+        let offscreen = self.offscreen.as_mut().context("offscreen is missing")?;
+        Ok(offscreen.texture.clone())
+    }
+}

--- a/src/render_helpers/framebuffer_effect.rs
+++ b/src/render_helpers/framebuffer_effect.rs
@@ -1,0 +1,457 @@
+use std::cell::RefCell;
+
+use glam::{Mat3, Vec2};
+use niri_config::CornerRadius;
+use smithay::backend::allocator::Fourcc;
+use smithay::backend::renderer::element::{Element, Id, RenderElement};
+use smithay::backend::renderer::gles::{
+    ffi, GlesError, GlesFrame, GlesRenderer, GlesTexture, Uniform,
+};
+use smithay::backend::renderer::utils::CommitCounter;
+use smithay::backend::renderer::{Frame as _, FrameContext, Offscreen, Texture as _};
+use smithay::gpu_span_location;
+use smithay::utils::user_data::UserDataMap;
+use smithay::utils::{Buffer, Logical, Physical, Rectangle, Scale, Transform};
+
+use crate::backend::tty::{TtyFrame, TtyRenderer, TtyRendererError};
+use crate::render_helpers::background_effect::RenderParams;
+use crate::render_helpers::blur::{Blur, BlurOptions};
+use crate::render_helpers::renderer::AsGlesFrame as _;
+use crate::render_helpers::shaders::{mat3_uniform, Shaders};
+use crate::utils::region::TransformedRegion;
+
+#[derive(Debug)]
+pub struct FramebufferEffect {
+    id: Id,
+    commit: CommitCounter,
+}
+
+#[derive(Debug)]
+pub struct FramebufferEffectElement {
+    id: Id,
+    commit: CommitCounter,
+    geometry: Rectangle<f64, Logical>,
+    clip_geo: Rectangle<f64, Logical>,
+    corner_radius: CornerRadius,
+    subregion: Option<TransformedRegion>,
+    scale: f32,
+    blur_options: Option<BlurOptions>,
+    noise: f32,
+    saturation: f32,
+}
+
+#[derive(Debug)]
+struct Inner {
+    framebuffer: Option<GlesTexture>,
+    blur: Option<Blur>,
+    intermediate: Option<GlesTexture>,
+    /// Reusable storage for subregion-filtered damage rects.
+    subregion_damage: Vec<Rectangle<i32, Physical>>,
+}
+
+impl FramebufferEffect {
+    pub fn new() -> Self {
+        Self {
+            id: Id::new(),
+            commit: CommitCounter::default(),
+        }
+    }
+
+    pub fn damage(&mut self) {
+        self.commit.increment();
+    }
+
+    pub fn render(
+        &self,
+        ns: Option<usize>,
+        params: RenderParams,
+        blur_options: Option<BlurOptions>,
+        noise: f32,
+        saturation: f32,
+    ) -> FramebufferEffectElement {
+        let (clip_geo, corner_radius) = params
+            .clip
+            .unwrap_or((params.geometry, CornerRadius::default()));
+
+        let mut id = self.id.clone();
+        if let Some(ns) = ns {
+            id = id.namespaced(ns);
+        }
+
+        FramebufferEffectElement {
+            id,
+            commit: self.commit,
+            geometry: params.geometry,
+            clip_geo,
+            corner_radius,
+            subregion: params.subregion,
+            scale: params.scale as f32,
+            blur_options,
+            noise,
+            saturation,
+        }
+    }
+}
+
+impl FramebufferEffectElement {
+    fn compute_uniforms(
+        &self,
+        crop: Rectangle<f64, Logical>,
+        transform: Transform,
+    ) -> [Uniform<'static>; 7] {
+        let offset = crop.loc - (self.clip_geo.loc - self.geometry.loc);
+        let offset = Vec2::new(offset.x as f32, offset.y as f32);
+        let crop_size = Vec2::new(crop.size.w as f32, crop.size.h as f32);
+        let clip_size = Vec2::new(self.clip_geo.size.w as f32, self.clip_geo.size.h as f32);
+
+        // Our v_coords are [0, 1] inside crop. We want them to be [0, 1] inside clip_geo.
+        let input_to_clip_geo =
+            Mat3::from_scale(crop_size / clip_size) * Mat3::from_translation(offset / crop_size);
+
+        // Revert the effect of the texture transform.
+        let transform_mat = Mat3::from_translation(Vec2::new(0.5, 0.5))
+            * Mat3::from_cols_array(transform.matrix().as_ref())
+            * Mat3::from_translation(Vec2::new(-0.5, -0.5));
+        let input_to_clip_geo = input_to_clip_geo * transform_mat;
+
+        let clip_geo_size = (self.clip_geo.size.w as f32, self.clip_geo.size.h as f32);
+
+        [
+            Uniform::new("niri_scale", self.scale),
+            Uniform::new("geo_size", clip_geo_size),
+            Uniform::new("corner_radius", <[f32; 4]>::from(self.corner_radius)),
+            mat3_uniform("input_to_geo", input_to_clip_geo),
+            Uniform::new("noise", self.noise),
+            Uniform::new("saturation", self.saturation),
+            Uniform::new("bg_color", [0f32, 0., 0., 0.]),
+        ]
+    }
+}
+
+impl Element for FramebufferEffectElement {
+    fn id(&self) -> &Id {
+        &self.id
+    }
+
+    fn current_commit(&self) -> CommitCounter {
+        self.commit
+    }
+
+    fn src(&self) -> Rectangle<f64, Buffer> {
+        // We don't use src for drawing but we can use it to figure out how we were cropped.
+        let size = self.geometry.size.to_buffer(1., Transform::Normal);
+        Rectangle::from_size(size)
+    }
+
+    fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
+        self.geometry.to_physical_precise_round(scale)
+    }
+
+    fn is_framebuffer_effect(&self) -> bool {
+        true
+    }
+}
+
+impl RenderElement<GlesRenderer> for FramebufferEffectElement {
+    fn capture_framebuffer(
+        &self,
+        frame: &mut GlesFrame<'_, '_>,
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        cache: &UserDataMap,
+    ) -> Result<(), GlesError> {
+        let _span = tracy_client::span!("FramebufferEffectElement::capture_framebuffer");
+        let location = gpu_span_location!("FramebufferEffectElement::capture_framebuffer");
+        frame.with_gpu_span(location, |frame| {
+            let output_rect = Rectangle::from_size(frame.output_size());
+            let transform = frame.transformation();
+
+            let mut guard = frame.renderer();
+
+            let inner = cache
+                .get_or_insert::<RefCell<Inner>, _>(|| RefCell::new(Inner::new(guard.as_mut())));
+            let mut inner = inner.borrow_mut();
+            let inner = &mut *inner;
+
+            inner.intermediate = None;
+
+            // We want clamp-to-edge behavior for out-of-bounds pixels. However, glBlitFramebuffer
+            // seems to skip out-of-bounds pixels, even though my reading of the docs suggests
+            // otherwise (we use GL_LINEAR filter). So, clamp dst to the framebuffer bounds
+            // ourselves.
+            let clamped_dst = match dst.intersection(output_rect) {
+                Some(clamped) => clamped,
+                None => return Ok(()),
+            };
+            let clamp_scale = clamped_dst.size.to_f64() / dst.size.to_f64();
+
+            let dst = transform.transform_rect_in(clamped_dst, &output_rect.size);
+
+            // Compute size from our geometry and scale.
+            //
+            // The "correct" size is always dst.size since that's the pixel region we're actually
+            // blitting. However, using dst.size causes two undesirable things when zooming out for
+            // the overview:
+            // 1. dst.size shrinks every frame, causing a texture realloaction for every fb effect
+            //    element every frame.
+            // 2. The underlying blur visually expands. This is technically correct, since the
+            //    underlying contents shrink, but it's not what you visually expect: you expect the
+            //    blur to also shrink as the windows zoom out, to give the zooming out effect.
+            //
+            // Using size computed from geometry and scale solves both of those problems (even
+            // though there's a bit of a cost in that zoomed-out elements still blur the entire
+            // unzoomed texture size, and even though the blur ends up slightly wrong as there's two
+            // layers of texture resampling, up and back down).
+            //
+            // Here we use src.size rather than geometry directly because src takes into account
+            // cropping.
+            let size = src
+                .size
+                .to_logical(1., Transform::Normal)
+                .upscale(clamp_scale)
+                .to_physical_precise_round(self.scale);
+            let size = transform.transform_size(size);
+
+            let size = size.to_logical(1).to_buffer(1, Transform::Normal);
+
+            // Recreate framebuffer if needed.
+            if inner
+                .framebuffer
+                .as_ref()
+                .is_some_and(|fb| fb.size() != size)
+            {
+                inner.framebuffer = None;
+            }
+            let framebuffer = if let Some(fb) = &inner.framebuffer {
+                fb
+            } else {
+                trace!("creating framebuffer texture sized {} × {}", size.w, size.h);
+                let renderer = guard.as_mut();
+                let texture = renderer.create_buffer(Fourcc::Abgr8888, size)?;
+                inner.framebuffer.insert(texture)
+            };
+
+            // Prepare blur textures.
+            let mut blur = Option::zip(inner.blur.as_mut(), self.blur_options);
+            if let Some((b, options)) = &mut blur {
+                let renderer = guard.as_mut();
+                if let Err(err) = b.prepare_textures(
+                    |fourcc, size| renderer.create_buffer(fourcc, size),
+                    framebuffer,
+                    *options,
+                ) {
+                    warn!("error preparing blur textures: {err:?}");
+                    blur = None;
+                }
+            }
+
+            // We can't use renderer.with_context() as that will reset the GlesFrame binding that we
+            // want to blit from.
+            drop(guard);
+
+            // Blit the framebuffer contents.
+            frame.with_context(|gl| unsafe {
+                while gl.GetError() != ffi::NO_ERROR {}
+
+                let mut current_fbo = 0i32;
+                gl.GetIntegerv(ffi::DRAW_FRAMEBUFFER_BINDING, &mut current_fbo as *mut _);
+
+                // BlitFramebuffer is affected by the scissor test, we don't want that.
+                gl.Disable(ffi::SCISSOR_TEST);
+
+                let mut fbo = 0;
+                gl.GenFramebuffers(1, &mut fbo as *mut _);
+                gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, fbo);
+
+                gl.FramebufferTexture2D(
+                    ffi::DRAW_FRAMEBUFFER,
+                    ffi::COLOR_ATTACHMENT0,
+                    ffi::TEXTURE_2D,
+                    framebuffer.tex_id(),
+                    0,
+                );
+
+                gl.BlitFramebuffer(
+                    dst.loc.x,
+                    dst.loc.y,
+                    dst.loc.x + dst.size.w,
+                    dst.loc.y + dst.size.h,
+                    0,
+                    0,
+                    size.w,
+                    size.h,
+                    ffi::COLOR_BUFFER_BIT,
+                    ffi::LINEAR,
+                );
+
+                // Restore state set by GlesFrame that we just modified.
+                gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, current_fbo as u32);
+                gl.Enable(ffi::SCISSOR_TEST);
+
+                gl.DeleteFramebuffers(1, &mut fbo as *mut _);
+
+                if gl.GetError() != ffi::NO_ERROR {
+                    Err(GlesError::BlitError)
+                } else {
+                    Ok(())
+                }
+            })??;
+
+            // If blur is off, use the unblurred texture.
+            if self.blur_options.is_none() {
+                inner.intermediate = Some(framebuffer.clone());
+                return Ok(());
+            }
+
+            if let Some((blur, options)) = blur {
+                let mut guard = frame.renderer();
+                let renderer = guard.as_mut();
+                match blur.render(renderer, framebuffer, options) {
+                    Ok(blurred) => inner.intermediate = Some(blurred),
+                    Err(err) => {
+                        warn!("error rendering blur: {err:?}");
+                    }
+                }
+            }
+
+            Ok(())
+        })
+    }
+
+    fn draw(
+        &self,
+        frame: &mut GlesFrame<'_, '_>,
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
+    ) -> Result<(), GlesError> {
+        let Some(cache) = cache else {
+            return Ok(());
+        };
+        let Some(inner) = cache.get::<RefCell<Inner>>() else {
+            return Ok(());
+        };
+        let mut inner = inner.borrow_mut();
+        let inner = &mut *inner;
+
+        let Some(texture) = &inner.intermediate else {
+            return Ok(());
+        };
+
+        // Clamp the same way as in capture_framebuffer().
+        let output_rect = Rectangle::from_size(frame.output_size());
+        let clamped_dst = match dst.intersection(output_rect) {
+            Some(clamped) => clamped,
+            None => return Ok(()),
+        };
+        let clamp_offset = clamped_dst.loc - dst.loc;
+
+        // Filter damage by subregion, reusing the stored Vec to avoid allocation.
+        let filtered = &mut inner.subregion_damage;
+        filtered.clear();
+
+        if let Some(subregion) = &self.subregion {
+            // Convert to subregion coordinates.
+            let mut crop = src.to_logical(1., Transform::Normal, &src.size);
+            crop.loc += self.geometry.loc;
+            subregion.filter_damage(crop, dst, damage, filtered);
+        } else {
+            filtered.extend(damage.iter());
+        };
+
+        // Adjust for clamped dst.
+        if clamped_dst != dst {
+            let r = Rectangle::new(clamp_offset, clamped_dst.size);
+            filtered.retain_mut(|d| {
+                if let Some(mut crop) = d.intersection(r) {
+                    crop.loc -= clamp_offset;
+                    *d = crop;
+                    true
+                } else {
+                    false
+                }
+            });
+        }
+
+        if filtered.is_empty() {
+            return Ok(());
+        }
+        let damage = &filtered[..];
+
+        // Adjust src proportionally to the dst clamping.
+        let src_loc = src.loc.to_logical(1., Transform::Normal, &src.size);
+        let dst_to_src = src.size / dst.size.to_f64();
+        let crop = Rectangle::new(
+            src_loc + clamp_offset.to_f64().upscale(dst_to_src).to_logical(1.),
+            clamped_dst.size.to_f64().upscale(dst_to_src).to_logical(1.),
+        );
+
+        let program = Shaders::get_from_frame(frame).postprocess_and_clip.clone();
+        let uniforms = program
+            .is_some()
+            .then(|| self.compute_uniforms(crop, frame.transformation()));
+        let uniforms = uniforms.as_ref().map_or(&[][..], |x| &x[..]);
+
+        frame.render_texture_from_to(
+            texture,
+            Rectangle::from_size(texture.size().to_f64()),
+            clamped_dst,
+            damage,
+            &[],
+            // The intermediate texture has the same transform as the frame.
+            frame.transformation().invert(),
+            1.,
+            program.as_ref(),
+            uniforms,
+        )
+    }
+}
+
+impl<'render> RenderElement<TtyRenderer<'render>> for FramebufferEffectElement {
+    fn capture_framebuffer(
+        &self,
+        frame: &mut TtyFrame<'_, '_, '_>,
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        cache: &UserDataMap,
+    ) -> Result<(), TtyRendererError<'render>> {
+        let gles_frame = frame.as_gles_frame();
+        RenderElement::<GlesRenderer>::capture_framebuffer(&self, gles_frame, src, dst, cache)?;
+        Ok(())
+    }
+
+    fn draw(
+        &self,
+        frame: &mut TtyFrame<'_, '_, '_>,
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
+    ) -> Result<(), TtyRendererError<'render>> {
+        let gles_frame = frame.as_gles_frame();
+        RenderElement::<GlesRenderer>::draw(
+            &self,
+            gles_frame,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            cache,
+        )?;
+        Ok(())
+    }
+}
+
+impl Inner {
+    fn new(renderer: &mut GlesRenderer) -> Self {
+        Inner {
+            framebuffer: None,
+            blur: Blur::new(renderer),
+            intermediate: None,
+            subregion_damage: Vec::new(),
+        }
+    }
+}

--- a/src/render_helpers/gradient_fade_texture.rs
+++ b/src/render_helpers/gradient_fade_texture.rs
@@ -3,6 +3,7 @@ use smithay::backend::renderer::gles::{
     GlesError, GlesFrame, GlesRenderer, GlesTexProgram, GlesTexture, Uniform,
 };
 use smithay::backend::renderer::utils::{CommitCounter, DamageSet, OpaqueRegions};
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Physical, Rectangle, Scale, Transform};
 
 use super::texture::TextureRenderElement;
@@ -96,10 +97,19 @@ impl RenderElement<GlesRenderer> for GradientFadeTextureRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         let uniforms = vec![Uniform::new("cutoff", self.cutoff)];
         frame.override_default_tex_program(self.program.0.clone(), uniforms);
-        RenderElement::<GlesRenderer>::draw(&self.inner, frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(
+            &self.inner,
+            frame,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            cache,
+        )?;
         frame.clear_tex_program_override();
         Ok(())
     }
@@ -119,9 +129,18 @@ impl<'render> RenderElement<TtyRenderer<'render>> for GradientFadeTextureRenderE
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), TtyRendererError<'render>> {
         let gles_frame = frame.as_gles_frame();
-        RenderElement::<GlesRenderer>::draw(&self, gles_frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(
+            &self,
+            gles_frame,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            cache,
+        )?;
         Ok(())
     }
 

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -33,6 +33,7 @@ pub mod clipped_surface;
 pub mod damage;
 pub mod debug;
 pub mod effect_buffer;
+pub mod framebuffer_effect;
 pub mod gradient_fade_texture;
 pub mod memory;
 pub mod offscreen;

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -6,9 +6,13 @@ use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::allocator::{Buffer, Fourcc};
 use smithay::backend::renderer::element::utils::{Relocate, RelocateRenderElement};
 use smithay::backend::renderer::element::{Element, Kind, RenderElement};
-use smithay::backend::renderer::gles::{GlesMapping, GlesRenderer, GlesTarget, GlesTexture};
+use smithay::backend::renderer::gles::{
+    GlesError, GlesMapping, GlesRenderer, GlesTarget, GlesTexture,
+};
 use smithay::backend::renderer::sync::SyncPoint;
-use smithay::backend::renderer::{Bind, Color32F, ExportMem, Frame, Offscreen, Renderer};
+use smithay::backend::renderer::{
+    Bind, Color32F, ExportMem, Frame, Offscreen, Renderer, Texture as _,
+};
 use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
 use smithay::reexports::wayland_server::protocol::wl_shm;
 use smithay::utils::{Logical, Physical, Point, Rectangle, Scale, Size, Transform};
@@ -155,6 +159,23 @@ pub fn encompassing_geo(
         .unwrap_or_default()
 }
 
+pub fn create_texture(
+    renderer: &mut GlesRenderer,
+    size: Size<i32, Physical>,
+    fourcc: Fourcc,
+) -> Result<GlesTexture, GlesError> {
+    let buffer_size = size.to_logical(1).to_buffer(1, Transform::Normal);
+    renderer.create_buffer(fourcc, buffer_size)
+}
+
+pub fn copy_framebuffer(
+    renderer: &mut GlesRenderer,
+    target: &GlesTarget,
+    fourcc: Fourcc,
+) -> Result<GlesMapping, GlesError> {
+    renderer.copy_framebuffer(target, Rectangle::from_size(target.size()), fourcc)
+}
+
 pub fn render_to_encompassing_texture(
     renderer: &mut GlesRenderer,
     scale: Scale<f64>,
@@ -183,11 +204,7 @@ pub fn render_to_texture(
 ) -> anyhow::Result<(GlesTexture, SyncPoint)> {
     let _span = tracy_client::span!();
 
-    let buffer_size = size.to_logical(1).to_buffer(1, Transform::Normal);
-
-    let mut texture: GlesTexture = renderer
-        .create_buffer(fourcc, buffer_size)
-        .context("error creating texture")?;
+    let mut texture = create_texture(renderer, size, fourcc).context("error creating texture")?;
 
     let sync_point = {
         let mut target = renderer
@@ -210,18 +227,15 @@ pub fn render_and_download(
 ) -> anyhow::Result<GlesMapping> {
     let _span = tracy_client::span!();
 
-    let (mut texture, _) = render_to_texture(renderer, size, scale, transform, fourcc, elements)?;
-
-    let buffer_size = size.to_logical(1).to_buffer(1, Transform::Normal);
-    // FIXME: would be nice to avoid binding the second time here (after render_to_texture()), but
-    // borrowing makes this inconvenient.
-    let target = renderer
+    let mut texture = create_texture(renderer, size, fourcc).context("error creating texture")?;
+    let mut target = renderer
         .bind(&mut texture)
         .context("error binding texture")?;
-    let mapping = renderer
-        .copy_framebuffer(&target, Rectangle::from_size(buffer_size), fourcc)
-        .context("error copying framebuffer")?;
-    Ok(mapping)
+
+    let _sync = render_elements(renderer, &mut target, size, scale, transform, elements)
+        .context("error rendering")?;
+
+    copy_framebuffer(renderer, &target, fourcc).context("error copying framebuffer")
 }
 
 pub fn render_to_vec(

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -4,8 +4,9 @@ use anyhow::{ensure, Context as _};
 use niri_config::BlockOutFrom;
 use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::allocator::{Buffer, Fourcc};
+use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::element::utils::{Relocate, RelocateRenderElement};
-use smithay::backend::renderer::element::{Element, Kind, RenderElement};
+use smithay::backend::renderer::element::{Element, Kind, RenderElement, RenderElementStates};
 use smithay::backend::renderer::gles::{
     GlesError, GlesMapping, GlesRenderer, GlesTarget, GlesTexture,
 };
@@ -269,33 +270,44 @@ pub fn render_to_vec(
 
 pub fn render_to_dmabuf(
     renderer: &mut GlesRenderer,
+    damage_tracker: &mut OutputDamageTracker,
     mut dmabuf: Dmabuf,
-    size: Size<i32, Physical>,
-    scale: Scale<f64>,
-    transform: Transform,
-    elements: impl Iterator<Item = impl RenderElement<GlesRenderer>>,
+    elements: &[impl RenderElement<GlesRenderer>],
+    states: RenderElementStates,
 ) -> anyhow::Result<SyncPoint> {
     let _span = tracy_client::span!();
+    let (size, _scale, _transform) = damage_tracker.mode().try_into().unwrap();
     ensure!(
         dmabuf.width() == size.w as u32 && dmabuf.height() == size.h as u32,
         "invalid buffer size"
     );
-    let mut target = renderer
-        .bind(&mut dmabuf)
-        .context("error binding texture")?;
-    render_elements(renderer, &mut target, size, scale, transform, elements)
+
+    let mut target = renderer.bind(&mut dmabuf).context("error binding dmabuf")?;
+    let res = damage_tracker
+        .render_output_with_states(
+            renderer,
+            &mut target,
+            0,
+            elements,
+            Color32F::TRANSPARENT,
+            states,
+        )
+        .context("error rendering to dmabuf")?;
+    Ok(res.sync)
 }
 
 pub fn render_to_shm(
     renderer: &mut GlesRenderer,
+    damage_tracker: &mut OutputDamageTracker,
     buffer: &WlBuffer,
-    size: Size<i32, Physical>,
-    scale: Scale<f64>,
-    transform: Transform,
-    elements: impl Iterator<Item = impl RenderElement<GlesRenderer>>,
+    elements: &[impl RenderElement<GlesRenderer>],
+    states: RenderElementStates,
 ) -> anyhow::Result<()> {
     let _span = tracy_client::span!();
     shm::with_buffer_contents_mut(buffer, |shm_buffer, shm_len, buffer_data| {
+        let (size, _scale, _transform) = damage_tracker.mode().try_into().unwrap();
+        let fourcc = Fourcc::Xrgb8888;
+
         ensure!(
             // The buffer prefers pixels in little endian ...
             buffer_data.format == wl_shm::Format::Xrgb8888
@@ -305,9 +317,26 @@ pub fn render_to_shm(
                 && shm_len == buffer_data.stride as usize * buffer_data.height as usize,
             "invalid buffer format or size"
         );
-        let mapping =
-            render_and_download(renderer, size, scale, transform, Fourcc::Xrgb8888, elements)?;
 
+        let mut texture =
+            create_texture(renderer, size, fourcc).context("error creating texture")?;
+        let mut target = renderer
+            .bind(&mut texture)
+            .context("error binding texture")?;
+
+        let _res = damage_tracker
+            .render_output_with_states(
+                renderer,
+                &mut target,
+                0,
+                elements,
+                Color32F::TRANSPARENT,
+                states,
+            )
+            .context("error rendering")?;
+
+        let mapping =
+            copy_framebuffer(renderer, &target, fourcc).context("error copying framebuffer")?;
         let bytes = renderer
             .map_texture(&mapping)
             .context("error mapping texture")?;

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -15,6 +15,7 @@ use smithay::backend::renderer::{
 };
 use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
 use smithay::reexports::wayland_server::protocol::wl_shm;
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 use smithay::wayland::shm;
 use solid_color::{SolidColorBuffer, SolidColorRenderElement};
@@ -359,8 +360,15 @@ fn render_elements(
 
         if let Some(mut damage) = output_rect.intersection(dst) {
             damage.loc -= dst.loc;
+
+            let cache = UserDataMap::new();
+            if element.is_framebuffer_effect() {
+                element
+                    .capture_framebuffer(&mut frame, src, dst, &cache)
+                    .context("error in capture_framebuffer()")?;
+            }
             element
-                .draw(&mut frame, src, dst, &[damage], &[])
+                .draw(&mut frame, src, dst, &[damage], &[], Some(&cache))
                 .context("error drawing element")?;
         }
     }

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -25,6 +25,7 @@ use crate::render_helpers::renderer::AsGlesRenderer;
 use crate::render_helpers::xray::Xray;
 
 pub mod background_effect;
+pub mod blur;
 pub mod border;
 pub mod clipped_surface;
 pub mod damage;

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -22,11 +22,14 @@ use solid_color::{SolidColorBuffer, SolidColorRenderElement};
 use self::primary_gpu_texture::PrimaryGpuTextureRenderElement;
 use self::texture::{TextureBuffer, TextureRenderElement};
 use crate::render_helpers::renderer::AsGlesRenderer;
+use crate::render_helpers::xray::Xray;
 
+pub mod background_effect;
 pub mod border;
 pub mod clipped_surface;
 pub mod damage;
 pub mod debug;
+pub mod effect_buffer;
 pub mod gradient_fade_texture;
 pub mod memory;
 pub mod offscreen;
@@ -42,6 +45,7 @@ pub mod snapshot;
 pub mod solid_color;
 pub mod surface;
 pub mod texture;
+pub mod xray;
 
 /// A rendering context.
 ///
@@ -49,6 +53,7 @@ pub mod texture;
 pub struct RenderCtx<'a, R> {
     pub renderer: &'a mut R,
     pub target: RenderTarget,
+    pub xray: Option<&'a Xray>,
 }
 
 impl<'a, R> RenderCtx<'a, R> {
@@ -58,6 +63,7 @@ impl<'a, R> RenderCtx<'a, R> {
         RenderCtx {
             renderer: self.renderer,
             target: self.target,
+            xray: self.xray,
         }
     }
 }
@@ -67,6 +73,7 @@ impl<'a, R: AsGlesRenderer> RenderCtx<'a, R> {
         RenderCtx {
             renderer: self.renderer.as_gles_renderer(),
             target: self.target,
+            xray: self.xray,
         }
     }
 }
@@ -75,7 +82,7 @@ impl<'a, R: AsGlesRenderer> RenderCtx<'a, R> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RenderTarget {
     /// Rendering to display on screen.
-    Output,
+    Output = 0,
     /// Rendering for a screencast.
     Screencast,
     /// Rendering for any other screen capture.
@@ -104,6 +111,8 @@ pub trait ToRenderElement {
 }
 
 impl RenderTarget {
+    pub const COUNT: usize = 3;
+
     pub fn should_block_out(self, block_out_from: Option<BlockOutFrom>) -> bool {
         match block_out_from {
             None => false,

--- a/src/render_helpers/offscreen.rs
+++ b/src/render_helpers/offscreen.rs
@@ -15,6 +15,7 @@ use smithay::backend::renderer::utils::{
 use smithay::backend::renderer::{
     Bind as _, Color32F, ContextId, Frame as _, Offscreen as _, Renderer, Texture as _,
 };
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
 use super::encompassing_geo;
@@ -306,6 +307,7 @@ impl RenderElement<GlesRenderer> for OffscreenRenderElement {
         dest: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         if frame.context_id() != self.renderer_context_id {
             warn!("trying to render texture from different renderer");
@@ -340,9 +342,18 @@ impl<'render> RenderElement<TtyRenderer<'render>> for OffscreenRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), TtyRendererError<'render>> {
         let gles_frame = frame.as_gles_frame();
-        RenderElement::<GlesRenderer>::draw(&self, gles_frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(
+            &self,
+            gles_frame,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            cache,
+        )?;
         Ok(())
     }
 

--- a/src/render_helpers/offscreen.rs
+++ b/src/render_helpers/offscreen.rs
@@ -81,7 +81,12 @@ impl OffscreenBuffer {
             RelocateRenderElement::from_element(ele, geo.loc.upscale(-1), Relocate::Relative)
         }));
 
-        let src_size = geo.size;
+        // Guard against empty elements producing a zero size.
+        let mut src_size = geo.size;
+        if src_size.w == 0 || src_size.h == 0 {
+            src_size = Size::new(1, 1);
+        }
+
         let src_size = src_size.to_logical(1).to_buffer(1, Transform::Normal);
         let offset = geo.loc.to_f64().to_logical(scale);
 

--- a/src/render_helpers/offscreen.rs
+++ b/src/render_helpers/offscreen.rs
@@ -157,13 +157,10 @@ impl OffscreenBuffer {
 
         let res = {
             let mut target = renderer.bind(&mut inner.texture)?;
-            inner.damage.render_output(
-                renderer,
-                &mut target,
-                1,
-                &elements,
-                Color32F::TRANSPARENT,
-            )?
+            inner
+                .damage
+                .render_output(renderer, &mut target, 1, &elements, Color32F::TRANSPARENT)
+                .context("error rendering")?
         };
 
         // Add the resulting damage to the outer tracker.

--- a/src/render_helpers/primary_gpu_texture.rs
+++ b/src/render_helpers/primary_gpu_texture.rs
@@ -1,6 +1,7 @@
 use smithay::backend::renderer::element::{Element, Id, Kind, RenderElement, UnderlyingStorage};
 use smithay::backend::renderer::gles::{GlesError, GlesFrame, GlesRenderer, GlesTexture};
 use smithay::backend::renderer::utils::{CommitCounter, DamageSet, OpaqueRegions};
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Physical, Rectangle, Scale, Transform};
 
 use super::renderer::AsGlesFrame;
@@ -61,9 +62,18 @@ impl RenderElement<GlesRenderer> for PrimaryGpuTextureRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         let gles_frame = frame.as_gles_frame();
-        RenderElement::<GlesRenderer>::draw(&self.0, gles_frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(
+            &self.0,
+            gles_frame,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            cache,
+        )?;
         Ok(())
     }
 
@@ -82,9 +92,18 @@ impl<'render> RenderElement<TtyRenderer<'render>> for PrimaryGpuTextureRenderEle
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), TtyRendererError<'render>> {
         let gles_frame = frame.as_gles_frame();
-        RenderElement::<GlesRenderer>::draw(&self.0, gles_frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(
+            &self.0,
+            gles_frame,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            cache,
+        )?;
         Ok(())
     }
 

--- a/src/render_helpers/render_elements.rs
+++ b/src/render_helpers/render_elements.rs
@@ -93,11 +93,31 @@ macro_rules! niri_render_elements {
                     $($name::$variant(elem) => elem.kind()),+
                 }
             }
+
+            fn is_framebuffer_effect(&self) -> bool {
+                match self {
+                    $($name::$variant(elem) => elem.is_framebuffer_effect()),+
+                }
+            }
         }
 
         impl smithay::backend::renderer::element::RenderElement<smithay::backend::renderer::gles::GlesRenderer>
             for $($name_R<smithay::backend::renderer::gles::GlesRenderer>)? $($name_no_R)?
         {
+            fn capture_framebuffer(
+                &self,
+                frame: &mut smithay::backend::renderer::gles::GlesFrame<'_, '_>,
+                src: smithay::utils::Rectangle<f64, smithay::utils::Buffer>,
+                dst: smithay::utils::Rectangle<i32, smithay::utils::Physical>,
+                cache: &smithay::utils::user_data::UserDataMap,
+            ) -> Result<(), smithay::backend::renderer::gles::GlesError> {
+                match self {
+                    $($name::$variant(elem) => {
+                        smithay::backend::renderer::element::RenderElement::<smithay::backend::renderer::gles::GlesRenderer>::capture_framebuffer(elem, frame, src, dst, cache)
+                    })+
+                }
+            }
+
             fn draw(
                 &self,
                 frame: &mut smithay::backend::renderer::gles::GlesFrame<'_, '_>,
@@ -105,10 +125,11 @@ macro_rules! niri_render_elements {
                 dst: smithay::utils::Rectangle<i32, smithay::utils::Physical>,
                 damage: &[smithay::utils::Rectangle<i32, smithay::utils::Physical>],
                 opaque_regions: &[smithay::utils::Rectangle<i32, smithay::utils::Physical>],
+                cache: Option<&smithay::utils::user_data::UserDataMap>,
             ) -> Result<(), smithay::backend::renderer::gles::GlesError> {
                 match self {
                     $($name::$variant(elem) => {
-                        smithay::backend::renderer::element::RenderElement::<smithay::backend::renderer::gles::GlesRenderer>::draw(elem, frame, src, dst, damage, opaque_regions)
+                        smithay::backend::renderer::element::RenderElement::<smithay::backend::renderer::gles::GlesRenderer>::draw(elem, frame, src, dst, damage, opaque_regions, cache)
                     })+
                 }
             }
@@ -123,6 +144,20 @@ macro_rules! niri_render_elements {
         impl<'render> smithay::backend::renderer::element::RenderElement<$crate::backend::tty::TtyRenderer<'render>>
             for $($name_R<$crate::backend::tty::TtyRenderer<'render>>)? $($name_no_R)?
         {
+            fn capture_framebuffer(
+                &self,
+                frame: &mut $crate::backend::tty::TtyFrame<'render, '_, '_>,
+                src: smithay::utils::Rectangle<f64, smithay::utils::Buffer>,
+                dst: smithay::utils::Rectangle<i32, smithay::utils::Physical>,
+                cache: &smithay::utils::user_data::UserDataMap,
+            ) -> Result<(), $crate::backend::tty::TtyRendererError<'render>> {
+                match self {
+                    $($name::$variant(elem) => {
+                        smithay::backend::renderer::element::RenderElement::<$crate::backend::tty::TtyRenderer<'render>>::capture_framebuffer(elem, frame, src, dst, cache)
+                    })+
+                }
+            }
+
             fn draw(
                 &self,
                 frame: &mut $crate::backend::tty::TtyFrame<'render, '_, '_>,
@@ -130,10 +165,11 @@ macro_rules! niri_render_elements {
                 dst: smithay::utils::Rectangle<i32, smithay::utils::Physical>,
                 damage: &[smithay::utils::Rectangle<i32, smithay::utils::Physical>],
                 opaque_regions: &[smithay::utils::Rectangle<i32, smithay::utils::Physical>],
+                cache: Option<&smithay::utils::user_data::UserDataMap>,
             ) -> Result<(), $crate::backend::tty::TtyRendererError<'render>> {
                 match self {
                     $($name::$variant(elem) => {
-                        smithay::backend::renderer::element::RenderElement::<$crate::backend::tty::TtyRenderer<'render>>::draw(elem, frame, src, dst, damage, opaque_regions)
+                        smithay::backend::renderer::element::RenderElement::<$crate::backend::tty::TtyRenderer<'render>>::draw(elem, frame, src, dst, damage, opaque_regions, cache)
                     })+
                 }
             }

--- a/src/render_helpers/resize.rs
+++ b/src/render_helpers/resize.rs
@@ -8,6 +8,7 @@ use smithay::backend::renderer::gles::{GlesError, GlesFrame, GlesRenderer, GlesT
 use smithay::backend::renderer::utils::{CommitCounter, DamageSet, OpaqueRegions};
 use smithay::backend::renderer::Texture as _;
 use smithay::gpu_span_location;
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Rectangle, Scale, Size, Transform};
 
 use super::renderer::{AsGlesFrame, NiriRenderer};
@@ -171,10 +172,19 @@ impl RenderElement<GlesRenderer> for ResizeRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         let _span = tracy_client::span!("ResizeRenderElement::draw");
         frame.with_gpu_span(gpu_span_location!("ResizeRenderElement::draw"), |frame| {
-            RenderElement::<GlesRenderer>::draw(&self.0, frame, src, dst, damage, opaque_regions)
+            RenderElement::<GlesRenderer>::draw(
+                &self.0,
+                frame,
+                src,
+                dst,
+                damage,
+                opaque_regions,
+                cache,
+            )
         })
     }
 
@@ -191,9 +201,10 @@ impl<'render> RenderElement<TtyRenderer<'render>> for ResizeRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), TtyRendererError<'render>> {
         let frame = frame.as_gles_frame();
-        RenderElement::<GlesRenderer>::draw(self, frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(self, frame, src, dst, damage, opaque_regions, cache)?;
         Ok(())
     }
 

--- a/src/render_helpers/shader_element.rs
+++ b/src/render_helpers/shader_element.rs
@@ -10,6 +10,7 @@ use smithay::backend::renderer::gles::{
 };
 use smithay::backend::renderer::utils::{CommitCounter, OpaqueRegions};
 use smithay::backend::renderer::DebugFlags;
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size};
 
 use super::renderer::AsGlesFrame;
@@ -293,6 +294,7 @@ impl RenderElement<GlesRenderer> for ShaderRenderElement {
         dest: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         let _span = tracy_client::span!("ShaderRenderElement::draw");
 
@@ -527,10 +529,11 @@ impl<'render> RenderElement<TtyRenderer<'render>> for ShaderRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), TtyRendererError<'render>> {
         let frame = frame.as_gles_frame();
 
-        RenderElement::<GlesRenderer>::draw(self, frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(self, frame, src, dst, damage, opaque_regions, cache)?;
 
         Ok(())
     }

--- a/src/render_helpers/shaders/blur.vert
+++ b/src/render_helpers/shaders/blur.vert
@@ -1,0 +1,11 @@
+#version 100
+
+attribute vec2 vert;
+varying vec2 v_coords;
+
+void main() {
+    v_coords = vert;
+    // vert goes from 0 to 1; position must be from -1 to 1.
+    vec2 position = vert * 2.0 - 1.0;
+    gl_Position = vec4(position, 1.0, 1.0);
+}

--- a/src/render_helpers/shaders/blur_down.frag
+++ b/src/render_helpers/shaders/blur_down.frag
@@ -1,0 +1,21 @@
+#version 100
+
+precision highp float;
+
+varying vec2 v_coords;
+
+uniform sampler2D tex;
+uniform vec2 half_pixel;
+uniform float offset;
+
+void main() {
+    vec2 o = half_pixel * offset;
+
+    vec4 sum = texture2D(tex, v_coords) * 4.0;
+    sum += texture2D(tex, v_coords + vec2(-o.x, -o.y));
+    sum += texture2D(tex, v_coords + vec2( o.x, -o.y));
+    sum += texture2D(tex, v_coords + vec2(-o.x,  o.y));
+    sum += texture2D(tex, v_coords + vec2( o.x,  o.y));
+
+    gl_FragColor = sum / 8.0;
+}

--- a/src/render_helpers/shaders/blur_up.frag
+++ b/src/render_helpers/shaders/blur_up.frag
@@ -1,0 +1,29 @@
+#version 100
+
+precision highp float;
+
+varying vec2 v_coords;
+
+uniform sampler2D tex;
+uniform vec2 half_pixel;
+uniform float offset;
+
+void main() {
+    vec2 o = half_pixel * offset;
+
+    vec4 sum = vec4(0.0);
+
+    // Four edge centers
+    sum += texture2D(tex, v_coords + vec2(-o.x * 2.0, 0.0));
+    sum += texture2D(tex, v_coords + vec2( o.x * 2.0, 0.0));
+    sum += texture2D(tex, v_coords + vec2(0.0, -o.y * 2.0));
+    sum += texture2D(tex, v_coords + vec2(0.0,  o.y * 2.0));
+
+    // Four diagonal corners
+    sum += texture2D(tex, v_coords + vec2(-o.x,  o.y)) * 2.0;
+    sum += texture2D(tex, v_coords + vec2( o.x,  o.y)) * 2.0;
+    sum += texture2D(tex, v_coords + vec2(-o.x, -o.y)) * 2.0;
+    sum += texture2D(tex, v_coords + vec2( o.x, -o.y)) * 2.0;
+
+    gl_FragColor = sum / 12.0;
+}

--- a/src/render_helpers/shaders/border.frag
+++ b/src/render_helpers/shaders/border.frag
@@ -208,35 +208,12 @@ vec4 gradient_color(vec2 coords) {
     return color_mix(color_from, color_to, frac);
 }
 
-float rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius) {
-    vec2 center;
-    float radius;
-
-    if (coords.x < corner_radius.x && coords.y < corner_radius.x) {
-        radius = corner_radius.x;
-        center = vec2(radius, radius);
-    } else if (size.x - corner_radius.y < coords.x && coords.y < corner_radius.y) {
-        radius = corner_radius.y;
-        center = vec2(size.x - radius, radius);
-    } else if (size.x - corner_radius.z < coords.x && size.y - corner_radius.z < coords.y) {
-        radius = corner_radius.z;
-        center = vec2(size.x - radius, size.y - radius);
-    } else if (coords.x < corner_radius.w && size.y - corner_radius.w < coords.y) {
-        radius = corner_radius.w;
-        center = vec2(radius, size.y - radius);
-    } else {
-        return 1.0;
-    }
-
-    float dist = distance(coords, center);
-    float half_px = 0.5 / niri_scale;
-    return 1.0 - smoothstep(radius - half_px, radius + half_px, dist);
-}
+float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius);
 
 void main() {
     vec3 coords_geo = input_to_geo * vec3(niri_v_coords, 1.0);
     vec4 color = gradient_color(coords_geo.xy);
-    color = color * rounding_alpha(coords_geo.xy, geo_size, outer_radius);
+    color = color * niri_rounding_alpha(coords_geo.xy, geo_size, outer_radius);
 
     if (border_width > 0.0) {
         coords_geo -= vec3(border_width);
@@ -245,7 +222,7 @@ void main() {
                 && 0.0 <= coords_geo.y && coords_geo.y <= inner_geo_size.y)
         {
             vec4 inner_radius = max(outer_radius - vec4(border_width), 0.0);
-            color = color * (1.0 - rounding_alpha(coords_geo.xy, inner_geo_size, inner_radius));
+            color = color * (1.0 - niri_rounding_alpha(coords_geo.xy, inner_geo_size, inner_radius));
         }
     }
 

--- a/src/render_helpers/shaders/clipped_surface.frag
+++ b/src/render_helpers/shaders/clipped_surface.frag
@@ -27,6 +27,7 @@ uniform vec4 corner_radius;
 uniform mat3 input_to_geo;
 
 float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius);
+vec4 postprocess(vec4 color);
 
 void main() {
     vec3 coords_geo = input_to_geo * vec3(v_coords, 1.0);
@@ -36,6 +37,8 @@ void main() {
 #if defined(NO_ALPHA)
     color = vec4(color.rgb, 1.0);
 #endif
+
+    color = postprocess(color);
 
     if (coords_geo.x < 0.0 || 1.0 < coords_geo.x || coords_geo.y < 0.0 || 1.0 < coords_geo.y) {
         // Clip outside geometry.

--- a/src/render_helpers/shaders/clipped_surface.frag
+++ b/src/render_helpers/shaders/clipped_surface.frag
@@ -26,30 +26,7 @@ uniform vec2 geo_size;
 uniform vec4 corner_radius;
 uniform mat3 input_to_geo;
 
-float rounding_alpha(vec2 coords, vec2 size) {
-    vec2 center;
-    float radius;
-
-    if (coords.x < corner_radius.x && coords.y < corner_radius.x) {
-        radius = corner_radius.x;
-        center = vec2(radius, radius);
-    } else if (size.x - corner_radius.y < coords.x && coords.y < corner_radius.y) {
-        radius = corner_radius.y;
-        center = vec2(size.x - radius, radius);
-    } else if (size.x - corner_radius.z < coords.x && size.y - corner_radius.z < coords.y) {
-        radius = corner_radius.z;
-        center = vec2(size.x - radius, size.y - radius);
-    } else if (coords.x < corner_radius.w && size.y - corner_radius.w < coords.y) {
-        radius = corner_radius.w;
-        center = vec2(radius, size.y - radius);
-    } else {
-        return 1.0;
-    }
-
-    float dist = distance(coords, center);
-    float half_px = 0.5 / niri_scale;
-    return 1.0 - smoothstep(radius - half_px, radius + half_px, dist);
-}
+float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius);
 
 void main() {
     vec3 coords_geo = input_to_geo * vec3(v_coords, 1.0);
@@ -65,7 +42,7 @@ void main() {
         color = vec4(0.0);
     } else {
         // Apply corner rounding inside geometry.
-        color = color * rounding_alpha(coords_geo.xy * geo_size, geo_size);
+        color = color * niri_rounding_alpha(coords_geo.xy * geo_size, geo_size, corner_radius);
     }
 
     // Apply final alpha and tint.

--- a/src/render_helpers/shaders/mod.rs
+++ b/src/render_helpers/shaders/mod.rs
@@ -35,7 +35,10 @@ impl Shaders {
 
         let border = ShaderProgram::compile(
             renderer,
-            include_str!("border.frag"),
+            concat!(
+                include_str!("border.frag"),
+                include_str!("rounding_alpha.frag")
+            ),
             &[
                 UniformName::new("colorspace", UniformType::_1f),
                 UniformName::new("hue_interpolation", UniformType::_1f),
@@ -58,7 +61,10 @@ impl Shaders {
 
         let shadow = ShaderProgram::compile(
             renderer,
-            include_str!("shadow.frag"),
+            concat!(
+                include_str!("shadow.frag"),
+                include_str!("rounding_alpha.frag")
+            ),
             &[
                 UniformName::new("shadow_color", UniformType::_4f),
                 UniformName::new("sigma", UniformType::_1f),
@@ -78,7 +84,10 @@ impl Shaders {
 
         let clipped_surface = renderer
             .compile_custom_texture_shader(
-                include_str!("clipped_surface.frag"),
+                concat!(
+                    include_str!("clipped_surface.frag"),
+                    include_str!("rounding_alpha.frag")
+                ),
                 &[
                     UniformName::new("niri_scale", UniformType::_1f),
                     UniformName::new("geo_size", UniformType::_2f),
@@ -183,6 +192,7 @@ fn compile_resize_program(
     let mut program = include_str!("resize_prelude.frag").to_string();
     program.push_str(src);
     program.push_str(include_str!("resize_epilogue.frag"));
+    program.push_str(include_str!("rounding_alpha.frag"));
 
     ShaderProgram::compile(
         renderer,

--- a/src/render_helpers/shaders/mod.rs
+++ b/src/render_helpers/shaders/mod.rs
@@ -8,6 +8,7 @@ use smithay::backend::renderer::gles::{
 
 use super::renderer::NiriRenderer;
 use super::shader_element::ShaderProgram;
+use crate::render_helpers::blur::BlurProgram;
 
 pub struct Shaders {
     pub border: Option<ShaderProgram>,
@@ -16,6 +17,7 @@ pub struct Shaders {
     pub postprocess_and_clip: Option<GlesTexProgram>,
     pub resize: Option<ShaderProgram>,
     pub gradient_fade: Option<GlesTexProgram>,
+    pub blur: Option<BlurProgram>,
     pub custom_resize: RefCell<Option<ShaderProgram>>,
     pub custom_close: RefCell<Option<ShaderProgram>>,
     pub custom_open: RefCell<Option<ShaderProgram>>,
@@ -140,6 +142,12 @@ impl Shaders {
             })
             .ok();
 
+        let blur = BlurProgram::compile(renderer)
+            .map_err(|err| {
+                warn!("error compiling blur shaders: {err:?}");
+            })
+            .ok();
+
         Self {
             border,
             shadow,
@@ -147,6 +155,7 @@ impl Shaders {
             postprocess_and_clip,
             resize,
             gradient_fade,
+            blur,
             custom_resize: RefCell::new(None),
             custom_close: RefCell::new(None),
             custom_open: RefCell::new(None),

--- a/src/render_helpers/shaders/mod.rs
+++ b/src/render_helpers/shaders/mod.rs
@@ -13,6 +13,7 @@ pub struct Shaders {
     pub border: Option<ShaderProgram>,
     pub shadow: Option<ShaderProgram>,
     pub clipped_surface: Option<GlesTexProgram>,
+    pub postprocess_and_clip: Option<GlesTexProgram>,
     pub resize: Option<ShaderProgram>,
     pub gradient_fade: Option<GlesTexProgram>,
     pub custom_resize: RefCell<Option<ShaderProgram>>,
@@ -86,7 +87,8 @@ impl Shaders {
             .compile_custom_texture_shader(
                 concat!(
                     include_str!("clipped_surface.frag"),
-                    include_str!("rounding_alpha.frag")
+                    include_str!("rounding_alpha.frag"),
+                    "\nvec4 postprocess(vec4 color) { return color; }",
                 ),
                 &[
                     UniformName::new("niri_scale", UniformType::_1f),
@@ -97,6 +99,26 @@ impl Shaders {
             )
             .map_err(|err| {
                 warn!("error compiling clipped surface shader: {err:?}");
+            })
+            .ok();
+
+        let postprocess_and_clip = renderer
+            .compile_custom_texture_shader(
+                concat!(
+                    include_str!("clipped_surface.frag"),
+                    include_str!("rounding_alpha.frag"),
+                    include_str!("postprocess.frag"),
+                ),
+                &[
+                    UniformName::new("niri_scale", UniformType::_1f),
+                    UniformName::new("geo_size", UniformType::_2f),
+                    UniformName::new("corner_radius", UniformType::_4f),
+                    UniformName::new("input_to_geo", UniformType::Matrix3x3),
+                    UniformName::new("bg_color", UniformType::_4f),
+                ],
+            )
+            .map_err(|err| {
+                warn!("error compiling postprocess_and_clip shader: {err:?}");
             })
             .ok();
 
@@ -120,6 +142,7 @@ impl Shaders {
             border,
             shadow,
             clipped_surface,
+            postprocess_and_clip,
             resize,
             gradient_fade,
             custom_resize: RefCell::new(None),

--- a/src/render_helpers/shaders/mod.rs
+++ b/src/render_helpers/shaders/mod.rs
@@ -114,6 +114,8 @@ impl Shaders {
                     UniformName::new("geo_size", UniformType::_2f),
                     UniformName::new("corner_radius", UniformType::_4f),
                     UniformName::new("input_to_geo", UniformType::Matrix3x3),
+                    UniformName::new("noise", UniformType::_1f),
+                    UniformName::new("saturation", UniformType::_1f),
                     UniformName::new("bg_color", UniformType::_4f),
                 ],
             )

--- a/src/render_helpers/shaders/postprocess.frag
+++ b/src/render_helpers/shaders/postprocess.frag
@@ -1,0 +1,8 @@
+uniform vec4 bg_color;
+
+vec4 postprocess(vec4 color) {
+    // Mix bg_color behind the texture (both premultiplied alpha).
+    color = color + bg_color * (1.0 - color.a);
+
+    return color;
+}

--- a/src/render_helpers/shaders/postprocess.frag
+++ b/src/render_helpers/shaders/postprocess.frag
@@ -1,6 +1,28 @@
+uniform float noise;
+uniform float saturation;
 uniform vec4 bg_color;
 
+// Interleaved Gradient Noise
+float gradient_noise(vec2 uv) {
+    const vec3 magic = vec3(0.06711056, 0.00583715, 52.9829189);
+    return fract(magic.z * fract(dot(uv, magic.xy)));
+}
+
+vec3 saturate(vec3 color, float sat) {
+    const vec3 w = vec3(0.2126, 0.7152, 0.0722);
+    return mix(vec3(dot(color, w)), color, sat);
+}
+
 vec4 postprocess(vec4 color) {
+    if (saturation != 1.0) {
+        color.rgb = saturate(color.rgb, saturation);
+    }
+
+    if (noise > 0.0) {
+        vec2 uv = gl_FragCoord.xy;
+        color.rgb += (gradient_noise(uv) - 0.5) * noise;
+    }
+
     // Mix bg_color behind the texture (both premultiplied alpha).
     color = color + bg_color * (1.0 - color.a);
 

--- a/src/render_helpers/shaders/resize_epilogue.frag
+++ b/src/render_helpers/shaders/resize_epilogue.frag
@@ -12,7 +12,7 @@ void main() {
             color = vec4(0.0);
         } else {
             // Apply corner rounding inside geometry.
-            color = color * niri_rounding_alpha(coords_curr_geo.xy * size_curr_geo.xy, size_curr_geo.xy);
+            color = color * niri_rounding_alpha(coords_curr_geo.xy * size_curr_geo.xy, size_curr_geo.xy, niri_corner_radius);
         }
     }
 

--- a/src/render_helpers/shaders/resize_prelude.frag
+++ b/src/render_helpers/shaders/resize_prelude.frag
@@ -27,27 +27,4 @@ uniform float niri_clip_to_geometry;
 uniform float niri_alpha;
 uniform float niri_scale;
 
-float niri_rounding_alpha(vec2 coords, vec2 size) {
-    vec2 center;
-    float radius;
-
-    if (coords.x < niri_corner_radius.x && coords.y < niri_corner_radius.x) {
-        radius = niri_corner_radius.x;
-        center = vec2(radius, radius);
-    } else if (size.x - niri_corner_radius.y < coords.x && coords.y < niri_corner_radius.y) {
-        radius = niri_corner_radius.y;
-        center = vec2(size.x - radius, radius);
-    } else if (size.x - niri_corner_radius.z < coords.x && size.y - niri_corner_radius.z < coords.y) {
-        radius = niri_corner_radius.z;
-        center = vec2(size.x - radius, size.y - radius);
-    } else if (coords.x < niri_corner_radius.w && size.y - niri_corner_radius.w < coords.y) {
-        radius = niri_corner_radius.w;
-        center = vec2(radius, size.y - radius);
-    } else {
-        return 1.0;
-    }
-
-    float dist = distance(coords, center);
-    float half_px = 0.5 / niri_scale;
-    return 1.0 - smoothstep(radius - half_px, radius + half_px, dist);
-}
+float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius);

--- a/src/render_helpers/shaders/rounding_alpha.frag
+++ b/src/render_helpers/shaders/rounding_alpha.frag
@@ -1,0 +1,24 @@
+float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius) {
+    vec2 center;
+    float radius;
+
+    if (coords.x < corner_radius.x && coords.y < corner_radius.x) {
+        radius = corner_radius.x;
+        center = vec2(radius, radius);
+    } else if (size.x - corner_radius.y < coords.x && coords.y < corner_radius.y) {
+        radius = corner_radius.y;
+        center = vec2(size.x - radius, radius);
+    } else if (size.x - corner_radius.z < coords.x && size.y - corner_radius.z < coords.y) {
+        radius = corner_radius.z;
+        center = vec2(size.x - radius, size.y - radius);
+    } else if (coords.x < corner_radius.w && size.y - corner_radius.w < coords.y) {
+        radius = corner_radius.w;
+        center = vec2(radius, size.y - radius);
+    } else {
+        return 1.0;
+    }
+
+    float dist = distance(coords, center);
+    float half_px = 0.5 / niri_scale;
+    return 1.0 - smoothstep(radius - half_px, radius + half_px, dist);
+}

--- a/src/render_helpers/shaders/rounding_alpha.frag
+++ b/src/render_helpers/shaders/rounding_alpha.frag
@@ -19,6 +19,9 @@ float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius) {
     }
 
     float dist = distance(coords, center);
-    float half_px = 0.5 / niri_scale;
-    return 1.0 - smoothstep(radius - half_px, radius + half_px, dist);
+
+    // Manual smoothstep() between radius - half_px and radius + half_px
+    // to avoid a division in clamp().
+    float t = clamp((dist - radius) * niri_scale + 0.5, 0.0, 1.0);
+    return 1.0 - t * t * (3.0 - 2.0 * t);
 }

--- a/src/render_helpers/shaders/shadow.frag
+++ b/src/render_helpers/shaders/shadow.frag
@@ -72,30 +72,7 @@ float roundedBoxShadow(vec2 lower, vec2 upper, vec2 point, float sigma, float co
   return value;
 }
 
-float rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius) {
-    vec2 center;
-    float radius;
-
-    if (coords.x < corner_radius.x && coords.y < corner_radius.x) {
-        radius = corner_radius.x;
-        center = vec2(radius, radius);
-    } else if (size.x - corner_radius.y < coords.x && coords.y < corner_radius.y) {
-        radius = corner_radius.y;
-        center = vec2(size.x - radius, radius);
-    } else if (size.x - corner_radius.z < coords.x && size.y - corner_radius.z < coords.y) {
-        radius = corner_radius.z;
-        center = vec2(size.x - radius, size.y - radius);
-    } else if (coords.x < corner_radius.w && size.y - corner_radius.w < coords.y) {
-        radius = corner_radius.w;
-        center = vec2(radius, size.y - radius);
-    } else {
-        return 1.0;
-    }
-
-    float dist = distance(coords, center);
-    float half_px = 0.5 / niri_scale;
-    return 1.0 - smoothstep(radius - half_px, radius + half_px, dist);
-}
+float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius);
 
 void main() {
     vec3 coords_geo = input_to_geo * vec3(niri_v_coords, 1.0);
@@ -106,7 +83,7 @@ void main() {
     float shadow_value;
     if (sigma < 0.1) {
         // With low enough sigma just draw a rounded rectangle.
-        shadow_value = rounding_alpha(coords_geo.xy, geo_size, corner_radius);
+        shadow_value = niri_rounding_alpha(coords_geo.xy, geo_size, corner_radius);
     } else {
         shadow_value = roundedBoxShadow(
             vec2(0.0, 0.0),
@@ -126,7 +103,7 @@ void main() {
     if (window_geo_size != vec2(0.0, 0.0)) {
         if (0.0 <= coords_window_geo.x && coords_window_geo.x <= window_geo_size.x
                 && 0.0 <= coords_window_geo.y && coords_window_geo.y <= window_geo_size.y) {
-            float alpha = rounding_alpha(coords_window_geo.xy, window_geo_size, window_corner_radius);
+            float alpha = niri_rounding_alpha(coords_window_geo.xy, window_geo_size, window_corner_radius);
             color = color * (1.0 - alpha);
         }
     }

--- a/src/render_helpers/shadow.rs
+++ b/src/render_helpers/shadow.rs
@@ -7,6 +7,7 @@ use smithay::backend::renderer::element::{Element, Id, Kind, RenderElement, Unde
 use smithay::backend::renderer::gles::{GlesError, GlesFrame, GlesRenderer, Uniform};
 use smithay::backend::renderer::utils::{CommitCounter, DamageSet, OpaqueRegions};
 use smithay::gpu_span_location;
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
 use super::renderer::NiriRenderer;
@@ -246,6 +247,7 @@ impl RenderElement<GlesRenderer> for ShadowRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         let _span = tracy_client::span!("ShadowRenderElement::draw");
         frame.with_gpu_span(gpu_span_location!("ShadowRenderElement::draw"), |frame| {
@@ -256,6 +258,7 @@ impl RenderElement<GlesRenderer> for ShadowRenderElement {
                 dst,
                 damage,
                 opaque_regions,
+                cache,
             )
         })
     }
@@ -273,9 +276,10 @@ impl<'render> RenderElement<TtyRenderer<'render>> for ShadowRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), TtyRendererError<'render>> {
         let frame = frame.as_gles_frame();
-        RenderElement::<GlesRenderer>::draw(self, frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(self, frame, src, dst, damage, opaque_regions, cache)?;
         Ok(())
     }
 

--- a/src/render_helpers/snapshot.rs
+++ b/src/render_helpers/snapshot.rs
@@ -6,7 +6,8 @@ use smithay::backend::renderer::element::{Kind, RenderElement};
 use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
 use smithay::utils::{Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
-use super::{render_to_encompassing_texture, RenderTarget, ToRenderElement};
+use super::{render_to_encompassing_texture, ToRenderElement};
+use crate::render_helpers::RenderCtx;
 
 /// Snapshot of a render.
 #[derive(Debug)]
@@ -43,11 +44,10 @@ where
 {
     pub fn texture(
         &self,
-        renderer: &mut GlesRenderer,
+        ctx: RenderCtx<GlesRenderer>,
         scale: Scale<f64>,
-        target: RenderTarget,
     ) -> Option<&(GlesTexture, Rectangle<i32, Physical>)> {
-        if target.should_block_out(self.block_out_from) {
+        if ctx.target.should_block_out(self.block_out_from) {
             self.blocked_out_texture.get_or_init(|| {
                 let _span = tracy_client::span!("RenderSnapshot::texture");
 
@@ -60,7 +60,7 @@ where
                     .collect();
 
                 match render_to_encompassing_texture(
-                    renderer,
+                    ctx.renderer,
                     scale,
                     Transform::Normal,
                     Fourcc::Abgr8888,
@@ -86,7 +86,7 @@ where
                     .collect();
 
                 match render_to_encompassing_texture(
-                    renderer,
+                    ctx.renderer,
                     scale,
                     Transform::Normal,
                     Fourcc::Abgr8888,

--- a/src/render_helpers/snapshot.rs
+++ b/src/render_helpers/snapshot.rs
@@ -7,7 +7,7 @@ use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
 use smithay::utils::{Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
 use super::{render_to_encompassing_texture, ToRenderElement};
-use crate::render_helpers::RenderCtx;
+use crate::render_helpers::{RenderCtx, RenderTarget};
 
 /// Snapshot of a render.
 #[derive(Debug)]
@@ -16,6 +16,12 @@ pub struct RenderSnapshot<C, B> {
     ///
     /// Relative to the geometry.
     pub contents: Vec<C>,
+
+    /// Contents that are not blocked out, but the background is blocked out.
+    ///
+    /// If `None` then the background doesn't have any blocked-out surfaces, and normal `contents`
+    /// can be used instead.
+    pub contents_with_blocked_out_bg: Option<Vec<C>>,
 
     /// Blocked-out contents.
     ///
@@ -30,6 +36,9 @@ pub struct RenderSnapshot<C, B> {
 
     /// Contents rendered into a texture (lazily).
     pub texture: OnceCell<Option<(GlesTexture, Rectangle<i32, Physical>)>>,
+
+    /// Contents with blocked-out bg rendered into a texture (lazily).
+    pub texture_with_blocked_out_bg: OnceCell<Option<(GlesTexture, Rectangle<i32, Physical>)>>,
 
     /// Blocked-out contents rendered into a texture (lazily).
     pub blocked_out_texture: OnceCell<Option<(GlesTexture, Rectangle<i32, Physical>)>>,
@@ -69,6 +78,33 @@ where
                     Ok((texture, _sync_point, geo)) => Some((texture, geo)),
                     Err(err) => {
                         warn!("error rendering blocked-out contents to texture: {err:?}");
+                        None
+                    }
+                }
+            })
+        } else if ctx.target != RenderTarget::Output && self.contents_with_blocked_out_bg.is_some()
+        {
+            let contents = self.contents_with_blocked_out_bg.as_ref().unwrap();
+            self.texture_with_blocked_out_bg.get_or_init(|| {
+                let _span = tracy_client::span!("RenderSnapshot::texture");
+
+                let elements: Vec<_> = contents
+                    .iter()
+                    .map(|baked| {
+                        baked.to_render_element(Point::from((0., 0.)), scale, 1., Kind::Unspecified)
+                    })
+                    .collect();
+
+                match render_to_encompassing_texture(
+                    ctx.renderer,
+                    scale,
+                    Transform::Normal,
+                    Fourcc::Abgr8888,
+                    &elements,
+                ) {
+                    Ok((texture, _sync_point, geo)) => Some((texture, geo)),
+                    Err(err) => {
+                        warn!("error rendering contents with blocked-out bg to texture: {err:?}");
                         None
                     }
                 }

--- a/src/render_helpers/solid_color.rs
+++ b/src/render_helpers/solid_color.rs
@@ -1,6 +1,7 @@
 use smithay::backend::renderer::element::{Element, Id, Kind, RenderElement, UnderlyingStorage};
 use smithay::backend::renderer::utils::{CommitCounter, OpaqueRegions};
 use smithay::backend::renderer::{Color32F, Frame as _, Renderer};
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size};
 
 /// Smithay's solid color buffer, but with fractional scale.
@@ -158,6 +159,7 @@ impl<R: Renderer> RenderElement<R> for SolidColorRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         frame.draw_solid(dst, damage, self.color)
     }

--- a/src/render_helpers/texture.rs
+++ b/src/render_helpers/texture.rs
@@ -3,6 +3,7 @@ use smithay::backend::renderer::element::{Element, Id, Kind, RenderElement, Unde
 use smithay::backend::renderer::gles::GlesTexture;
 use smithay::backend::renderer::utils::{CommitCounter, OpaqueRegions};
 use smithay::backend::renderer::{ContextId, Frame as _, ImportMem, Renderer, Texture};
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
 use super::memory::MemoryBuffer;
@@ -230,6 +231,7 @@ where
         dest: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), R::Error> {
         if frame.context_id() != self.buffer.renderer_context_id {
             warn!("trying to render texture from different renderer");

--- a/src/render_helpers/xray.rs
+++ b/src/render_helpers/xray.rs
@@ -1,0 +1,328 @@
+use std::array;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use glam::{Mat3, Vec2};
+use niri_config::CornerRadius;
+use smithay::backend::renderer::element::{Element, Id, RenderElement};
+use smithay::backend::renderer::gles::{
+    GlesError, GlesFrame, GlesRenderer, GlesTexProgram, Uniform,
+};
+use smithay::backend::renderer::utils::{CommitCounter, OpaqueRegions};
+use smithay::backend::renderer::Color32F;
+use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Transform};
+
+use crate::backend::tty::{TtyFrame, TtyRenderer, TtyRendererError};
+use crate::render_helpers::background_effect::RenderParams;
+use crate::render_helpers::effect_buffer::EffectBuffer;
+use crate::render_helpers::renderer::AsGlesFrame as _;
+use crate::render_helpers::shaders::{mat3_uniform, Shaders};
+use crate::render_helpers::{RenderCtx, RenderTarget};
+
+#[derive(Debug)]
+pub struct Xray {
+    // The buffers are per-render-target to avoid constant rerendering when screencasting.
+    pub background: [Rc<RefCell<EffectBuffer>>; RenderTarget::COUNT],
+    pub backdrop: [Rc<RefCell<EffectBuffer>>; RenderTarget::COUNT],
+    pub backdrop_color: Color32F,
+    pub workspaces: Vec<(Rectangle<f64, Logical>, Color32F)>,
+}
+
+/// Position for drawing xray background.
+#[derive(Debug, Clone, Copy)]
+pub struct XrayPos {
+    /// Position of geometry relative to the backdrop in zoomed coordinates.
+    ///
+    /// Should be upscaled by `zoom` to get position in backdrop coordinates.
+    pub pos_in_backdrop: Point<f64, Logical>,
+
+    /// Zoom factor between backdrop coordinates and geometry.
+    pub zoom: f64,
+}
+
+impl XrayPos {
+    pub fn new(pos_in_backdrop: Point<f64, Logical>, zoom: f64) -> Self {
+        Self {
+            pos_in_backdrop: pos_in_backdrop.downscale(zoom),
+            zoom,
+        }
+    }
+
+    pub fn offset(mut self, offset: Point<f64, Logical>) -> Self {
+        self.pos_in_backdrop += offset;
+        self
+    }
+}
+
+impl Default for XrayPos {
+    fn default() -> Self {
+        Self {
+            pos_in_backdrop: Point::new(0., 0.),
+            zoom: 1.,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct XrayElement {
+    buffer: Rc<RefCell<EffectBuffer>>,
+    id: Id,
+    geometry: Rectangle<f64, Logical>,
+    src: Rectangle<f64, Buffer>,
+    input_to_clip_geo: Mat3,
+    clip_geo_size: Vec2,
+    corner_radius: CornerRadius,
+    scale: f32,
+    bg_color: Color32F,
+    program: Option<GlesTexProgram>,
+}
+
+impl Xray {
+    pub fn new() -> Self {
+        Self {
+            background: array::from_fn(|_| Rc::new(RefCell::new(EffectBuffer::new()))),
+            backdrop: array::from_fn(|_| Rc::new(RefCell::new(EffectBuffer::new()))),
+            backdrop_color: Color32F::TRANSPARENT,
+            workspaces: Vec::new(),
+        }
+    }
+
+    pub fn render(
+        &self,
+        ctx: RenderCtx<GlesRenderer>,
+        params: RenderParams,
+        xray_pos: XrayPos,
+        push: &mut dyn FnMut(XrayElement),
+    ) {
+        let program = Shaders::get(ctx.renderer).postprocess_and_clip.clone();
+
+        let zoom = xray_pos.zoom;
+        let pos_in_backdrop = xray_pos.pos_in_backdrop.upscale(zoom);
+
+        let (clip_geo, corner_radius) = params
+            .clip
+            .unwrap_or((params.geometry, CornerRadius::default()));
+
+        let clip_offset = clip_geo.loc - params.geometry.loc;
+        let clip_pos_in_backdrop = pos_in_backdrop + clip_offset.upscale(zoom);
+
+        let geo_in_backdrop = Rectangle::new(pos_in_backdrop, params.geometry.size.upscale(zoom));
+
+        let mut backdrop = self.backdrop[ctx.target as usize].borrow_mut();
+        let backdrop_geo = Rectangle::from_size(backdrop.logical_size());
+        let intersection_with_backdrop = backdrop_geo.intersection(geo_in_backdrop);
+
+        let mut skip_backdrop = intersection_with_backdrop.is_none();
+
+        let mut background = self.background[ctx.target as usize].borrow_mut();
+        let prev = background.commit();
+        if background.prepare(ctx.renderer) {
+            if background.commit() != prev {
+                trace!("background damaged");
+            }
+
+            let clip_geo_size = Vec2::new(clip_geo.size.w as f32, clip_geo.size.h as f32);
+            let buf_size = background.logical_size();
+
+            for (ws_geo, bg_color) in &self.workspaces {
+                // If the background color is opaque, check if the workspace fully covers the
+                // element. In this case, we will skip the backdrop element since it's fully
+                // covered.
+                //
+                // FIXME: also implement some way to check if the background elements are fully
+                // covered in opaque regions, and not just the niri background color is opaque
+                let crop = if bg_color.is_opaque() && ws_geo.contains_rect(geo_in_backdrop) {
+                    skip_backdrop = true;
+                    // No need to intersect, we know it's fully covered.
+                    Some(geo_in_backdrop)
+                } else {
+                    ws_geo.intersection(geo_in_backdrop)
+                };
+
+                let Some(crop) = crop else {
+                    continue;
+                };
+
+                // If crop contains the intersection with backdrop, then the workspace fully
+                // covers the backdrop, so we can skip the backdrop.
+                //
+                // This can happen when the overview is closed (so workspaces align left/right with
+                // the backdrop) and the window is peeking out off screen to the side. In this
+                // case, this off-screen part is on top of nothing, neither workspace nor backdrop,
+                // but since the window doesn't fully cover the workspace, the check above doesn't
+                // skip the backdrop.
+                if bg_color.is_opaque()
+                    && intersection_with_backdrop
+                        .is_some_and(|backdrop| crop.contains_rect(backdrop))
+                {
+                    skip_backdrop = true;
+                }
+
+                // This can be different from zoom for surfaces that do not scale with
+                // workspaces, e.g. layer-shell top and overlay layer.
+                let ws_zoom = ws_geo.size / buf_size;
+
+                let src = Rectangle::new(crop.loc - ws_geo.loc, crop.size).downscale(ws_zoom);
+                let src = src.to_buffer(background.scale(), Transform::Normal, &buf_size);
+
+                let buf_size = Vec2::new(buf_size.w as f32, buf_size.h as f32);
+                let pos_against_buf = (clip_pos_in_backdrop - ws_geo.loc).downscale(ws_zoom);
+                let pos_against_buf = Vec2::new(pos_against_buf.x as f32, pos_against_buf.y as f32);
+                let ws_zoom_vec = Vec2::new(ws_zoom.x as f32, ws_zoom.y as f32);
+                let input_to_clip_geo = Mat3::from_scale(ws_zoom_vec / zoom as f32)
+                    * Mat3::from_scale(buf_size / clip_geo_size)
+                    * Mat3::from_translation(-pos_against_buf / buf_size);
+
+                let mut geometry =
+                    Rectangle::new(crop.loc - geo_in_backdrop.loc, crop.size).downscale(zoom);
+                geometry.loc += params.geometry.loc;
+
+                let elem = XrayElement {
+                    buffer: self.background[ctx.target as usize].clone(),
+                    id: background.id().clone(),
+                    geometry,
+                    src,
+                    input_to_clip_geo,
+                    clip_geo_size,
+                    corner_radius,
+                    scale: params.scale as f32,
+                    bg_color: *bg_color,
+                    program: program.clone(),
+                };
+                push(elem);
+            }
+        }
+
+        // If the backdrop is fully covered by opaque background, we can skip it.
+        if skip_backdrop {
+            return;
+        }
+
+        let prev = backdrop.commit();
+        if backdrop.prepare(ctx.renderer) {
+            if backdrop.commit() != prev {
+                trace!("backdrop damaged");
+            }
+
+            let buf_size = backdrop.logical_size();
+            let src = geo_in_backdrop.to_buffer(backdrop.scale(), Transform::Normal, &buf_size);
+
+            let mut clip_geo_in_backdrop = Rectangle::new(clip_offset, clip_geo.size).upscale(zoom);
+            clip_geo_in_backdrop.loc += geo_in_backdrop.loc;
+
+            let clip_pos_in_backdrop = Vec2::new(
+                clip_geo_in_backdrop.loc.x as f32,
+                clip_geo_in_backdrop.loc.y as f32,
+            );
+            let clip_geo_size = Vec2::new(
+                clip_geo_in_backdrop.size.w as f32,
+                clip_geo_in_backdrop.size.h as f32,
+            );
+
+            let buf_size = Vec2::new(buf_size.w as f32, buf_size.h as f32);
+            let input_to_clip_geo = Mat3::from_scale(buf_size / clip_geo_size)
+                * Mat3::from_translation(-clip_pos_in_backdrop / buf_size);
+
+            let elem = XrayElement {
+                buffer: self.backdrop[ctx.target as usize].clone(),
+                id: backdrop.id().clone(),
+                geometry: params.geometry,
+                src,
+                input_to_clip_geo,
+                clip_geo_size,
+                corner_radius: corner_radius.scaled_by(zoom as f32),
+                scale: params.scale as f32,
+                bg_color: self.backdrop_color,
+                program: program.clone(),
+            };
+            push(elem);
+        }
+    }
+}
+
+impl XrayElement {
+    fn compute_uniforms(&self) -> [Uniform<'static>; 5] {
+        [
+            Uniform::new("niri_scale", self.scale),
+            Uniform::new("geo_size", <[f32; 2]>::from(self.clip_geo_size)),
+            Uniform::new("corner_radius", <[f32; 4]>::from(self.corner_radius)),
+            mat3_uniform("input_to_geo", self.input_to_clip_geo),
+            Uniform::new("bg_color", self.bg_color.components()),
+        ]
+    }
+}
+
+impl Element for XrayElement {
+    fn id(&self) -> &Id {
+        &self.id
+    }
+
+    fn current_commit(&self) -> CommitCounter {
+        self.buffer.borrow().commit()
+    }
+
+    fn src(&self) -> Rectangle<f64, Buffer> {
+        self.src
+    }
+
+    fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
+        self.geometry.to_physical_precise_round(scale)
+    }
+
+    fn opaque_regions(&self, _scale: Scale<f64>) -> OpaqueRegions<i32, Physical> {
+        // FIXME: if bg_color alpha is 1 then compute opaque regions here taking corners into
+        // account
+        OpaqueRegions::default()
+    }
+}
+
+impl RenderElement<GlesRenderer> for XrayElement {
+    fn draw(
+        &self,
+        frame: &mut GlesFrame<'_, '_>,
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        _opaque_regions: &[Rectangle<i32, Physical>],
+    ) -> Result<(), GlesError> {
+        let mut buffer = self.buffer.borrow_mut();
+        let texture = match buffer.render() {
+            Ok(x) => x,
+            Err(err) => {
+                warn!("error rendering effect buffer: {err:?}");
+                return Ok(());
+            }
+        };
+
+        let uniforms = self.program.is_some().then(|| self.compute_uniforms());
+        let uniforms = uniforms.as_ref().map_or(&[][..], |x| &x[..]);
+
+        frame.render_texture_from_to(
+            &texture,
+            src,
+            dst,
+            damage,
+            // FIXME: opaque regions need to be filtered like damage.
+            &[],
+            Transform::Normal,
+            1.,
+            self.program.as_ref(),
+            uniforms,
+        )
+    }
+}
+
+impl<'render> RenderElement<TtyRenderer<'render>> for XrayElement {
+    fn draw(
+        &self,
+        frame: &mut TtyFrame<'_, '_, '_>,
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
+    ) -> Result<(), TtyRendererError<'render>> {
+        let gles_frame = frame.as_gles_frame();
+        RenderElement::<GlesRenderer>::draw(&self, gles_frame, src, dst, damage, opaque_regions)?;
+        Ok(())
+    }
+}

--- a/src/render_helpers/xray.rs
+++ b/src/render_helpers/xray.rs
@@ -73,6 +73,7 @@ pub struct XrayElement {
     clip_geo_size: Vec2,
     corner_radius: CornerRadius,
     scale: f32,
+    blur: bool,
     noise: f32,
     saturation: f32,
     bg_color: Color32F,
@@ -95,6 +96,7 @@ impl Xray {
         ctx: RenderCtx<GlesRenderer>,
         params: RenderParams,
         xray_pos: XrayPos,
+        blur: bool,
         noise: f32,
         saturation: f32,
         push: &mut dyn FnMut(XrayElement),
@@ -121,7 +123,7 @@ impl Xray {
 
         let mut background = self.background[ctx.target as usize].borrow_mut();
         let prev = background.commit();
-        if background.prepare(ctx.renderer) {
+        if background.prepare(ctx.renderer, blur) {
             if background.commit() != prev {
                 trace!("background damaged");
             }
@@ -191,6 +193,7 @@ impl Xray {
                     clip_geo_size,
                     corner_radius,
                     scale: params.scale as f32,
+                    blur,
                     noise,
                     saturation,
                     bg_color: *bg_color,
@@ -206,7 +209,7 @@ impl Xray {
         }
 
         let prev = backdrop.commit();
-        if backdrop.prepare(ctx.renderer) {
+        if backdrop.prepare(ctx.renderer, blur) {
             if backdrop.commit() != prev {
                 trace!("backdrop damaged");
             }
@@ -239,6 +242,7 @@ impl Xray {
                 clip_geo_size,
                 corner_radius: corner_radius.scaled_by(zoom as f32),
                 scale: params.scale as f32,
+                blur,
                 noise,
                 saturation,
                 bg_color: self.backdrop_color,
@@ -297,7 +301,7 @@ impl RenderElement<GlesRenderer> for XrayElement {
         _opaque_regions: &[Rectangle<i32, Physical>],
     ) -> Result<(), GlesError> {
         let mut buffer = self.buffer.borrow_mut();
-        let texture = match buffer.render() {
+        let texture = match buffer.render(frame, self.blur) {
             Ok(x) => x,
             Err(err) => {
                 warn!("error rendering effect buffer: {err:?}");

--- a/src/render_helpers/xray.rs
+++ b/src/render_helpers/xray.rs
@@ -10,7 +10,7 @@ use smithay::backend::renderer::gles::{
 };
 use smithay::backend::renderer::utils::{CommitCounter, OpaqueRegions};
 use smithay::backend::renderer::Color32F;
-use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Transform};
+use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
 use crate::backend::tty::{TtyFrame, TtyRenderer, TtyRendererError};
 use crate::render_helpers::background_effect::RenderParams;
@@ -18,6 +18,7 @@ use crate::render_helpers::effect_buffer::EffectBuffer;
 use crate::render_helpers::renderer::AsGlesFrame as _;
 use crate::render_helpers::shaders::{mat3_uniform, Shaders};
 use crate::render_helpers::{RenderCtx, RenderTarget};
+use crate::utils::region::TransformedRegion;
 
 #[derive(Debug)]
 pub struct Xray {
@@ -69,6 +70,7 @@ pub struct XrayElement {
     id: Id,
     geometry: Rectangle<f64, Logical>,
     src: Rectangle<f64, Buffer>,
+    subregion: Option<TransformedRegion>,
     input_to_clip_geo: Mat3,
     clip_geo_size: Vec2,
     corner_radius: CornerRadius,
@@ -189,6 +191,7 @@ impl Xray {
                     id: background.id().clone(),
                     geometry,
                     src,
+                    subregion: params.subregion.clone(),
                     input_to_clip_geo,
                     clip_geo_size,
                     corner_radius,
@@ -238,6 +241,7 @@ impl Xray {
                 id: backdrop.id().clone(),
                 geometry: params.geometry,
                 src,
+                subregion: params.subregion.clone(),
                 input_to_clip_geo,
                 clip_geo_size,
                 corner_radius: corner_radius.scaled_by(zoom as f32),
@@ -307,6 +311,30 @@ impl RenderElement<GlesRenderer> for XrayElement {
                 warn!("error rendering effect buffer: {err:?}");
                 return Ok(());
             }
+        };
+
+        // FIXME: avoid reallocating a fresh Vec here somehow.
+        let mut filtered_damage = Vec::new();
+        let damage = if let Some(subregion) = &self.subregion {
+            let src_to_geo = self.geometry.size / self.src.size;
+
+            // Compute crop in geometry coordinates.
+            let mut crop = src;
+            crop.loc -= self.src.loc;
+            crop = crop.upscale(src_to_geo);
+            let mut crop = crop.to_logical(1., Transform::Normal, &Size::default());
+
+            // Then convert to subregion coordinates.
+            crop.loc += self.geometry.loc;
+
+            subregion.filter_damage(crop, dst, damage, &mut filtered_damage);
+
+            if filtered_damage.is_empty() {
+                return Ok(());
+            }
+            &filtered_damage[..]
+        } else {
+            damage
         };
 
         let uniforms = self.program.is_some().then(|| self.compute_uniforms());

--- a/src/render_helpers/xray.rs
+++ b/src/render_helpers/xray.rs
@@ -10,6 +10,7 @@ use smithay::backend::renderer::gles::{
 };
 use smithay::backend::renderer::utils::{CommitCounter, OpaqueRegions};
 use smithay::backend::renderer::Color32F;
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
 use crate::backend::tty::{TtyFrame, TtyRenderer, TtyRendererError};
@@ -303,6 +304,7 @@ impl RenderElement<GlesRenderer> for XrayElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         _opaque_regions: &[Rectangle<i32, Physical>],
+        _cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         let mut buffer = self.buffer.borrow_mut();
         let texture = match buffer.render(frame, self.blur) {
@@ -363,9 +365,18 @@ impl<'render> RenderElement<TtyRenderer<'render>> for XrayElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), TtyRendererError<'render>> {
         let gles_frame = frame.as_gles_frame();
-        RenderElement::<GlesRenderer>::draw(&self, gles_frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(
+            &self,
+            gles_frame,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            cache,
+        )?;
         Ok(())
     }
 }

--- a/src/render_helpers/xray.rs
+++ b/src/render_helpers/xray.rs
@@ -73,6 +73,8 @@ pub struct XrayElement {
     clip_geo_size: Vec2,
     corner_radius: CornerRadius,
     scale: f32,
+    noise: f32,
+    saturation: f32,
     bg_color: Color32F,
     program: Option<GlesTexProgram>,
 }
@@ -87,11 +89,14 @@ impl Xray {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn render(
         &self,
         ctx: RenderCtx<GlesRenderer>,
         params: RenderParams,
         xray_pos: XrayPos,
+        noise: f32,
+        saturation: f32,
         push: &mut dyn FnMut(XrayElement),
     ) {
         let program = Shaders::get(ctx.renderer).postprocess_and_clip.clone();
@@ -186,6 +191,8 @@ impl Xray {
                     clip_geo_size,
                     corner_radius,
                     scale: params.scale as f32,
+                    noise,
+                    saturation,
                     bg_color: *bg_color,
                     program: program.clone(),
                 };
@@ -232,6 +239,8 @@ impl Xray {
                 clip_geo_size,
                 corner_radius: corner_radius.scaled_by(zoom as f32),
                 scale: params.scale as f32,
+                noise,
+                saturation,
                 bg_color: self.backdrop_color,
                 program: program.clone(),
             };
@@ -241,12 +250,14 @@ impl Xray {
 }
 
 impl XrayElement {
-    fn compute_uniforms(&self) -> [Uniform<'static>; 5] {
+    fn compute_uniforms(&self) -> [Uniform<'static>; 7] {
         [
             Uniform::new("niri_scale", self.scale),
             Uniform::new("geo_size", <[f32; 2]>::from(self.clip_geo_size)),
             Uniform::new("corner_radius", <[f32; 4]>::from(self.corner_radius)),
             mat3_uniform("input_to_geo", self.input_to_clip_geo),
+            Uniform::new("noise", self.noise),
+            Uniform::new("saturation", self.saturation),
             Uniform::new("bg_color", self.bg_color.components()),
         ]
     }

--- a/src/screencasting/mod.rs
+++ b/src/screencasting/mod.rs
@@ -578,6 +578,7 @@ impl Niri {
                 let ctx = RenderCtx {
                     renderer,
                     target: RenderTarget::Screencast,
+                    xray: None,
                 };
                 self.render(ctx, output, false, &mut |elem| elements.push(elem.into()));
 

--- a/src/screencasting/mod.rs
+++ b/src/screencasting/mod.rs
@@ -19,7 +19,7 @@ use zbus::object_server::SignalEmitter;
 use crate::dbus::mutter_screen_cast::{self, CursorMode, ScreenCastToNiri, StreamTargetId};
 use crate::niri::{CastTarget, Niri, OutputRenderElements, PointerRenderElements, State};
 use crate::niri_render_elements;
-use crate::render_helpers::RenderTarget;
+use crate::render_helpers::{RenderCtx, RenderTarget};
 use crate::utils::{get_monotonic_time, CastSessionId, CastStreamId};
 use crate::window::mapped::{MappedId, WindowCastRenderElements};
 
@@ -575,13 +575,11 @@ impl Niri {
             }
 
             if cursor_data.is_none() {
-                self.render_inner(
+                let ctx = RenderCtx {
                     renderer,
-                    output,
-                    false,
-                    RenderTarget::Screencast,
-                    &mut |elem| elements.push(elem.into()),
-                );
+                    target: RenderTarget::Screencast,
+                };
+                self.render_inner(ctx, output, false, &mut |elem| elements.push(elem.into()));
 
                 let mut pointer_pos = Point::default();
                 if self.pointer_visibility.is_visible() {

--- a/src/screencasting/mod.rs
+++ b/src/screencasting/mod.rs
@@ -579,7 +579,7 @@ impl Niri {
                     renderer,
                     target: RenderTarget::Screencast,
                 };
-                self.render_inner(ctx, output, false, &mut |elem| elements.push(elem.into()));
+                self.render(ctx, output, false, &mut |elem| elements.push(elem.into()));
 
                 let mut pointer_pos = Point::default();
                 if self.pointer_visibility.is_visible() {

--- a/src/screencasting/mod.rs
+++ b/src/screencasting/mod.rs
@@ -201,11 +201,6 @@ impl State {
 
             self.backend.with_primary_renderer(|renderer| {
                 let mut elements = Vec::new();
-                mapped.render_for_screen_cast(renderer, scale, &mut |elem| {
-                    elements.push(CastRenderElement::from(elem))
-                });
-
-                let mut pointer_elements = Vec::new();
                 let mut pointer_location = Point::default();
 
                 if self.niri.pointer_visibility.is_visible() {
@@ -225,11 +220,18 @@ impl State {
                         self.niri.render_pointer(renderer, output, &mut |elem| {
                             let elem =
                                 RelocateRenderElement::from_element(elem, pos, Relocate::Relative);
-                            pointer_elements.push(CastRenderElement::from(elem));
+                            elements.push(CastRenderElement::from(elem));
                         });
                     }
                 }
-                let cursor_data = CursorData::compute(&pointer_elements, pointer_location, scale);
+
+                let main_start = elements.len();
+                mapped.render_for_screen_cast(renderer, scale, &mut |elem| {
+                    elements.push(CastRenderElement::from(elem))
+                });
+
+                let cursor_data =
+                    CursorData::compute(&elements, main_start, pointer_location, scale);
 
                 if cast.dequeue_buffer_and_render(
                     renderer,
@@ -546,7 +548,6 @@ impl Niri {
         let scale = Scale::from(output.current_scale().fractional_scale());
 
         let mut elements = Vec::new();
-        let mut pointer = Vec::new();
         let mut cursor_data = None;
 
         let mut casts_to_stop = vec![];
@@ -575,13 +576,6 @@ impl Niri {
             }
 
             if cursor_data.is_none() {
-                let ctx = RenderCtx {
-                    renderer,
-                    target: RenderTarget::Screencast,
-                    xray: None,
-                };
-                self.render(ctx, output, false, &mut |elem| elements.push(elem.into()));
-
                 let mut pointer_pos = Point::default();
                 if self.pointer_visibility.is_visible() {
                     let output_geo = self.global_space.output_geometry(output).unwrap().to_f64();
@@ -593,12 +587,25 @@ impl Niri {
                     if output_geo.contains(pointer_loc) {
                         pointer_pos = pointer_loc - output_geo.loc;
                         self.render_pointer(renderer, output, &mut |elem| {
-                            pointer.push(elem.into())
+                            elements.push(elem.into())
                         });
                     }
                 }
 
-                cursor_data = Some(CursorData::compute(&pointer, pointer_pos, scale));
+                let main_start = elements.len();
+                let ctx = RenderCtx {
+                    renderer,
+                    target: RenderTarget::Screencast,
+                    xray: None,
+                };
+                self.render(ctx, output, false, &mut |elem| elements.push(elem.into()));
+
+                cursor_data = Some(CursorData::compute(
+                    &elements,
+                    main_start,
+                    pointer_pos,
+                    scale,
+                ));
             }
             let cursor_data = cursor_data.as_ref().unwrap();
 
@@ -659,11 +666,6 @@ impl Niri {
             }
 
             let mut elements = Vec::new();
-            mapped.render_for_screen_cast(renderer, scale, &mut |elem| {
-                elements.push(CastRenderElement::from(elem))
-            });
-
-            let mut pointer_elements = Vec::new();
             let mut pointer_location = Point::default();
 
             if self.pointer_visibility.is_visible() {
@@ -680,11 +682,17 @@ impl Niri {
                     self.render_pointer(renderer, output, &mut |elem| {
                         let elem =
                             RelocateRenderElement::from_element(elem, pos, Relocate::Relative);
-                        pointer_elements.push(CastRenderElement::from(elem));
+                        elements.push(CastRenderElement::from(elem));
                     });
                 }
             }
-            let cursor_data = CursorData::compute(&pointer_elements, pointer_location, scale);
+
+            let main_start = elements.len();
+            mapped.render_for_screen_cast(renderer, scale, &mut |elem| {
+                elements.push(CastRenderElement::from(elem))
+            });
+
+            let cursor_data = CursorData::compute(&elements, main_start, pointer_location, scale);
 
             if cast.dequeue_buffer_and_render(renderer, &elements, &cursor_data, bbox.size, scale) {
                 cast.last_frame_time = target_presentation_time;

--- a/src/screencasting/pw_utils.rs
+++ b/src/screencasting/pw_utils.rs
@@ -153,15 +153,19 @@ pub enum CastSizeChange {
 
 /// Data for drawing a cursor either as metadata or embedded.
 ///
+/// The cursor elements are expected to be at the start of the main elements slice. `elem_count` is
+/// the count of the pointer elements. This way, the full slice includes both main and cursor
+/// elements for embedded mode, and `&elements[elem_count..]` gives just the main elements for
+/// metadata mode.
+///
 /// We have weird borrowed references here in order to support both metadata and embedded cases.
 /// The cursor damage tracker needs a slice of impl Element at (0, 0), so we pass it `relocated`
-/// (luckily, &impl Element also impls Element). Then, if we need to embed the cursor, we chain the
-/// elements to the main video buffer elements, so we need the same type. We use `original` for
-/// this; `E` is expected to match the type of the main video buffer elements.
+/// (luckily, &impl Element also impls Element). Then, if we need to embed the cursor, we use the
+/// full elements slice which starts with non-relocated pointer elements (that we borrow from).
 #[derive(Debug)]
 pub struct CursorData<'a, E> {
-    /// Cursor elements at their original location.
-    original: &'a [E],
+    /// Count of the pointer elements in the slice (index of the first non-pointer element).
+    elem_count: usize,
     /// Cursor elements relocated to (0, 0).
     relocated: Vec<RelocateRenderElement<&'a E>>,
     /// Location of the cursor's hotspot in the video buffer.
@@ -175,16 +179,22 @@ pub struct CursorData<'a, E> {
 }
 
 impl<'a, E: Element> CursorData<'a, E> {
-    pub fn compute(elements: &'a [E], location: Point<f64, Logical>, scale: Scale<f64>) -> Self {
+    pub fn compute(
+        elements: &'a [E],
+        elem_count: usize,
+        location: Point<f64, Logical>,
+        scale: Scale<f64>,
+    ) -> Self {
+        let pointer_elements = &elements[..elem_count];
         let location = location.to_physical_precise_round(scale);
 
-        let geo = encompassing_geo(scale, elements.iter());
-        let relocated = Vec::from_iter(elements.iter().map(|elem| {
+        let geo = encompassing_geo(scale, pointer_elements.iter());
+        let relocated = Vec::from_iter(pointer_elements.iter().map(|elem| {
             RelocateRenderElement::from_element(elem, geo.loc.upscale(-1), Relocate::Relative)
         }));
 
         Self {
-            original: elements,
+            elem_count,
             relocated,
             location,
             hotspot: location - geo.loc,
@@ -1052,7 +1062,7 @@ impl Cast {
     pub fn dequeue_buffer_and_render(
         &mut self,
         renderer: &mut GlesRenderer,
-        elements: &[CastRenderElement<GlesRenderer>],
+        mut elements: &[CastRenderElement<GlesRenderer>],
         cursor_data: &CursorData<CastRenderElement<GlesRenderer>>,
         size: Size<i32, Physical>,
         scale: Scale<f64>,
@@ -1092,11 +1102,17 @@ impl Cast {
             );
         }
 
-        let (damage, _states) = damage_tracker.damage_output(1, elements).unwrap();
-
         let mut has_cursor_update = false;
         let mut redraw_cursor = false;
-        if self.cursor_mode != CursorMode::Hidden {
+
+        // For embedded cursor, pass the full slice (cursor + main) to the damage tracker.
+        // For metadata or hidden cursor, pass only the main elements.
+        if self.cursor_mode == CursorMode::Metadata || self.cursor_mode == CursorMode::Hidden {
+            elements = &elements[cursor_data.elem_count..];
+        }
+        let (damage, states) = damage_tracker.damage_output(1, elements).unwrap();
+
+        if self.cursor_mode == CursorMode::Metadata {
             let (damage, _states) = cursor_damage_tracker
                 .damage_output(1, &cursor_data.relocated)
                 .unwrap();
@@ -1118,33 +1134,30 @@ impl Cast {
         };
         let buffer = pw_buffer.as_ptr();
 
+        let mut inner = self.inner.borrow_mut();
+        let inner_ = &mut *inner;
+        let CastState::Ready { damage_tracker, .. } = &mut inner_.state else {
+            unreachable!()
+        };
+        let damage_tracker = damage_tracker.as_mut().unwrap();
+
         unsafe {
             let spa_buffer = (*buffer).buffer;
 
-            let mut pointer_elements = None;
             if self.cursor_mode == CursorMode::Metadata {
                 add_cursor_metadata(renderer, spa_buffer, cursor_data, redraw_cursor);
-            } else if self.cursor_mode != CursorMode::Hidden {
-                // Embed the cursor into the main render.
-                pointer_elements = Some(cursor_data.original.iter());
             }
-            let pointer_elements = pointer_elements.into_iter().flatten();
-            let elements = pointer_elements.chain(elements);
 
             // FIXME: would be good to skip rendering the full frame if only the pointer changed.
             // Unfortunately, I think the OBS PipeWire code needs to be updated first to cleanly
             // allow for that codepath.
             let fd = (*(*spa_buffer).datas).fd;
-            let dmabuf = self.inner.borrow().dmabufs[&fd].clone();
+            let dmabuf = inner_.dmabufs[&fd].clone();
 
-            match render_to_dmabuf(
-                renderer,
-                dmabuf,
-                size,
-                scale,
-                Transform::Normal,
-                elements.rev(),
-            ) {
+            let res = render_to_dmabuf(renderer, damage_tracker, dmabuf, elements, states);
+            drop(inner);
+
+            match res {
                 Ok(sync_point) => {
                     mark_buffer_as_good(pw_buffer, &mut self.sequence_counter);
                     trace!("queueing buffer with seq={}", self.sequence_counter);

--- a/src/ui/mru.rs
+++ b/src/ui/mru.rs
@@ -421,6 +421,12 @@ impl Thumbnail {
                 // Otherwise, render the solid color as is.
                 LayoutElementRenderElement::SolidColor(elem).into()
             }
+            elem @ LayoutElementRenderElement::BackgroundEffect(_) => {
+                // This is only used on popups for now. If subsurface blur is implemented, this
+                // will need to be handled somehow.
+                error!("background effect clipping is unimplemented");
+                elem.into()
+            }
         };
 
         let downscale = move |elem| {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,7 +14,9 @@ use bitflags::bitflags;
 use directories::UserDirs;
 use git_version::git_version;
 use niri_config::{Config, OutputName};
-use smithay::backend::renderer::utils::with_renderer_surface_state;
+use smithay::backend::renderer::utils::{
+    with_renderer_surface_state, RendererSurfaceStateUserData,
+};
 use smithay::input::pointer::CursorIcon;
 use smithay::output::{self, Output};
 use smithay::reexports::rustix::time::{clock_gettime, ClockId};
@@ -35,6 +37,7 @@ use crate::handlers::KdeDecorationsModeState;
 use crate::niri::ClientState;
 
 pub mod id;
+pub mod region;
 pub mod scale;
 pub mod signals;
 pub mod spawning;
@@ -323,6 +326,18 @@ pub fn output_matches_name(output: &Output, target: &str) -> bool {
 
 pub fn is_laptop_panel(connector: &str) -> bool {
     matches!(connector.get(..4), Some("eDP-" | "LVDS" | "DSI-"))
+}
+
+/// Returns the geometry of the surface.
+///
+/// Returns `None` if the surface isn't mapped.
+pub fn surface_geo(states: &SurfaceData) -> Option<Rectangle<i32, Logical>> {
+    let data = states.data_map.get::<RendererSurfaceStateUserData>();
+    data.and_then(|d| d.lock().unwrap().view())
+        .map(|view| Rectangle {
+            loc: view.offset,
+            size: view.dst,
+        })
 }
 
 pub fn with_toplevel_role<T>(

--- a/src/utils/region.rs
+++ b/src/utils/region.rs
@@ -1,0 +1,320 @@
+use std::cmp::{max, min};
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use smithay::utils::{Logical, Physical, Point, Rectangle, Scale};
+use smithay::wayland::compositor::{RectangleKind, RegionAttributes};
+
+/// Helper for fractionally transforming an i32 region while preserving adjacent rects.
+///
+/// Naively applying floating point transforms may cause adjacent rects to go misaligned due to
+/// rounding differences. This struct helps apply the transforms in such a way as to preserve
+/// alignment.
+#[derive(Debug, Clone)]
+pub struct TransformedRegion {
+    /// Non-overlapping rects (usually in surface-local coordinates).
+    pub rects: Arc<Vec<Rectangle<i32, Logical>>>,
+    /// Scale to apply to each rect.
+    pub scale: Scale<f64>,
+    /// Translation to apply to each rect after scaling.
+    pub offset: Point<f64, Logical>,
+}
+
+impl TransformedRegion {
+    /// Returns an iterator over the top-left and bottom-right corners of transformed rects.
+    pub fn iter(&self) -> impl Iterator<Item = (Point<f64, Logical>, Point<f64, Logical>)> + '_ {
+        self.rects.iter().map(|r| {
+            // Here we start in a happy i32 world where everything lines up, and rectangle loc +
+            // size is exactly equal to the adjacent rectangle's loc.
+            //
+            // Unfortunately, we're about to descend to the floating point hell. And we *really*
+            // want adjacent rects to remain adjacent no matter what. So we'll convert our rects to
+            // their extremities (rather than loc and size), and operate on those. Coordinates from
+            // adjacent rects will undergo exactly the same floating point operations, so when
+            // they're ultimately rounded to physical pixels, they will remain adjacent.
+            let r = r.to_f64();
+
+            let mut a = r.loc;
+            // f64 is enough to represent this i32 addition exactly.
+            let mut b = r.loc + r.size.to_point();
+
+            a = a.upscale(self.scale);
+            b = b.upscale(self.scale);
+
+            a += self.offset;
+            b += self.offset;
+
+            (a, b)
+        })
+    }
+
+    /// Intersects damage with this subregion.
+    pub fn filter_damage(
+        &self,
+        // Same coordinate space as self.iter().
+        crop: Rectangle<f64, Logical>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        filtered: &mut Vec<Rectangle<i32, Physical>>,
+    ) {
+        let scale = dst.size.to_f64() / crop.size;
+
+        let cs = crop.size.to_point();
+
+        for (mut a, mut b) in self.iter() {
+            // Convert to dst-relative.
+            a -= crop.loc;
+            b -= crop.loc;
+
+            // Intersect with crop.
+            let ia = Point::new(f64::max(a.x, 0.), f64::max(a.y, 0.));
+            let ib = Point::new(f64::min(b.x, cs.x), f64::min(b.y, cs.y));
+            if ib.x <= ia.x || ib.y <= ia.y {
+                // No intersection.
+                continue;
+            }
+
+            // Round extremities to physical pixels, ensuring that adjacent rectangles stay adjacent
+            // at fractional scales.
+            let ia = ia.to_physical_precise_round(scale);
+            let ib = ib.to_physical_precise_round(scale);
+
+            let r = Rectangle::from_extremities(ia, ib);
+
+            // Intersect with each damage rect.
+            for d in damage {
+                if let Some(intersection) = r.intersection(*d) {
+                    filtered.push(intersection);
+                }
+            }
+        }
+    }
+}
+
+pub fn region_to_non_overlapping_rects(
+    region: &RegionAttributes,
+    output: &mut Vec<Rectangle<i32, Logical>>,
+) {
+    let _span = tracy_client::span!("region_to_non_overlapping_rects");
+
+    output.clear();
+
+    // Collect all unique Y coordinates.
+    let ys = BTreeSet::from_iter(
+        region
+            .rects
+            .iter()
+            .flat_map(|(_, r)| [r.loc.y, r.loc.y + r.size.h]),
+    );
+
+    let mut ys = ys.into_iter();
+    let Some(mut lo) = ys.next() else {
+        // The region was empty.
+        return;
+    };
+
+    // Sorted list of non-overlapping [start, end) tuples.
+    let mut spans = Vec::<(i32, i32)>::new();
+
+    // Iterate over Y bands.
+    for hi in ys {
+        spans.clear();
+
+        'region: for (kind, r) in &region.rects {
+            // Skip rects that don't overlap with the Y band.
+            if hi <= r.loc.y || r.loc.y + r.size.h <= lo {
+                continue;
+            }
+
+            let mut x1 = r.loc.x;
+            let mut x2 = r.loc.x + r.size.w;
+            if x1 == x2 {
+                // Empty rect.
+                continue;
+            }
+
+            match *kind {
+                RectangleKind::Add => {
+                    // Iterate over existing spans backwards.
+                    for i in (0..spans.len()).rev() {
+                        let (start, end) = spans[i];
+
+                        // New span is to the right.
+                        if end < x1 {
+                            spans.insert(i + 1, (x1, x2));
+                            continue 'region;
+                        }
+
+                        // New span is to the left.
+                        if x2 < start {
+                            continue;
+                        }
+
+                        // New span overlaps this span; merge them.
+                        spans.remove(i);
+                        x1 = min(x1, start);
+                        x2 = max(x2, end);
+                    }
+
+                    spans.insert(0, (x1, x2));
+                }
+                RectangleKind::Subtract => {
+                    // Iterate over existing spans backwards.
+                    for i in (0..spans.len()).rev() {
+                        let (start, end) = spans[i];
+
+                        // Subtract span is to the right.
+                        if end <= x1 {
+                            continue 'region;
+                        }
+
+                        // Subtract span is to the left.
+                        if x2 <= start {
+                            continue;
+                        }
+
+                        // Subtract span overlaps this span.
+                        spans.remove(i);
+                        if x2 < end {
+                            spans.insert(i, (x2, end));
+                        }
+                        if start < x1 {
+                            spans.insert(i, (start, x1));
+                        }
+                    }
+                }
+            }
+        }
+
+        for (x1, x2) in spans.drain(..) {
+            output.push(Rectangle::from_extremities((x1, lo), (x2, hi)));
+        }
+
+        lo = hi;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Write as _;
+
+    use insta::assert_snapshot;
+    use proptest::prelude::*;
+    use smithay::utils::{Logical, Point, Rectangle, Size};
+    use smithay::wayland::compositor::{RectangleKind, RegionAttributes};
+
+    use super::region_to_non_overlapping_rects;
+
+    #[allow(clippy::type_complexity)]
+    fn check(rects: &[(RectangleKind, (i32, i32, i32, i32))]) -> String {
+        let region = RegionAttributes {
+            rects: rects
+                .iter()
+                .map(|(kind, (x1, y1, x2, y2))| {
+                    (*kind, Rectangle::from_extremities((*x1, *y1), (*x2, *y2)))
+                })
+                .collect(),
+        };
+        let mut output = Vec::new();
+        region_to_non_overlapping_rects(&region, &mut output);
+        let mut s = String::new();
+        for r in &output {
+            let x1 = r.loc.x;
+            let y1 = r.loc.y;
+            let x2 = x1 + r.size.w;
+            let y2 = y1 + r.size.h;
+            writeln!(s, "{x1:2} {y1:2} - {x2:2} {y2:2}").unwrap();
+        }
+        s
+    }
+
+    #[test]
+    fn test_region_to_non_overlapping_rects() {
+        use RectangleKind::*;
+
+        // empty_region
+        assert_snapshot!(check(&[]), @"");
+
+        // single_rectangle
+        assert_snapshot!(check(&[(Add, (0, 0, 10, 10))]), @" 0  0 - 10 10");
+
+        // empty_rectangle
+        assert_snapshot!(check(&[(Add, (0, 0, 0, 1))]), @"");
+        assert_snapshot!(check(&[(Add, (0, 0, 1, 0))]), @"");
+
+        // two_non_overlapping
+        assert_snapshot!(
+            check(&[(Add, (0, 0, 5, 10)), (Add, (7, 0, 12, 10))]),
+            @"
+        0  0 -  5 10
+        7  0 - 12 10
+        "
+        );
+
+        // two_overlapping
+        assert_snapshot!(
+            check(&[(Add, (0, 0, 10, 10)), (Add, (5, 5, 15, 15))]),
+            @"
+        0  0 - 10  5
+        0  5 - 15 10
+        5 10 - 15 15
+        "
+        );
+
+        // subtraction
+        assert_snapshot!(
+            check(&[(Add, (0, 0, 20, 20)), (Subtract, (5, 5, 15, 15))]),
+            @"
+         0  0 - 20  5
+         0  5 -  5 15
+        15  5 - 20 15
+         0 15 - 20 20
+        "
+        );
+
+        // adjacent_rectangles
+        assert_snapshot!(
+            check(&[(Add, (0, 0, 10, 10)), (Add, (10, 0, 20, 10))]),
+            @" 0  0 - 20 10"
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn non_overlapping_output(
+            rects in proptest::collection::vec(
+                (
+                    prop_oneof![Just(RectangleKind::Add), Just(RectangleKind::Subtract)],
+                    (0..20i32, 0..20i32, 0..20i32, 0..20i32),
+                ),
+                1..10,
+            )
+        ) {
+            let region = RegionAttributes {
+                rects: rects
+                    .into_iter()
+                    .map(|(kind, (x, y, w, h))| {
+                        (kind, Rectangle::new(Point::new(x, y), Size::new(w, h)))
+                    })
+                    .collect(),
+            };
+
+            let mut output: Vec<Rectangle<i32, Logical>> = Vec::new();
+            region_to_non_overlapping_rects(&region, &mut output);
+
+            for i in 0..output.len() {
+                prop_assert!(!output[i].is_empty());
+
+                // Verify no pair of output rectangles overlaps.
+                for j in (i + 1)..output.len() {
+                    prop_assert!(
+                        !output[i].overlaps(output[j]),
+                        "rectangles overlap: {:?} and {:?}",
+                        output[i],
+                        output[j],
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -535,6 +535,7 @@ impl Mapped {
             location,
             scale,
             1.,
+            XrayPos::default(),
             &mut |elem| push(use_border(elem)),
         );
     }
@@ -661,6 +662,7 @@ impl LayoutElement for Mapped {
         location: Point<f64, Logical>,
         scale: Scale<f64>,
         alpha: f32,
+        xray_pos: XrayPos,
         push: &mut dyn FnMut(LayoutElementRenderElement<R>),
     ) {
         if ctx.target.should_block_out(self.rules.block_out_from) {
@@ -693,10 +695,12 @@ impl LayoutElement for Mapped {
             let geometry = Rectangle::new(location + offset.to_f64(), popup_geo.size.to_f64());
             let surface_off = popup_geo.loc.upscale(-1).to_f64();
             let surface_anim_scale = Scale::from(1.);
-            let effect = niri_config::BackgroundEffect {
-                xray: Some(false),
-                ..Default::default()
-            };
+            let mut effect = popup_rules.background_effect;
+            // Default xray to false for pop-ups since they're always on top of something.
+            if effect.xray.is_none() {
+                effect.xray = Some(false);
+            }
+            let xray_pos = xray_pos.offset(offset.to_f64());
             background_effect::render_for_tile(
                 ctx.as_gles(),
                 None,
@@ -707,10 +711,10 @@ impl LayoutElement for Mapped {
                 surface_off,
                 surface_anim_scale,
                 self.blur_config,
-                CornerRadius::default(),
+                popup_rules.geometry_corner_radius.unwrap_or_default(),
                 effect,
                 false,
-                XrayPos::default(),
+                xray_pos,
                 &mut |elem| push(elem.into()),
             );
         }

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -28,6 +28,7 @@ use crate::layout::{
     LayoutElementRenderSnapshot, SizingMode,
 };
 use crate::niri_render_elements;
+use crate::render_helpers::background_effect::BackgroundEffectElement;
 use crate::render_helpers::border::BorderRenderElement;
 use crate::render_helpers::offscreen::OffscreenData;
 use crate::render_helpers::renderer::NiriRenderer;
@@ -36,7 +37,8 @@ use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderEleme
 use crate::render_helpers::surface::{
     push_elements_from_surface_tree, render_snapshot_from_surface_tree,
 };
-use crate::render_helpers::{BakedBuffer, RenderCtx, RenderTarget};
+use crate::render_helpers::xray::XrayPos;
+use crate::render_helpers::{background_effect, BakedBuffer, RenderCtx, RenderTarget};
 use crate::utils::id::IdCounter;
 use crate::utils::transaction::Transaction;
 use crate::utils::{
@@ -252,7 +254,6 @@ impl Mapped {
     pub fn new(window: Window, rules: ResolvedWindowRules, hook: HookId) -> Self {
         let surface = window.wl_surface().expect("no X11 support");
         let credentials = get_credentials_for_surface(&surface);
-
         let mut rv = Self {
             window,
             id: MappedId::next(),
@@ -407,10 +408,12 @@ impl Mapped {
 
         RenderSnapshot {
             contents,
+            contents_with_blocked_out_bg: None,
             blocked_out_contents,
             block_out_from: self.rules().block_out_from,
             size,
             texture: Default::default(),
+            texture_with_blocked_out_bg: Default::default(),
             blocked_out_texture: Default::default(),
         }
     }
@@ -523,6 +526,7 @@ impl Mapped {
             RenderCtx {
                 renderer,
                 target: RenderTarget::Screencast,
+                xray: None,
             },
             location,
             scale,
@@ -669,6 +673,29 @@ impl LayoutElement for Mapped {
                 &mut |elem| push(elem.into()),
             );
         }
+    }
+
+    fn render_background_effect(
+        &self,
+        ctx: RenderCtx<GlesRenderer>,
+        geometry: Rectangle<f64, Logical>,
+        scale: f64,
+        clip_to_geometry: bool,
+        radius: CornerRadius,
+        xray_pos: XrayPos,
+        push: &mut dyn FnMut(BackgroundEffectElement),
+    ) {
+        background_effect::render_for_tile(
+            ctx,
+            geometry,
+            scale,
+            clip_to_geometry,
+            self.toplevel().wl_surface(),
+            radius,
+            self.rules.background_effect,
+            xray_pos,
+            push,
+        );
     }
 
     fn request_size(

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -697,6 +697,7 @@ impl LayoutElement for Mapped {
         let should_block_out = ctx.target.should_block_out(self.rules.block_out_from);
         background_effect::render_for_tile(
             ctx,
+            None,
             geometry,
             scale,
             clip_to_geometry,

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -106,6 +106,9 @@ pub struct Mapped {
     /// Buffer to draw instead of the window when it should be blocked out.
     block_out_buffer: RefCell<SolidColorBuffer>,
 
+    /// The blur config, passed for background effect rendering.
+    blur_config: niri_config::Blur,
+
     /// Whether the next configure should be animated, if the configured state changed.
     animate_next_configure: bool,
 
@@ -251,7 +254,7 @@ enum RequestSizeOnce {
 }
 
 impl Mapped {
-    pub fn new(window: Window, rules: ResolvedWindowRules, hook: HookId) -> Self {
+    pub fn new(window: Window, rules: ResolvedWindowRules, hook: HookId, config: &Config) -> Self {
         let surface = window.wl_surface().expect("no X11 support");
         let credentials = get_credentials_for_surface(&surface);
         let mut rv = Self {
@@ -271,6 +274,7 @@ impl Mapped {
             is_window_cast_target: false,
             ignore_opacity_window_rule: false,
             block_out_buffer: RefCell::new(SolidColorBuffer::new((0., 0.), [0., 0., 0., 1.])),
+            blur_config: config.blur,
             animate_next_configure: false,
             animate_serials: Vec::new(),
             animation_snapshot: None,
@@ -604,6 +608,10 @@ impl LayoutElement for Mapped {
         &self.window
     }
 
+    fn update_config(&mut self, blur_config: niri_config::Blur) {
+        self.blur_config = blur_config;
+    }
+
     fn size(&self) -> Size<i32, Logical> {
         self.window.geometry().size
     }
@@ -691,6 +699,7 @@ impl LayoutElement for Mapped {
             scale,
             clip_to_geometry,
             self.toplevel().wl_surface(),
+            self.blur_config,
             radius,
             self.rules.background_effect,
             xray_pos,

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -1,7 +1,7 @@
 use std::cell::{Cell, Ref, RefCell};
 use std::time::Duration;
 
-use niri_config::{Color, CornerRadius, GradientInterpolation, WindowRule};
+use niri_config::{Color, Config, CornerRadius, GradientInterpolation, WindowRule};
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::Kind;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -689,19 +689,24 @@ impl LayoutElement for Mapped {
         geometry: Rectangle<f64, Logical>,
         scale: f64,
         clip_to_geometry: bool,
+        surface_anim_scale: Scale<f64>,
         radius: CornerRadius,
         xray_pos: XrayPos,
         push: &mut dyn FnMut(BackgroundEffectElement),
     ) {
+        let should_block_out = ctx.target.should_block_out(self.rules.block_out_from);
         background_effect::render_for_tile(
             ctx,
             geometry,
             scale,
             clip_to_geometry,
             self.toplevel().wl_surface(),
+            self.buf_loc().to_f64(),
+            surface_anim_scale,
             self.blur_config,
             radius,
             self.rules.background_effect,
+            should_block_out,
             xray_pos,
             push,
         );

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -657,7 +657,7 @@ impl LayoutElement for Mapped {
 
     fn render_popups<R: NiriRenderer>(
         &self,
-        ctx: RenderCtx<R>,
+        mut ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
         scale: Scale<f64>,
         alpha: f32,
@@ -669,15 +669,41 @@ impl LayoutElement for Mapped {
 
         let surface = self.toplevel().wl_surface();
         for (popup, offset) in PopupManager::popups_for_surface(surface) {
+            let surface = popup.wl_surface();
+            let popup_geo = popup.geometry();
             let surface_loc = location + (offset - popup.geometry().loc).to_f64();
 
             push_elements_from_surface_tree(
                 ctx.renderer,
-                popup.wl_surface(),
+                surface,
                 surface_loc.to_physical_precise_round(scale),
                 scale,
                 alpha,
                 Kind::ScanoutCandidate,
+                &mut |elem| push(elem.into()),
+            );
+
+            let geometry = Rectangle::new(location + offset.to_f64(), popup_geo.size.to_f64());
+            let surface_off = popup_geo.loc.upscale(-1).to_f64();
+            let surface_anim_scale = Scale::from(1.);
+            let effect = niri_config::BackgroundEffect {
+                xray: Some(false),
+                ..Default::default()
+            };
+            background_effect::render_for_tile(
+                ctx.as_gles(),
+                None,
+                geometry,
+                scale.x,
+                false,
+                surface,
+                surface_off,
+                surface_anim_scale,
+                self.blur_config,
+                CornerRadius::default(),
+                effect,
+                false,
+                XrayPos::default(),
                 &mut |elem| push(elem.into()),
             );
         }

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -655,20 +655,18 @@ impl LayoutElement for Mapped {
             return;
         }
 
-        let buf_pos = location - self.window.geometry().loc.to_f64();
         let surface = self.toplevel().wl_surface();
-        let mut push = |elem: WaylandSurfaceRenderElement<R>| push(elem.into());
-        for (popup, popup_offset) in PopupManager::popups_for_surface(surface) {
-            let offset = self.window.geometry().loc + popup_offset - popup.geometry().loc;
+        for (popup, offset) in PopupManager::popups_for_surface(surface) {
+            let surface_loc = location + (offset - popup.geometry().loc).to_f64();
 
             push_elements_from_surface_tree(
                 ctx.renderer,
                 popup.wl_surface(),
-                (buf_pos + offset.to_f64()).to_physical_precise_round(scale),
+                surface_loc.to_physical_precise_round(scale),
                 scale,
                 alpha,
                 Kind::ScanoutCandidate,
-                &mut push,
+                &mut |elem| push(elem.into()),
             );
         }
     }

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -6,7 +6,7 @@ use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::Kind;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::desktop::space::SpaceElement as _;
-use smithay::desktop::{PopupManager, Window};
+use smithay::desktop::{PopupKind, PopupManager, Window};
 use smithay::output::{self, Output};
 use smithay::reexports::wayland_protocols::xdg::decoration::zv1::server::zxdg_toplevel_decoration_v1;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
@@ -669,6 +669,13 @@ impl LayoutElement for Mapped {
 
         let surface = self.toplevel().wl_surface();
         for (popup, offset) in PopupManager::popups_for_surface(surface) {
+            let popup_rules = match popup {
+                PopupKind::Xdg(_) => self.rules.popups,
+                // IME popups aren't affected by rules for regular popups.
+                PopupKind::InputMethod(_) => niri_config::ResolvedPopupsRules::default(),
+            };
+            let alpha = alpha * popup_rules.opacity.unwrap_or(1.).clamp(0., 1.);
+
             let surface = popup.wl_surface();
             let popup_geo = popup.geometry();
             let surface_loc = location + (offset - popup.geometry().loc).to_f64();

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -3,8 +3,8 @@ use std::cmp::{max, min};
 use niri_config::utils::MergeWith as _;
 use niri_config::window_rule::{Match, WindowRule};
 use niri_config::{
-    BlockOutFrom, BorderRule, CornerRadius, FloatingPosition, PresetSize, ShadowRule,
-    TabIndicatorRule,
+    BackgroundEffect, BlockOutFrom, BorderRule, CornerRadius, FloatingPosition, PresetSize,
+    ShadowRule, TabIndicatorRule,
 };
 use niri_ipc::ColumnDisplay;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
@@ -119,6 +119,9 @@ pub struct ResolvedWindowRules {
 
     /// Override whether to set the Tiled xdg-toplevel state on the window.
     pub tiled_state: Option<bool>,
+
+    /// Background effect configuration.
+    pub background_effect: BackgroundEffect,
 }
 
 impl<'a> WindowRef<'a> {
@@ -296,6 +299,10 @@ impl ResolvedWindowRules {
                 if let Some(x) = rule.tiled_state {
                     resolved.tiled_state = Some(x);
                 }
+
+                resolved
+                    .background_effect
+                    .merge_with(&rule.background_effect);
             }
 
             resolved.open_on_output = open_on_output.map(|x| x.to_owned());

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -4,7 +4,7 @@ use niri_config::utils::MergeWith as _;
 use niri_config::window_rule::{Match, WindowRule};
 use niri_config::{
     BackgroundEffect, BlockOutFrom, BorderRule, CornerRadius, FloatingPosition, PresetSize,
-    ShadowRule, TabIndicatorRule,
+    ResolvedPopupsRules, ShadowRule, TabIndicatorRule,
 };
 use niri_ipc::ColumnDisplay;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
@@ -122,6 +122,9 @@ pub struct ResolvedWindowRules {
 
     /// Background effect configuration.
     pub background_effect: BackgroundEffect,
+
+    /// Rules for this window's popups.
+    pub popups: ResolvedPopupsRules,
 }
 
 impl<'a> WindowRef<'a> {
@@ -303,6 +306,8 @@ impl ResolvedWindowRules {
                 resolved
                     .background_effect
                     .merge_with(&rule.background_effect);
+
+                resolved.popups.merge_with(&rule.popups);
             }
 
             resolved.open_on_output = open_on_output.map(|x| x.to_owned());


### PR DESCRIPTION
Well, looks like I'm ready to promote this branch to a pull request. All planned features are implemented, all bugs that I knew about and wanted to fix should be fixed.

Please test and report any problems and suggestions. See the docs at https://github.com/niri-wm/niri/blob/wip/branch/docs/wiki/Window-Effects.md.

<img width="1217" height="984" alt="image" src="https://github.com/user-attachments/assets/67b0a5cd-fad4-4dfb-8be1-44e3548ddb20" />

There's no "alpha threshold" setting for blur, instead clients are encouraged to implement the [`ext-background-effect`](https://wayland.app/protocols/ext-background-effect-v1) protocol which lets them shape their background blur. It's already implemented, or in progress, in:
- Vicinae launcher
- Ghostty: https://github.com/ghostty-org/ghostty/pull/10727
- foot: https://codeberg.org/dnkl/foot/pulls/2198
- kitty: https://github.com/kovidgoyal/kitty/pull/9536
- Quickshell: https://github.com/quickshell-mirror/quickshell/pull/566
- DankMaterialShell: https://github.com/AvengeMedia/DankMaterialShell/tree/blur

> [!NOTE]
> Currently, this PR doesn't implement `ext-background-effect` for ~~popups and~~ subsurfaces. ~~This is mainly because I don't have any clients that do this to test with. If some client can do it I'll look into it.~~

This PR also implements the KDE blur protocol which makes a bunch of other clients work (Alacritty, kitty, etc.) but I'll remove it before merging because even KDE [has dropped it](https://invent.kde.org/plasma/kwin/-/commit/7f9e0aa1cd2c2ab4fea1097800893b6f780089eb) in favor of ext-background-effect.

Background blur turned out to be a massive undertaking. Not because of blur itself, but because window background effects in general required a lot of thinking and additions to the code, especially to make them as efficient as possible. Xray and non-xray background effects, both of which this PR implements, are also pretty much two entirely separate and very different beasts, both of which I had to get working with all other niri features (like block-out-from).

What's left is some code cleanups, and maybe splitting the commits a bit further.

Non-xray might land a bit later than xray because it depends on a WIP Smithay PR.

Implements #54, supersedes #1634. Thanks @visualglitch91 for rebasing and maintaining the previous blur PR all this time!