### PR TITLE
winit: add an `app-id` when running `niri` in nested mode in nested mode

### DIFF
--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -14,6 +14,7 @@ use smithay::output::{Mode, Output, PhysicalProperties, Subpixel};
 use smithay::reexports::calloop::LoopHandle;
 use smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback;
 use smithay::reexports::winit::dpi::LogicalSize;
+use smithay::reexports::winit::platform::wayland::WindowAttributesExtWayland;
 use smithay::reexports::winit::window::Window;
 use smithay::wayland::presentation::Refresh;
 
@@ -41,7 +42,8 @@ impl Winit {
         let builder = Window::default_attributes()
             .with_inner_size(LogicalSize::new(1280.0, 800.0))
             // .with_resizable(false)
-            .with_title("niri");
+            .with_title("niri")
+            .with_name("niri", "");
         let (backend, winit) = winit::init_from_attributes(builder)?;
 
         let output = Output::new(


### PR DESCRIPTION
@Axlefublr complained about in on discord :wink: 