### PR TITLE
fix: no longer input locks when TTY is switched before full compositor

### DIFF
--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -441,6 +441,14 @@ impl Tty {
         }
         .map_err(|()| anyhow!("error assigning the seat to libinput"))?;
 
+        //  If the session is not active at startup (e.g. Niri was launched from a different TTY),
+        // suspend libinput now so that when ActivateSession fires, libinput.resume() performs a
+        // full re-enumeration of input devices instead of being a no-op.
+        if !session.is_active() {
+            debug!("session is not active, starting in paused state");
+            libinput.suspend();
+        }
+
         let input_backend = LibinputInputBackend::new(libinput.clone());
         event_loop
             .insert_source(input_backend, |mut event, _, state| {

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -441,11 +441,11 @@ impl Tty {
         }
         .map_err(|()| anyhow!("error assigning the seat to libinput"))?;
 
-        //  If the session is not active at startup (e.g. Niri was launched from a different TTY),
+        // If the session is not active at startup (e.g. niri was launched from a different TTY),
         // suspend libinput now so that when ActivateSession fires, libinput.resume() performs a
         // full re-enumeration of input devices instead of being a no-op.
         if !session.is_active() {
-            debug!("session is not active, starting in paused state");
+            debug!("session is not active, starting libinput in paused state");
             libinput.suspend();
         }
 


### PR DESCRIPTION
This fixes the case of starting Niri from a separate TTY (via Tmux or a TTY switch before full startup) and then switching to that Niri session causing an input lock.

I hack on Niri mostly in separate TTY and this behavior was a super annoying blocker. Resolving it required either restarting my computer (since all input was blocked) or `ssh`ing into my machine and killing that Niri session.