### PR TITLE
 nix: fix NIRI_BUILD_COMMIT when tree is dirty/shortRev is not available 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
       rust-overlay,
     }:
     let
+      revision = self.shortRev or self.dirtyShortRev or "unknown";
       niri-package =
         {
           lib,
@@ -46,7 +47,7 @@
 
         rustPlatform.buildRustPackage {
           pname = "niri";
-          version = self.shortRev or self.dirtyShortRev or "unknown";
+          version = revision;
 
           src = lib.fileset.toSource {
             root = ./.;
@@ -148,7 +149,7 @@
                 "-Wl,--pop-state"
               ]
             );
-            NIRI_BUILD_COMMIT = self.shortRev;
+            NIRI_BUILD_COMMIT = revision;
           };
 
           passthru = {


### PR DESCRIPTION
Fixes failing Nix build if the git tree of niri is dirty due to shortRev being null:
```
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'niri-bf142e0-dirty'
         whose name attribute is located at /nix/store/hqgp14lgbpi50x2d4hx8bnw96r7gvy98-source/pkgs/stdenv/generic/make-derivation.nix:539:13

       … while evaluating attribute 'NIRI_BUILD_COMMIT' of derivation 'niri-bf142e0-dirty'

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'shortRev' missing
       at /nix/store/vyc366g1i5w68hslj9ikyla60xr1xxry-source/flake.nix:151:33:
          150|             );
          151|             NIRI_BUILD_COMMIT = self.shortRev;
             |                                 ^
          152|           };
```
          
Now it uses the same logic as to get the revision for the version. Tested both clean and dirty tree build in my system.