### PR TITLE
Preserve NumLock state in set_xkb_file

### DIFF
--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1369,9 +1369,19 @@ impl State {
 
         let keymap = std::fs::read_to_string(xkb_file).context("failed to read xkb_file")?;
 
-        let xkb = self.niri.seat.get_keyboard().unwrap();
-        xkb.set_keymap_from_string(self, keymap)
+        let keyboard = self.niri.seat.get_keyboard().unwrap();
+        let num_lock = keyboard.modifier_state().num_lock;
+
+        keyboard
+            .set_keymap_from_string(self, keymap)
             .context("failed to set keymap")?;
+
+        // Restore num lock to its previous value.
+        let mut mods_state = keyboard.modifier_state();
+        if mods_state.num_lock != num_lock {
+            mods_state.num_lock = num_lock;
+            keyboard.set_modifier_state(mods_state);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Mirrors the NumLock save/restore pattern from `set_xkb_config()` in `set_xkb_file()`.

`set_keymap_from_string()` creates a fresh XKB state, resetting all locked modifiers including NumLock. `set_xkb_config()` already handles this, but `set_xkb_file()` did not — so `keyboard { numlock }` had no effect when combined with `xkb.file`.

Fixes #3575