### PR TITLE
improve config error messages for duplicate binds

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -769,7 +769,7 @@ where
     ) -> Result<Self, DecodeError<S>> {
         expect_only_children(node, ctx);
 
-        let mut seen_keys = HashSet::new();
+        let mut seen_keys: HashMap<Key, Option<&knuffel::ast::SpannedNode<S>>> = HashMap::new();
 
         let mut binds = Vec::new();
 
@@ -779,39 +779,25 @@ where
                     ctx.emit_error(e);
                 }
                 Ok(bind) => {
-                    if seen_keys.insert(bind.key) {
-                        binds.push(bind);
-                    } else {
-                        // ideally, this error should point to the previous instance of this keybind
-                        //
-                        // i (sodiboo) have tried to implement this in various ways:
-                        // miette!(), #[derive(Diagnostic)]
-                        // DecodeError::Custom, DecodeError::Conversion
-                        // nothing seems to work, and i suspect it's not possible.
-                        //
-                        // DecodeError is fairly restrictive.
-                        // even DecodeError::Custom just wraps a std::error::Error
-                        // and this erases all rich information from miette. (why???)
-                        //
-                        // why does knuffel do this?
-                        // from what i can tell, it doesn't even use DecodeError for much.
-                        // it only ever converts them to a Report anyways!
-                        // https://github.com/tailhook/knuffel/blob/c44c6b0c0f31ea6d1174d5d2ed41064922ea44ca/src/wrappers.rs#L55-L58
-                        //
-                        // besides like, allowing downstream users (such as us!)
-                        // to match on parse failure, i don't understand why
-                        // it doesn't just use a generic error type
-                        //
-                        // even the matching isn't consistent,
-                        // because errors can also be omitted as ctx.emit_error.
-                        // why does *that one* especially, require a DecodeError?
-                        //
-                        // anyways if you can make it format nicely, definitely do fix this
+                    if let Some(first_node_opt) = seen_keys.get_mut(&bind.key) {
+                        if let Some(first_node_name) = first_node_opt.take() {
+                            // Even though it's technically incorrect, we use
+                            // `DecodeError::Missing` here because it labels the bind with
+                            // "node starts here", which is the least bad option
+                            ctx.emit_error(DecodeError::missing(
+                                first_node_name,
+                                "duplicate keybind first defined here",
+                            ));
+                        }
+
                         ctx.emit_error(DecodeError::unexpected(
                             &child.node_name,
                             "keybind",
-                            "duplicate keybind",
+                            "duplicate keybind later defined here",
                         ));
+                    } else {
+                        seen_keys.insert(bind.key, Some(child));
+                        binds.push(bind);
                     }
                 }
             }

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::Duration;
@@ -769,7 +770,7 @@ where
     ) -> Result<Self, DecodeError<S>> {
         expect_only_children(node, ctx);
 
-        let mut seen_keys: HashMap<Key, Option<&knuffel::ast::SpannedNode<S>>> = HashMap::new();
+        let mut seen_keys: HashMap<Key, &knuffel::ast::SpannedNode<S>> = HashMap::new();
 
         let mut binds = Vec::new();
 
@@ -779,25 +780,26 @@ where
                     ctx.emit_error(e);
                 }
                 Ok(bind) => {
-                    if let Some(first_node_opt) = seen_keys.get_mut(&bind.key) {
-                        if let Some(first_node_name) = first_node_opt.take() {
+                    match seen_keys.entry(bind.key) {
+                        Entry::Occupied(entry) => {
                             // Even though it's technically incorrect, we use
                             // `DecodeError::Missing` here because it labels the bind with
                             // "node starts here", which is the least bad option
                             ctx.emit_error(DecodeError::missing(
-                                first_node_name,
-                                "duplicate keybind first defined here",
+                                entry.get(),
+                                "keybind first defined here",
+                            ));
+
+                            ctx.emit_error(DecodeError::unexpected(
+                                &child.node_name,
+                                "keybind",
+                                "duplicate keybind later defined here",
                             ));
                         }
-
-                        ctx.emit_error(DecodeError::unexpected(
-                            &child.node_name,
-                            "keybind",
-                            "duplicate keybind later defined here",
-                        ));
-                    } else {
-                        seen_keys.insert(bind.key, Some(child));
-                        binds.push(bind);
+                        Entry::Vacant(entry) => {
+                            entry.insert(child);
+                            binds.push(bind);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
For config files with duplicate keybinds, an additional error is emitted that points to the previous instance of the bind. If a single bind is repeated 3+ times, only the first duplicate will get an additional error.

For example, with this config:
```kdl
binds {
    Mod+Shift+Slash { show-hotkey-overlay; }

    Mod+Shift+Slash { show-hotkey-overlay; }

    Mod+Tab { focus-workspace-previous; }

    Mod+Tab { focus-workspace-previous; }

    // ...

   Mod+Shift+Slash { show-hotkey-overlay; }
}
```

This error is shown
```go
Error:   × error loading config
  ├─▶ error parsing
  ╰─▶ error parsing KDL

Error:   × duplicate keybind first defined here
     ╭─[config.kdl:337:1]
 337 │ binds {
 338 │     Mod+Shift+Slash { show-hotkey-overlay; }
     ·     ───────┬───────
     ·            ╰── node starts here
 339 │
     ╰────
Error:   × duplicate keybind later defined here
     ╭─[config.kdl:339:1]
 339 │
 340 │     Mod+Shift+Slash { show-hotkey-overlay; }
     ·     ───────┬───────
     ·            ╰── unexpected keybind
 341 │
     ╰────
Error:   × duplicate keybind first defined here
     ╭─[config.kdl:341:1]
 341 │
 342 │     Mod+Tab { focus-workspace-previous; }
     ·     ───┬───
     ·        ╰── node starts here
 343 │
     ╰────
Error:   × duplicate keybind later defined here
     ╭─[config.kdl:343:1]
 343 │
 344 │     Mod+Tab { focus-workspace-previous; }
     ·     ───┬───
     ·        ╰── unexpected keybind
 345 │
     ╰────
Error:   × duplicate keybind later defined here
     ╭─[config.kdl:600:1]
 600 │
 601 │     Mod+Shift+Slash { show-hotkey-overlay; }
     ·     ───────┬───────
     ·            ╰── unexpected keybind
 602 │ }
     ╰────
```