### PR TITLE
fix: re-apply xkb.file keymap in reset_keymap path

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -381,7 +381,13 @@ impl State {
                 let xkb_config = config.input.keyboard.xkb.clone();
                 std::mem::drop(config);
 
-                if xkb_config != Xkb::default() {
+                if let Some(xkb_file) = xkb_config.file.as_ref() {
+                    // File-based keymap: re-apply from file (to_xkb_config()
+                    // drops the file field, so we must handle it separately).
+                    if let Err(err) = self.set_xkb_file(xkb_file.clone()) {
+                        warn!("error resetting xkb_file: {err:?}");
+                    }
+                } else if xkb_config != Xkb::default() {
                     self.set_xkb_config(xkb_config.to_xkb_config());
                 } else {
                     // Use locale1 settings if xkb config is unset.

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1366,7 +1366,7 @@ impl State {
     }
 
     /// Loads the xkb keymap from a file config setting.
-    fn set_xkb_file(&mut self, xkb_file: String) -> anyhow::Result<()> {
+    pub(crate) fn set_xkb_file(&mut self, xkb_file: String) -> anyhow::Result<()> {
         let xkb_file = PathBuf::from(xkb_file);
         let xkb_file = expand_home(&xkb_file)
             .context("failed to expand ~")?


### PR DESCRIPTION
Fixes the `reset_keymap` path described in #3557 (Bug 1).

## Problem

When `reset_keymap` triggers (after a Wayland virtual keyboard event followed by a physical keyboard event), the keymap is recompiled via `to_xkb_config()`. However, `to_xkb_config()` does not include the `file` field — it only forwards `rules`, `model`, `layout`, `variant`, and `options`. This silently replaces file-based keymaps with default rules-based keymaps, losing all custom symbols and overrides.

## Fix

Check for `xkb.file` first in the `reset_keymap` path and call `set_xkb_file()` directly, mirroring how the config-reload logic handles file-based keymaps.

Also makes `set_xkb_file()` `pub(crate)` so it can be called from `input/mod.rs`.

## Changes

- `src/input/mod.rs`: In the `reset_keymap` block, prioritize `xkb.file` over `to_xkb_config()`
- `src/niri.rs`: Change `set_xkb_file` visibility from private to `pub(crate)`

## Note

Issue #3557 also describes a second bug (config reload fallback permanently poisoning the keymap when `set_xkb_file` fails transiently). That is not addressed by this PR.
