### PR TITLE
Add prefer-windowed-fullscreen window rule

### DIFF
--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -63,6 +63,8 @@ pub struct WindowRule {
     #[knuffel(child, unwrap(argument))]
     pub block_out_from: Option<BlockOutFrom>,
     #[knuffel(child, unwrap(argument))]
+    pub prefer_windowed_fullscreen: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
     pub variable_refresh_rate: Option<bool>,
     #[knuffel(child, unwrap(argument, str))]
     pub default_column_display: Option<ColumnDisplay>,

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -624,6 +624,7 @@ impl XdgShellHandler for State {
             mapped.set_needs_configure();
 
             let window = mapped.window.clone();
+            let prefer_windowed = mapped.rules.prefer_windowed_fullscreen.unwrap_or(false);
 
             if let Some(requested_output) = requested_output {
                 if Some(&requested_output) != current_output {
@@ -636,7 +637,11 @@ impl XdgShellHandler for State {
                 }
             }
 
-            self.niri.layout.set_fullscreen(&window, true);
+            if prefer_windowed {
+                self.niri.layout.toggle_windowed_fullscreen(&window);
+            } else {
+                self.niri.layout.set_fullscreen(&window, true);
+            }
         } else if let Some(unmapped) = self.niri.unmapped_windows.get_mut(toplevel.wl_surface()) {
             match &mut unmapped.state {
                 InitialConfigureState::NotConfigured {

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -59,7 +59,7 @@ pub struct Mapped {
     pre_commit_hook: HookId,
 
     /// Up-to-date rules.
-    rules: ResolvedWindowRules,
+    pub(crate) rules: ResolvedWindowRules,
 
     /// Whether the window rules need to be recomputed.
     ///

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -111,6 +111,9 @@ pub struct ResolvedWindowRules {
     /// Whether to block out this window from certain render targets.
     pub block_out_from: Option<BlockOutFrom>,
 
+    /// Whether to use windowed (fake) fullscreen instead of real fullscreen.
+    pub prefer_windowed_fullscreen: Option<bool>,
+
     /// Whether to enable VRR on this window's primary output if it is on-demand.
     pub variable_refresh_rate: Option<bool>,
 
@@ -286,6 +289,9 @@ impl ResolvedWindowRules {
                 }
                 if let Some(x) = rule.block_out_from {
                     resolved.block_out_from = Some(x);
+                }
+                if let Some(x) = rule.prefer_windowed_fullscreen {
+                    resolved.prefer_windowed_fullscreen = Some(x);
                 }
                 if let Some(x) = rule.variable_refresh_rate {
                     resolved.variable_refresh_rate = Some(x);


### PR DESCRIPTION
## Summary

Adds a `prefer-windowed-fullscreen` window rule that intercepts fullscreen requests and redirects them to windowed (fake) fullscreen instead. When an app requests fullscreen, niri calls `toggle_windowed_fullscreen` rather than `set_fullscreen`, keeping the window confined to its column.

## Motivation

On ultrawides and multi-monitor setups, true fullscreen is often counterproductive — it takes over the entire output and defeats the purpose of a tiling workflow. This is especially painful in professional settings where multitasking is the whole reason for using niri: presenting a slide deck on a Zoom call while keeping notes, a terminal, and chat visible alongside it. Without this rule, the presentation app seizes the full output and you lose all context.

This rule lets users selectively opt apps into windowed fullscreen on a per-app basis via window rules, so fullscreen-happy apps (browsers, video players, presentation tools) stay well-behaved without affecting apps where true fullscreen is desired.

## Example config

```kdl
window-rule {
    match app-id=r#"^org\.mozilla\.firefox$"#
    prefer-windowed-fullscreen true
}
```

## How minimal is this change?

The entire implementation is **15 lines added across 4 files**, with the core logic being a simple 5-line `if/else` in the xdg_shell handler:

- `niri-config/src/window_rule.rs` — new `Option<bool>` config field
- `src/window/mod.rs` — field on `ResolvedWindowRules` + 3-line resolve logic
- `src/window/mapped.rs` — visibility change on `rules` field (`pub(crate)`)
- `src/handlers/xdg_shell.rs` — the actual behavior: branch on the rule to call `toggle_windowed_fullscreen` vs `set_fullscreen`

No new dependencies, no architectural changes, no impact on existing behavior when the rule is not set.

## Test plan

- [x] Set `prefer-windowed-fullscreen true` on a window rule matching Firefox
- [x] Triggered fullscreen (e.g. YouTube video) — window fullscreens within its column, not the output
- [x] Verified apps without the rule still get normal fullscreen behavior
- [x] Verified the rule can be toggled per app-id independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)