### PR TITLE
layout: add opt-in global workspace indices

### DIFF
--- a/docs/wiki/Configuration:-Layout.md
+++ b/docs/wiki/Configuration:-Layout.md
@@ -154,6 +154,29 @@ layout {
 }
 ```
 
+### `global-workspace-indices`
+
+If set, workspace numbers become globally unique across all outputs.
+
+Direct numeric references like `focus-workspace 1` and `move-column-to-workspace 2`
+target that global workspace number instead of the currently focused monitor's
+workspace position.
+
+Sequential actions like `focus-workspace-up`, `focus-workspace-down`, and the
+corresponding move-to-workspace actions keep operating on the current output,
+but step through globally unique workspace numbers instead of monitor-local
+positions.
+
+In this mode, each active or non-empty workspace gets a unique numeric index
+across all outputs, and empty internal placeholder workspaces are not exported
+through IPC or ext-workspace.
+
+```kdl
+layout {
+    global-workspace-indices
+}
+```
+
 ### `default-column-display`
 
 <sup>Since: 25.02</sup>

--- a/docs/wiki/Workspaces.md
+++ b/docs/wiki/Workspaces.md
@@ -35,6 +35,14 @@ Several actions in niri can address workspaces "by index": `focus-workspace 2`, 
 This index refers to whichever workspace *currently happens to be* at this position on the focused monitor.
 So, `focus-workspace 2` will always put you on the second workspace of the monitor, whichever workspace that currently is.
 
+If you enable `layout { global-workspace-indices; }`, workspace numbers become globally unique
+across all outputs instead. In that mode, each active or non-empty workspace gets a unique numeric
+index, and direct references like `focus-workspace 2` will target that global workspace rather
+than a monitor-local position.
+
+Sequential workspace actions still operate on the current output, but they step through globally
+unique workspace numbers rather than the monitor's local workspace positions.
+
 This is an important distinction from WMs with static workspace systems.
 In niri, workspaces *do not have indices on their own*.
 If you take the first workspace and move it further down on the monitor, `focus-workspace 1` will now put you on a different workspace (the one that was below the first workspace before you moved it).

--- a/niri-config/src/layout.rs
+++ b/niri-config/src/layout.rs
@@ -20,6 +20,7 @@ pub struct Layout {
     pub center_focused_column: CenterFocusedColumn,
     pub always_center_single_column: bool,
     pub empty_workspace_above_first: bool,
+    pub global_workspace_indices: bool,
     pub default_column_display: ColumnDisplay,
     pub gaps: f64,
     pub struts: Struts,
@@ -43,6 +44,7 @@ impl Default for Layout {
             center_focused_column: CenterFocusedColumn::Never,
             always_center_single_column: false,
             empty_workspace_above_first: false,
+            global_workspace_indices: false,
             default_column_display: ColumnDisplay::Normal,
             gaps: 16.,
             struts: Struts::default(),
@@ -67,6 +69,7 @@ impl MergeWith<LayoutPart> for Layout {
             insert_hint,
             always_center_single_column,
             empty_workspace_above_first,
+            global_workspace_indices,
             gaps,
         );
 
@@ -118,6 +121,8 @@ pub struct LayoutPart {
     pub always_center_single_column: Option<Flag>,
     #[knuffel(child)]
     pub empty_workspace_above_first: Option<Flag>,
+    #[knuffel(child)]
+    pub global_workspace_indices: Option<Flag>,
     #[knuffel(child, unwrap(argument, str))]
     pub default_column_display: Option<ColumnDisplay>,
     #[knuffel(child, unwrap(argument))]

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1429,6 +1429,7 @@ mod tests {
                 center_focused_column: OnOverflow,
                 always_center_single_column: false,
                 empty_workspace_above_first: false,
+                global_workspace_indices: false,
                 default_column_display: Tabbed,
                 gaps: 8.0,
                 struts: Struts {

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1418,8 +1418,12 @@ pub struct Workspace {
     ///
     /// This is the same index you can use for requests like `niri msg action focus-workspace`.
     ///
-    /// This index *will change* as you move and re-order workspace. It is merely the workspace's
-    /// current position on its monitor. Workspaces on different monitors can have the same index.
+    /// By default, this index *will change* as you move and re-order workspace. It is merely the
+    /// workspace's current position on its monitor, and workspaces on different monitors can have
+    /// the same index.
+    ///
+    /// If the `global-workspace-indices` layout option is enabled, this becomes the workspace's
+    /// global numeric index instead.
     ///
     /// If you need a unique workspace id that doesn't change, see [`Self::id`].
     pub idx: u8,

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -121,6 +121,9 @@ layout {
     //   together with the previously focused column.
     center-focused-column "never"
 
+    // Make numbered workspace references like "focus-workspace 1" global across outputs.
+    // global-workspace-indices
+
     // You can customize the widths that "switch-preset-column-width" (Mod+R) toggles between.
     preset-column-widths {
         // Proportion sets the width as a fraction of the output width, taking gaps into account.

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -217,7 +217,6 @@ impl CompositorHandler for State {
                         is_floating,
                         activate,
                     );
-                    let output = output.cloned();
 
                     // The window state cannot contain Fullscreen and Maximized at once. Therefore,
                     // if the window ended up fullscreen, then we only know that it is also

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1430,12 +1430,10 @@ impl State {
             }
             Action::FocusWorkspaceDownUnderMouse => {
                 if let Some(output) = self.niri.output_under_cursor() {
-                    if let Some(mon) = self.niri.layout.monitor_for_output_mut(&output) {
-                        mon.switch_workspace_down();
-                        self.maybe_warp_cursor_to_focus();
-                        self.niri.layer_shell_on_demand_focus = None;
-                        self.niri.queue_redraw(&output);
-                    }
+                    self.niri.layout.switch_workspace_down_on_output(&output);
+                    self.maybe_warp_cursor_to_focus();
+                    self.niri.layer_shell_on_demand_focus = None;
+                    self.niri.queue_redraw(&output);
                 }
             }
             Action::FocusWorkspaceUp => {
@@ -1447,12 +1445,10 @@ impl State {
             }
             Action::FocusWorkspaceUpUnderMouse => {
                 if let Some(output) = self.niri.output_under_cursor() {
-                    if let Some(mon) = self.niri.layout.monitor_for_output_mut(&output) {
-                        mon.switch_workspace_up();
-                        self.maybe_warp_cursor_to_focus();
-                        self.niri.layer_shell_on_demand_focus = None;
-                        self.niri.queue_redraw(&output);
-                    }
+                    self.niri.layout.switch_workspace_up_on_output(&output);
+                    self.maybe_warp_cursor_to_focus();
+                    self.niri.layer_shell_on_demand_focus = None;
+                    self.niri.queue_redraw(&output);
                 }
             }
             Action::FocusWorkspace(reference) => {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -605,6 +605,9 @@ impl State {
         let mut need_workspaces_changed = false;
         for (mon, ws_idx, ws) in layout.workspaces() {
             let id = ws.id().get();
+            let Some(display_idx) = layout.workspace_display_idx(ws.id(), ws_idx) else {
+                continue;
+            };
             seen.insert(id);
 
             let Some(ipc_ws) = state.workspaces.get(&id) else {
@@ -615,7 +618,8 @@ impl State {
 
             // Check for any changes that we can't signal as individual events.
             let output_name = mon.map(|mon| mon.output_name());
-            if ipc_ws.idx != u8::try_from(ws_idx + 1).unwrap_or(u8::MAX)
+            let display_idx = u8::try_from(display_idx).unwrap_or(u8::MAX);
+            if ipc_ws.idx != display_idx
                 || ipc_ws.name.as_ref() != ws.name()
                 || ipc_ws.output.as_ref() != output_name
             {
@@ -661,18 +665,19 @@ impl State {
 
             let workspaces = layout
                 .workspaces()
-                .map(|(mon, ws_idx, ws)| {
+                .filter_map(|(mon, ws_idx, ws)| {
+                    let display_idx = layout.workspace_display_idx(ws.id(), ws_idx)?;
                     let id = ws.id().get();
-                    Workspace {
+                    Some(Workspace {
                         id,
-                        idx: u8::try_from(ws_idx + 1).unwrap_or(u8::MAX),
+                        idx: u8::try_from(display_idx).unwrap_or(u8::MAX),
                         name: ws.name().cloned(),
                         output: mon.map(|mon| mon.output_name().clone()),
                         is_urgent: ws.is_urgent(),
                         is_active: mon.is_some_and(|mon| mon.active_workspace_idx() == ws_idx),
                         is_focused: Some(id) == focused_ws_id,
                         active_window_id: ws.active_window().map(|win| win.id().get()),
-                    }
+                    })
                 })
                 .collect();
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -31,7 +31,7 @@
 //! workspace just like any other. Then they come back, reconnect the second monitor, and now we
 //! don't want an unassuming workspace to end up on it.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::rc::Rc;
 use std::time::Duration;
@@ -255,16 +255,16 @@ pub trait LayoutElement {
     fn expected_size(&self) -> Option<Size<i32, Logical>> {
         if self.sizing_mode().is_fullscreen() {
             return None;
-        }
+        };
 
         let mut requested = self.requested_size().unwrap_or_default();
         let current = self.size();
         if requested.w == 0 {
             requested.w = current.w;
-        }
+        };
         if requested.h == 0 {
             requested.h = current.h;
-        }
+        };
         Some(requested)
     }
 
@@ -308,6 +308,8 @@ pub struct Layout<W: LayoutElement> {
     /// The workspace id does not necessarily point to a valid workspace. If it doesn't, then it is
     /// simply ignored.
     last_active_workspace_id: HashMap<String, WorkspaceId>,
+    /// Optional global workspace indices for workspaces when the feature is enabled.
+    global_workspace_idxs: HashMap<WorkspaceId, usize>,
     /// Ongoing interactive move.
     interactive_move: Option<InteractiveMoveState<W>>,
     /// Ongoing drag-and-drop operation.
@@ -645,6 +647,344 @@ impl OverviewProgress {
 }
 
 impl<W: LayoutElement> Layout<W> {
+    fn global_workspace_indices_enabled(&self) -> bool {
+        self.options.layout.global_workspace_indices
+    }
+
+    fn pick_global_workspace_index(&self, preferred: Option<usize>) -> usize {
+        let used: HashSet<_> = self.global_workspace_idxs.values().copied().collect();
+
+        if let Some(preferred) = preferred.filter(|preferred| *preferred > 0) {
+            if !used.contains(&preferred) {
+                return preferred;
+            }
+        }
+
+        (1..)
+            .find(|candidate| !used.contains(candidate))
+            .expect("there must always be a free global workspace index")
+    }
+
+    fn next_free_global_workspace_index_from(&self, start: usize) -> usize {
+        let used: HashSet<_> = self.global_workspace_idxs.values().copied().collect();
+
+        (start.max(1)..)
+            .find(|candidate| !used.contains(candidate))
+            .expect("there must always be a free global workspace index")
+    }
+
+    fn previous_free_global_workspace_index_from(&self, start: usize) -> Option<usize> {
+        let used: HashSet<_> = self.global_workspace_idxs.values().copied().collect();
+
+        (1..start.max(1))
+            .rev()
+            .find(|candidate| !used.contains(candidate))
+    }
+
+    fn refresh_global_workspace_indices(&mut self) {
+        if !self.global_workspace_indices_enabled() {
+            self.global_workspace_idxs.clear();
+            return;
+        }
+
+        let old_indices = mem::take(&mut self.global_workspace_idxs);
+        let mut to_reassign = Vec::new();
+        let mut to_assign = Vec::new();
+
+        match &self.monitor_set {
+            MonitorSet::Normal { monitors, .. } => {
+                for (mon_idx, mon) in monitors.iter().enumerate() {
+                    for (ws_idx, ws) in mon.workspaces.iter().enumerate() {
+                        if ws.has_windows_or_name() || ws_idx == mon.active_workspace_idx {
+                            if let Some(index) = old_indices.get(&ws.id()).copied() {
+                                to_reassign.push((ws.id(), index));
+                            } else {
+                                let preferred =
+                                    (ws_idx == mon.active_workspace_idx).then_some(mon_idx + 1);
+                                to_assign.push((ws.id(), preferred));
+                            }
+                        }
+                    }
+                }
+            }
+            MonitorSet::NoOutputs { workspaces } => {
+                for ws in workspaces {
+                    if ws.has_windows_or_name() {
+                        if let Some(index) = old_indices.get(&ws.id()).copied() {
+                            to_reassign.push((ws.id(), index));
+                        } else {
+                            to_assign.push((ws.id(), None));
+                        }
+                    }
+                }
+            }
+        }
+
+        for (id, index) in to_reassign {
+            self.global_workspace_idxs.insert(id, index);
+        }
+
+        for (id, preferred) in to_assign {
+            let index = self.pick_global_workspace_index(preferred);
+            self.global_workspace_idxs.insert(id, index);
+        }
+    }
+
+    fn find_workspace_by_global_index(
+        &self,
+        index: usize,
+    ) -> Option<(Option<Output>, usize, WorkspaceId)> {
+        let id = self
+            .global_workspace_idxs
+            .iter()
+            .find_map(|(id, candidate)| (*candidate == index).then_some(*id))?;
+        let (workspace_idx, workspace) = self.find_workspace_by_id(id)?;
+        Some((workspace.current_output().cloned(), workspace_idx, id))
+    }
+
+    fn ensure_global_workspace_by_index(
+        &mut self,
+        index: usize,
+    ) -> Option<(Option<Output>, usize)> {
+        self.refresh_global_workspace_indices();
+
+        if let Some((output, workspace_idx, _)) = self.find_workspace_by_global_index(index) {
+            return Some((output, workspace_idx));
+        }
+
+        match &mut self.monitor_set {
+            MonitorSet::Normal {
+                monitors,
+                active_monitor_idx,
+                ..
+            } => {
+                let mon_idx = *active_monitor_idx;
+
+                let active_idx = monitors[mon_idx].active_workspace_idx;
+                let active_id = monitors[mon_idx].workspaces[active_idx].id();
+                let active_is_candidate = !monitors[mon_idx].workspaces[active_idx]
+                    .has_windows_or_name()
+                    && !self.global_workspace_idxs.contains_key(&active_id);
+
+                let target_idx = if active_is_candidate {
+                    active_idx
+                } else {
+                    let last_idx = monitors[mon_idx].workspaces.len() - 1;
+                    let last_id = monitors[mon_idx].workspaces[last_idx].id();
+                    if monitors[mon_idx].workspaces[last_idx].has_windows_or_name()
+                        || self.global_workspace_idxs.contains_key(&last_id)
+                    {
+                        monitors[mon_idx].add_workspace_bottom();
+                    }
+                    monitors[mon_idx].workspaces.len() - 1
+                };
+
+                let id = monitors[mon_idx].workspaces[target_idx].id();
+                self.global_workspace_idxs.insert(id, index);
+
+                Some((Some(monitors[mon_idx].output.clone()), target_idx))
+            }
+            MonitorSet::NoOutputs { workspaces } => {
+                let target_idx = if let Some(idx) = workspaces.iter().position(|ws| {
+                    !ws.has_windows_or_name() && !self.global_workspace_idxs.contains_key(&ws.id())
+                }) {
+                    idx
+                } else {
+                    workspaces.push(Workspace::new_no_outputs(
+                        self.clock.clone(),
+                        self.options.clone(),
+                    ));
+                    workspaces.len() - 1
+                };
+
+                let id = workspaces[target_idx].id();
+                self.global_workspace_idxs.insert(id, index);
+
+                Some((None, target_idx))
+            }
+        }
+    }
+
+    fn ensure_global_workspace_by_index_on_output(
+        &mut self,
+        output: &Output,
+        index: usize,
+    ) -> Option<usize> {
+        self.refresh_global_workspace_indices();
+
+        if let Some((existing_output, workspace_idx, _)) =
+            self.find_workspace_by_global_index(index)
+        {
+            return (existing_output.as_ref() == Some(output)).then_some(workspace_idx);
+        }
+
+        let (active_idx, active_is_candidate, last_is_occupied) = {
+            let monitor = self.monitor_for_output(output)?;
+            let active_idx = monitor.active_workspace_idx;
+            let active_id = monitor.workspaces[active_idx].id();
+            let active_is_candidate = !monitor.workspaces[active_idx].has_windows_or_name()
+                && !self.global_workspace_idxs.contains_key(&active_id);
+            let last_idx = monitor.workspaces.len() - 1;
+            let last_id = monitor.workspaces[last_idx].id();
+            let last_is_occupied = monitor.workspaces[last_idx].has_windows_or_name()
+                || self.global_workspace_idxs.contains_key(&last_id);
+            (active_idx, active_is_candidate, last_is_occupied)
+        };
+
+        let monitor = self.monitor_for_output_mut(output)?;
+
+        let target_idx = if active_is_candidate {
+            active_idx
+        } else {
+            if last_is_occupied {
+                monitor.add_workspace_bottom();
+            }
+            monitor.workspaces.len() - 1
+        };
+
+        let id = monitor.workspaces[target_idx].id();
+        self.global_workspace_idxs.insert(id, index);
+
+        Some(target_idx)
+    }
+
+    fn workspace_global_index_on_output(&mut self, output: &Output) -> Option<usize> {
+        self.refresh_global_workspace_indices();
+
+        let monitor = self.monitor_for_output(output)?;
+        let active_workspace = &monitor.workspaces[monitor.active_workspace_idx];
+        self.global_workspace_idxs
+            .get(&active_workspace.id())
+            .copied()
+    }
+
+    fn previous_global_workspace_index_on_output(&mut self, output: &Output) -> Option<usize> {
+        self.refresh_global_workspace_indices();
+
+        let current = self.workspace_global_index_on_output(output)?;
+        let monitor = self.monitor_for_output(output)?;
+
+        monitor
+            .workspaces
+            .iter()
+            .filter_map(|ws| self.global_workspace_idxs.get(&ws.id()).copied())
+            .filter(|idx| *idx < current)
+            .max()
+    }
+
+    fn next_global_workspace_index_on_output(&mut self, output: &Output) -> Option<usize> {
+        self.refresh_global_workspace_indices();
+
+        let current = self.workspace_global_index_on_output(output)?;
+        let monitor = self.monitor_for_output(output)?;
+        let active_workspace = &monitor.workspaces[monitor.active_workspace_idx];
+
+        let next_existing = monitor
+            .workspaces
+            .iter()
+            .filter_map(|ws| self.global_workspace_idxs.get(&ws.id()).copied())
+            .filter(|idx| *idx > current)
+            .min();
+
+        next_existing.or_else(|| {
+            active_workspace
+                .has_windows_or_name()
+                .then(|| self.next_free_global_workspace_index_from(current + 1))
+        })
+    }
+
+    fn next_global_workspace_index_on_output_for_move(&mut self, output: &Output) -> Option<usize> {
+        self.refresh_global_workspace_indices();
+
+        let current = self.workspace_global_index_on_output(output)?;
+        let monitor = self.monitor_for_output(output)?;
+
+        let next_existing = monitor
+            .workspaces
+            .iter()
+            .filter_map(|ws| self.global_workspace_idxs.get(&ws.id()).copied())
+            .filter(|idx| *idx > current)
+            .min();
+
+        Some(
+            next_existing
+                .unwrap_or_else(|| self.next_free_global_workspace_index_from(current + 1)),
+        )
+    }
+
+    fn previous_global_workspace_index_on_output_for_move(
+        &mut self,
+        output: &Output,
+    ) -> Option<usize> {
+        self.refresh_global_workspace_indices();
+
+        let current = self.workspace_global_index_on_output(output)?;
+        let monitor = self.monitor_for_output(output)?;
+
+        let previous_existing = monitor
+            .workspaces
+            .iter()
+            .filter_map(|ws| self.global_workspace_idxs.get(&ws.id()).copied())
+            .filter(|idx| *idx < current)
+            .max();
+
+        previous_existing.or_else(|| self.previous_free_global_workspace_index_from(current))
+    }
+
+    fn switch_workspace_to_global_index_on_output(&mut self, output: &Output, index: usize) {
+        let Some(workspace_idx) = self.ensure_global_workspace_by_index_on_output(output, index)
+        else {
+            return;
+        };
+        let Some(monitor) = self.monitor_for_output_mut(output) else {
+            return;
+        };
+        monitor.activate_workspace(workspace_idx);
+        self.refresh_global_workspace_indices();
+    }
+
+    fn move_active_workspace_to_global_index_on_output(&mut self, output: &Output, index: usize) {
+        self.refresh_global_workspace_indices();
+
+        let Some((active_id, current_index)) =
+            self.monitor_for_output(output).and_then(|monitor| {
+                let workspace = &monitor.workspaces[monitor.active_workspace_idx];
+                self.global_workspace_idxs
+                    .get(&workspace.id())
+                    .copied()
+                    .map(|idx| (workspace.id(), idx))
+            })
+        else {
+            return;
+        };
+
+        if current_index == index {
+            return;
+        }
+
+        let swap_with = self.monitor_for_output(output).and_then(|monitor| {
+            monitor.workspaces.iter().find_map(|ws| {
+                (self.global_workspace_idxs.get(&ws.id()).copied() == Some(index))
+                    .then_some(ws.id())
+            })
+        });
+
+        self.global_workspace_idxs.insert(active_id, index);
+        if let Some(other_id) = swap_with {
+            self.global_workspace_idxs.insert(other_id, current_index);
+        }
+
+        self.refresh_global_workspace_indices();
+    }
+
+    pub fn workspace_display_idx(&self, id: WorkspaceId, ws_idx: usize) -> Option<usize> {
+        if self.global_workspace_indices_enabled() {
+            self.global_workspace_idxs.get(&id).copied()
+        } else {
+            Some(ws_idx + 1)
+        }
+    }
+
     pub fn new(clock: Clock, config: &Config) -> Self {
         Self::with_options_and_workspaces(clock, config, Options::from_config(config))
     }
@@ -654,6 +994,7 @@ impl<W: LayoutElement> Layout<W> {
             monitor_set: MonitorSet::NoOutputs { workspaces: vec![] },
             is_active: true,
             last_active_workspace_id: HashMap::new(),
+            global_workspace_idxs: HashMap::new(),
             interactive_move: None,
             dnd: None,
             clock,
@@ -679,6 +1020,7 @@ impl<W: LayoutElement> Layout<W> {
             monitor_set: MonitorSet::NoOutputs { workspaces },
             is_active: true,
             last_active_workspace_id: HashMap::new(),
+            global_workspace_idxs: HashMap::new(),
             interactive_move: None,
             dnd: None,
             clock,
@@ -794,7 +1136,9 @@ impl<W: LayoutElement> Layout<W> {
                     active_monitor_idx: 0,
                 }
             }
-        }
+        };
+
+        self.refresh_global_workspace_indices();
     }
 
     pub fn remove_output(&mut self, output: &Output) {
@@ -852,7 +1196,9 @@ impl<W: LayoutElement> Layout<W> {
             MonitorSet::NoOutputs { .. } => {
                 panic!("tried to remove output when there were already none")
             }
-        }
+        };
+
+        self.refresh_global_workspace_indices();
     }
 
     pub fn add_column_by_idx(
@@ -891,11 +1237,11 @@ impl<W: LayoutElement> Layout<W> {
         is_full_width: bool,
         is_floating: bool,
         activate: ActivateWindow,
-    ) -> Option<&Output> {
+    ) -> Option<Output> {
         let scrolling_height = height.map(SizeChange::from);
         let id = window.id().clone();
 
-        match &mut self.monitor_set {
+        let rv = match &mut self.monitor_set {
             MonitorSet::Normal {
                 monitors,
                 active_monitor_idx,
@@ -988,7 +1334,7 @@ impl<W: LayoutElement> Layout<W> {
                     }
                 }
 
-                Some(&mon.output)
+                Some(mon.output.clone())
             }
             MonitorSet::NoOutputs { workspaces } => {
                 let (ws_idx, target) = match target {
@@ -1063,7 +1409,11 @@ impl<W: LayoutElement> Layout<W> {
 
                 None
             }
-        }
+        };
+
+        self.refresh_global_workspace_indices();
+
+        rv
     }
 
     pub fn remove_window(
@@ -1137,6 +1487,7 @@ impl<W: LayoutElement> Layout<W> {
                                 mon.workspaces.remove(1);
                                 mon.active_workspace_idx = 0;
                             }
+                            self.refresh_global_workspace_indices();
                             return Some(removed);
                         }
                     }
@@ -1152,6 +1503,7 @@ impl<W: LayoutElement> Layout<W> {
                             workspaces.remove(idx);
                         }
 
+                        self.refresh_global_workspace_indices();
                         return Some(removed);
                     }
                 }
@@ -1261,11 +1613,46 @@ impl<W: LayoutElement> Layout<W> {
         None
     }
 
+    pub fn find_output_and_workspace_index(
+        &mut self,
+        reference: WorkspaceReference,
+    ) -> Option<(Option<Output>, usize)> {
+        match reference {
+            WorkspaceReference::Index(index) if self.global_workspace_indices_enabled() => {
+                self.ensure_global_workspace_by_index(index.max(1) as usize)
+            }
+            WorkspaceReference::Index(index) => Some((None, index.saturating_sub(1) as usize)),
+            WorkspaceReference::Name(name) => {
+                let (target_workspace_index, target_workspace) =
+                    self.find_workspace_by_name(&name)?;
+                Some((
+                    target_workspace.current_output().cloned(),
+                    target_workspace_index,
+                ))
+            }
+            WorkspaceReference::Id(id) => {
+                let id = WorkspaceId::specific(id);
+                let (target_workspace_index, target_workspace) = self.find_workspace_by_id(id)?;
+                Some((
+                    target_workspace.current_output().cloned(),
+                    target_workspace_index,
+                ))
+            }
+        }
+    }
+
     pub fn find_workspace_by_ref(
         &mut self,
         reference: WorkspaceReference,
     ) -> Option<&mut Workspace<W>> {
         if let WorkspaceReference::Index(index) = reference {
+            if self.global_workspace_indices_enabled() {
+                let index = index.max(1) as usize;
+                self.ensure_global_workspace_by_index(index)?;
+                let (_, _, id) = self.find_workspace_by_global_index(index)?;
+                return self.workspaces_mut().find(|ws| ws.id() == id);
+            }
+
             self.active_monitor().and_then(|m| {
                 let index = index.saturating_sub(1) as usize;
                 m.workspaces.get_mut(index)
@@ -1817,17 +2204,31 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn move_down_or_to_workspace_down(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
-            return;
+        let moved = {
+            let Some(workspace) = self.active_workspace_mut() else {
+                return;
+            };
+            workspace.move_down()
         };
-        monitor.move_down_or_to_workspace_down();
+        if moved {
+            return;
+        }
+
+        self.move_to_workspace_down(true);
     }
 
     pub fn move_up_or_to_workspace_up(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
-            return;
+        let moved = {
+            let Some(workspace) = self.active_workspace_mut() else {
+                return;
+            };
+            workspace.move_up()
         };
-        monitor.move_up_or_to_workspace_up();
+        if moved {
+            return;
+        }
+
+        self.move_to_workspace_up(true);
     }
 
     pub fn consume_or_expel_window_left(&mut self, window: Option<&W::Id>) {
@@ -2019,17 +2420,31 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn focus_window_or_workspace_down(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
-            return;
+        let focused = {
+            let Some(workspace) = self.active_workspace_mut() else {
+                return;
+            };
+            workspace.focus_down()
         };
-        monitor.focus_window_or_workspace_down();
+        if focused {
+            return;
+        }
+
+        self.switch_workspace_down();
     }
 
     pub fn focus_window_or_workspace_up(&mut self) {
-        let Some(monitor) = self.active_monitor() else {
-            return;
+        let focused = {
+            let Some(workspace) = self.active_workspace_mut() else {
+                return;
+            };
+            workspace.focus_up()
         };
-        monitor.focus_window_or_workspace_up();
+        if focused {
+            return;
+        }
+
+        self.switch_workspace_up();
     }
 
     pub fn focus_window_top(&mut self) {
@@ -2061,17 +2476,68 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn move_to_workspace_up(&mut self, focus: bool) {
+        if self.global_workspace_indices_enabled() {
+            let Some(output) = self.active_output().cloned() else {
+                return;
+            };
+            let Some(index) = self.previous_global_workspace_index_on_output_for_move(&output)
+            else {
+                return;
+            };
+            let Some(target_idx) = self.ensure_global_workspace_by_index_on_output(&output, index)
+            else {
+                return;
+            };
+            let Some(monitor) = self.active_monitor() else {
+                return;
+            };
+            let activate = if focus {
+                ActivateWindow::Yes
+            } else {
+                ActivateWindow::Smart
+            };
+            monitor.move_to_workspace(None, target_idx, activate);
+            self.refresh_global_workspace_indices();
+            return;
+        }
+
         let Some(monitor) = self.active_monitor() else {
             return;
         };
         monitor.move_to_workspace_up(focus);
+        self.refresh_global_workspace_indices();
     }
 
     pub fn move_to_workspace_down(&mut self, focus: bool) {
+        if self.global_workspace_indices_enabled() {
+            let Some(output) = self.active_output().cloned() else {
+                return;
+            };
+            let Some(index) = self.next_global_workspace_index_on_output_for_move(&output) else {
+                return;
+            };
+            let Some(target_idx) = self.ensure_global_workspace_by_index_on_output(&output, index)
+            else {
+                return;
+            };
+            let Some(monitor) = self.active_monitor() else {
+                return;
+            };
+            let activate = if focus {
+                ActivateWindow::Yes
+            } else {
+                ActivateWindow::Smart
+            };
+            monitor.move_to_workspace(None, target_idx, activate);
+            self.refresh_global_workspace_indices();
+            return;
+        }
+
         let Some(monitor) = self.active_monitor() else {
             return;
         };
         monitor.move_to_workspace_down(focus);
+        self.refresh_global_workspace_indices();
     }
 
     pub fn move_to_workspace(
@@ -2103,20 +2569,62 @@ impl<W: LayoutElement> Layout<W> {
             monitor
         };
         monitor.move_to_workspace(window, idx, activate);
+        self.refresh_global_workspace_indices();
     }
 
     pub fn move_column_to_workspace_up(&mut self, activate: bool) {
+        if self.global_workspace_indices_enabled() {
+            let Some(output) = self.active_output().cloned() else {
+                return;
+            };
+            let Some(index) = self.previous_global_workspace_index_on_output_for_move(&output)
+            else {
+                return;
+            };
+            let Some(target_idx) = self.ensure_global_workspace_by_index_on_output(&output, index)
+            else {
+                return;
+            };
+            let Some(monitor) = self.active_monitor() else {
+                return;
+            };
+            monitor.move_column_to_workspace(target_idx, activate);
+            self.refresh_global_workspace_indices();
+            return;
+        }
+
         let Some(monitor) = self.active_monitor() else {
             return;
         };
         monitor.move_column_to_workspace_up(activate);
+        self.refresh_global_workspace_indices();
     }
 
     pub fn move_column_to_workspace_down(&mut self, activate: bool) {
+        if self.global_workspace_indices_enabled() {
+            let Some(output) = self.active_output().cloned() else {
+                return;
+            };
+            let Some(index) = self.next_global_workspace_index_on_output_for_move(&output) else {
+                return;
+            };
+            let Some(target_idx) = self.ensure_global_workspace_by_index_on_output(&output, index)
+            else {
+                return;
+            };
+            let Some(monitor) = self.active_monitor() else {
+                return;
+            };
+            monitor.move_column_to_workspace(target_idx, activate);
+            self.refresh_global_workspace_indices();
+            return;
+        }
+
         let Some(monitor) = self.active_monitor() else {
             return;
         };
         monitor.move_column_to_workspace_down(activate);
+        self.refresh_global_workspace_indices();
     }
 
     pub fn move_column_to_workspace(&mut self, idx: usize, activate: bool) {
@@ -2124,20 +2632,77 @@ impl<W: LayoutElement> Layout<W> {
             return;
         };
         monitor.move_column_to_workspace(idx, activate);
+        self.refresh_global_workspace_indices();
     }
 
     pub fn switch_workspace_up(&mut self) {
+        if self.global_workspace_indices_enabled() {
+            let Some(output) = self.active_output().cloned() else {
+                return;
+            };
+            let Some(index) = self.previous_global_workspace_index_on_output(&output) else {
+                return;
+            };
+            self.switch_workspace_to_global_index_on_output(&output, index);
+            return;
+        }
+
         let Some(monitor) = self.active_monitor() else {
             return;
         };
         monitor.switch_workspace_up();
+        self.refresh_global_workspace_indices();
+    }
+
+    pub fn switch_workspace_up_on_output(&mut self, output: &Output) {
+        if self.global_workspace_indices_enabled() {
+            let Some(index) = self.previous_global_workspace_index_on_output(output) else {
+                return;
+            };
+            self.switch_workspace_to_global_index_on_output(output, index);
+            return;
+        }
+
+        let Some(monitor) = self.monitor_for_output_mut(output) else {
+            return;
+        };
+        monitor.switch_workspace_up();
+        self.refresh_global_workspace_indices();
     }
 
     pub fn switch_workspace_down(&mut self) {
+        if self.global_workspace_indices_enabled() {
+            let Some(output) = self.active_output().cloned() else {
+                return;
+            };
+            let Some(index) = self.next_global_workspace_index_on_output(&output) else {
+                return;
+            };
+            self.switch_workspace_to_global_index_on_output(&output, index);
+            return;
+        }
+
         let Some(monitor) = self.active_monitor() else {
             return;
         };
         monitor.switch_workspace_down();
+        self.refresh_global_workspace_indices();
+    }
+
+    pub fn switch_workspace_down_on_output(&mut self, output: &Output) {
+        if self.global_workspace_indices_enabled() {
+            let Some(index) = self.next_global_workspace_index_on_output(output) else {
+                return;
+            };
+            self.switch_workspace_to_global_index_on_output(output, index);
+            return;
+        }
+
+        let Some(monitor) = self.monitor_for_output_mut(output) else {
+            return;
+        };
+        monitor.switch_workspace_down();
+        self.refresh_global_workspace_indices();
     }
 
     pub fn switch_workspace(&mut self, idx: usize) {
@@ -2145,6 +2710,7 @@ impl<W: LayoutElement> Layout<W> {
             return;
         };
         monitor.switch_workspace(idx);
+        self.refresh_global_workspace_indices();
     }
 
     pub fn switch_workspace_auto_back_and_forth(&mut self, idx: usize) {
@@ -2152,6 +2718,7 @@ impl<W: LayoutElement> Layout<W> {
             return;
         };
         monitor.switch_workspace_auto_back_and_forth(idx);
+        self.refresh_global_workspace_indices();
     }
 
     pub fn switch_workspace_previous(&mut self) {
@@ -2159,6 +2726,7 @@ impl<W: LayoutElement> Layout<W> {
             return;
         };
         monitor.switch_workspace_previous();
+        self.refresh_global_workspace_indices();
     }
 
     pub fn consume_into_column(&mut self) {
@@ -2901,6 +3469,7 @@ impl<W: LayoutElement> Layout<W> {
         }
 
         self.update_options(Options::from_config(config));
+        self.refresh_global_workspace_indices();
     }
 
     fn update_options(&mut self, options: Options) {
@@ -3326,6 +3895,8 @@ impl<W: LayoutElement> Layout<W> {
                 monitors[mon_idx].clean_up_workspaces();
             }
         }
+
+        self.refresh_global_workspace_indices();
     }
 
     pub fn move_column_to_output(
@@ -3362,6 +3933,8 @@ impl<W: LayoutElement> Layout<W> {
                 .min(monitors[new_idx].workspaces.len() - 1);
             self.add_column_by_idx(new_idx, workspace_idx, column, activate);
         }
+
+        self.refresh_global_workspace_indices();
     }
 
     pub fn move_workspace_to_output(&mut self, output: &Output) -> bool {
@@ -3435,6 +4008,8 @@ impl<W: LayoutElement> Layout<W> {
         if activate {
             *active_monitor_idx = target_idx;
         }
+
+        self.refresh_global_workspace_indices();
 
         activate
     }
@@ -4288,6 +4863,8 @@ impl<W: LayoutElement> Layout<W> {
                 );
             }
         }
+
+        self.refresh_global_workspace_indices();
     }
 
     pub fn interactive_move_is_moving_above_output(&self, output: &Output) -> bool {
@@ -4420,17 +4997,42 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn move_workspace_down(&mut self) {
+        if self.global_workspace_indices_enabled() {
+            let Some(output) = self.active_output().cloned() else {
+                return;
+            };
+            let Some(index) = self.next_global_workspace_index_on_output_for_move(&output) else {
+                return;
+            };
+            self.move_active_workspace_to_global_index_on_output(&output, index);
+            return;
+        }
+
         let Some(monitor) = self.active_monitor() else {
             return;
         };
         monitor.move_workspace_down();
+        self.refresh_global_workspace_indices();
     }
 
     pub fn move_workspace_up(&mut self) {
+        if self.global_workspace_indices_enabled() {
+            let Some(output) = self.active_output().cloned() else {
+                return;
+            };
+            let Some(index) = self.previous_global_workspace_index_on_output_for_move(&output)
+            else {
+                return;
+            };
+            self.move_active_workspace_to_global_index_on_output(&output, index);
+            return;
+        }
+
         let Some(monitor) = self.active_monitor() else {
             return;
         };
         monitor.move_workspace_up();
+        self.refresh_global_workspace_indices();
     }
 
     pub fn move_workspace_to_idx(
@@ -4462,6 +5064,7 @@ impl<W: LayoutElement> Layout<W> {
         };
 
         monitor.move_workspace_to_idx(old_idx, new_idx);
+        self.refresh_global_workspace_indices();
     }
 
     pub fn set_workspace_name(&mut self, name: String, reference: Option<WorkspaceReference>) {
@@ -4512,6 +5115,8 @@ impl<W: LayoutElement> Layout<W> {
                 monitor.add_workspace_bottom();
             }
         }
+
+        self.refresh_global_workspace_indices();
     }
 
     pub fn unset_workspace_name(&mut self, reference: Option<WorkspaceReference>) {
@@ -4526,6 +5131,7 @@ impl<W: LayoutElement> Layout<W> {
         let id = ws.id();
 
         self.unname_workspace_by_id(id);
+        self.refresh_global_workspace_indices();
     }
 
     pub fn set_monitors_overview_state(&mut self) {

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -1648,6 +1648,16 @@ fn check_ops_with_options(
     layout
 }
 
+fn options_with_global_workspace_indices() -> Options {
+    Options {
+        layout: niri_config::Layout {
+            global_workspace_indices: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
 #[test]
 fn operations_dont_panic() {
     if std::env::var_os("RUN_SLOW_TESTS").is_none() {
@@ -2271,6 +2281,548 @@ fn move_workspace_to_output() {
     assert_eq!(monitors[1].active_workspace_idx, 0);
     assert_eq!(monitors[1].workspaces.len(), 2);
     assert!(monitors[1].workspaces[0].has_windows());
+}
+
+#[test]
+fn global_workspace_indices_assign_unique_active_indices_per_output() {
+    let ops = [Op::AddOutput(1), Op::AddOutput(2)];
+
+    let layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[0].workspaces[monitors[0].active_workspace_idx].id(),
+            monitors[0].active_workspace_idx
+        ),
+        Some(1)
+    );
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[1].workspaces[monitors[1].active_workspace_idx].id(),
+            monitors[1].active_workspace_idx
+        ),
+        Some(2)
+    );
+}
+
+#[test]
+fn global_workspace_indices_resolve_and_move_across_outputs() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddOutput(2),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+    ];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let (output, index) = layout
+        .find_output_and_workspace_index(WorkspaceReference::Index(2))
+        .unwrap();
+    let output = output.unwrap();
+    assert_eq!(output.name(), "output2");
+    assert_eq!(index, 0);
+
+    layout.move_to_output(None, &output, Some(index), ActivateWindow::Smart);
+
+    let MonitorSet::Normal {
+        monitors,
+        active_monitor_idx,
+        ..
+    } = &layout.monitor_set
+    else {
+        unreachable!()
+    };
+
+    assert_eq!(*active_monitor_idx, 1);
+    assert!(monitors[1].workspaces[monitors[1].active_workspace_idx].has_window(&1));
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[1].workspaces[monitors[1].active_workspace_idx].id(),
+            monitors[1].active_workspace_idx
+        ),
+        Some(2)
+    );
+}
+
+#[test]
+fn global_workspace_indices_keep_empty_active_workspace_index_on_other_output() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddOutput(2),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+    ];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let (output, index) = layout
+        .find_output_and_workspace_index(WorkspaceReference::Index(2))
+        .unwrap();
+    let output = output.unwrap();
+    layout.move_to_output(None, &output, Some(index), ActivateWindow::Smart);
+    layout.remove_window(&1, Transaction::new());
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[0].workspaces[monitors[0].active_workspace_idx].id(),
+            monitors[0].active_workspace_idx
+        ),
+        Some(1)
+    );
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[1].workspaces[monitors[1].active_workspace_idx].id(),
+            monitors[1].active_workspace_idx
+        ),
+        Some(2)
+    );
+}
+
+#[test]
+fn global_workspace_indices_stay_unique_when_workspace_gains_a_window() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddOutput(2),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+    ];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let (output, index) = layout
+        .find_output_and_workspace_index(WorkspaceReference::Index(2))
+        .unwrap();
+    let output = output.unwrap();
+    layout.move_to_output(None, &output, Some(index), ActivateWindow::Smart);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+
+    let mut indices = monitors
+        .iter()
+        .flat_map(|mon| {
+            mon.workspaces
+                .iter()
+                .enumerate()
+                .filter_map(|(ws_idx, ws)| layout.workspace_display_idx(ws.id(), ws_idx))
+        })
+        .collect::<Vec<_>>();
+    indices.sort_unstable();
+    indices.dedup();
+
+    assert_eq!(indices, vec![1, 2]);
+}
+
+#[test]
+fn global_workspace_indices_keep_switched_active_workspace_number() {
+    let ops = [Op::AddOutput(1), Op::AddOutput(2)];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let (output, index) = layout
+        .find_output_and_workspace_index(WorkspaceReference::Index(3))
+        .unwrap();
+    let output = output.unwrap();
+    layout.focus_output(&output);
+    layout.switch_workspace(index);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[0].workspaces[monitors[0].active_workspace_idx].id(),
+            monitors[0].active_workspace_idx
+        ),
+        Some(3)
+    );
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[1].workspaces[monitors[1].active_workspace_idx].id(),
+            monitors[1].active_workspace_idx
+        ),
+        Some(2)
+    );
+}
+
+#[test]
+fn global_workspace_indices_recreate_released_workspace_on_active_monitor() {
+    let ops = [Op::AddOutput(1), Op::AddOutput(2)];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let (output, index) = layout
+        .find_output_and_workspace_index(WorkspaceReference::Index(3))
+        .unwrap();
+    let output = output.unwrap();
+    layout.focus_output(&output);
+    layout.switch_workspace(index);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    let output2 = monitors[1].output.clone();
+
+    layout.focus_output(&output2);
+    let (output, index) = layout
+        .find_output_and_workspace_index(WorkspaceReference::Index(1))
+        .unwrap();
+    assert_eq!(output.as_ref(), Some(&output2));
+    layout.switch_workspace(index);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[1].workspaces[monitors[1].active_workspace_idx].id(),
+            monitors[1].active_workspace_idx
+        ),
+        Some(1)
+    );
+}
+
+#[test]
+fn global_workspace_indices_workspace_down_creates_next_free_number() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddOutput(2),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+    ];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    let output1 = monitors[0].output.clone();
+
+    layout.focus_output(&output1);
+    layout.switch_workspace_down();
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[0].workspaces[monitors[0].active_workspace_idx].id(),
+            monitors[0].active_workspace_idx
+        ),
+        Some(3)
+    );
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[1].workspaces[monitors[1].active_workspace_idx].id(),
+            monitors[1].active_workspace_idx
+        ),
+        Some(2)
+    );
+}
+
+#[test]
+fn global_workspace_indices_focus_window_or_workspace_down_prefers_window_focus() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddOutput(2),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+    ];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    let output2 = monitors[1].output.clone();
+
+    layout.focus_output(&output2);
+    layout.focus_window_or_workspace_down();
+
+    let MonitorSet::Normal {
+        monitors,
+        active_monitor_idx,
+        ..
+    } = &layout.monitor_set
+    else {
+        unreachable!()
+    };
+
+    assert_eq!(*active_monitor_idx, 1);
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[1].workspaces[monitors[1].active_workspace_idx].id(),
+            monitors[1].active_workspace_idx
+        ),
+        Some(2)
+    );
+}
+
+#[test]
+fn global_workspace_indices_empty_workspace_down_does_not_create_new_workspace() {
+    let ops = [Op::AddOutput(1), Op::AddOutput(2)];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    let output2 = monitors[1].output.clone();
+
+    layout.focus_output(&output2);
+    layout.switch_workspace_down();
+
+    let win = TestWindow::new(TestWindowParams::new(1));
+    layout.add_window(
+        win,
+        AddWindowTarget::Auto,
+        None,
+        None,
+        false,
+        false,
+        ActivateWindow::default(),
+    );
+    layout.remove_window(&1, Transaction::new());
+    layout.focus_window_or_workspace_down();
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[1].workspaces[monitors[1].active_workspace_idx].id(),
+            monitors[1].active_workspace_idx
+        ),
+        Some(2)
+    );
+}
+
+#[test]
+fn global_workspace_indices_move_column_down_creates_next_free_number() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddOutput(2),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+    ];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    let output1 = monitors[0].output.clone();
+
+    layout.focus_output(&output1);
+    layout.move_column_to_workspace_down(true);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[0].workspaces[monitors[0].active_workspace_idx].id(),
+            monitors[0].active_workspace_idx
+        ),
+        Some(3)
+    );
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[1].workspaces[monitors[1].active_workspace_idx].id(),
+            monitors[1].active_workspace_idx
+        ),
+        Some(2)
+    );
+    assert!(monitors[0].workspaces[monitors[0].active_workspace_idx].has_window(&1));
+}
+
+#[test]
+fn global_workspace_indices_move_window_down_creates_next_free_number() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddOutput(2),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+    ];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    let output1 = monitors[0].output.clone();
+
+    layout.focus_output(&output1);
+    layout.move_to_workspace_down(true);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[0].workspaces[monitors[0].active_workspace_idx].id(),
+            monitors[0].active_workspace_idx
+        ),
+        Some(3)
+    );
+    assert!(monitors[0].workspaces[monitors[0].active_workspace_idx].has_window(&1));
+}
+
+#[test]
+fn global_workspace_indices_move_window_up_returns_to_previous_existing_number() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddOutput(2),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+    ];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    let output1 = monitors[0].output.clone();
+
+    layout.focus_output(&output1);
+    layout.move_to_workspace_down(true);
+    layout.move_to_workspace_up(true);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[0].workspaces[monitors[0].active_workspace_idx].id(),
+            monitors[0].active_workspace_idx
+        ),
+        Some(1)
+    );
+    assert!(monitors[0].workspaces[monitors[0].active_workspace_idx].has_window(&1));
+}
+
+#[test]
+fn global_workspace_indices_move_workspace_down_reassigns_active_workspace_number() {
+    let ops = [Op::AddOutput(1), Op::AddOutput(2)];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    let output1 = monitors[0].output.clone();
+
+    layout.focus_output(&output1);
+    layout.move_workspace_down();
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[0].workspaces[monitors[0].active_workspace_idx].id(),
+            monitors[0].active_workspace_idx
+        ),
+        Some(3)
+    );
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[1].workspaces[monitors[1].active_workspace_idx].id(),
+            monitors[1].active_workspace_idx
+        ),
+        Some(2)
+    );
+}
+
+#[test]
+fn global_workspace_indices_move_workspace_up_recreates_released_lower_number() {
+    let ops = [Op::AddOutput(1), Op::AddOutput(2)];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    let output1 = monitors[0].output.clone();
+
+    layout.focus_output(&output1);
+    layout.move_workspace_down();
+    layout.move_workspace_up();
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[0].workspaces[monitors[0].active_workspace_idx].id(),
+            monitors[0].active_workspace_idx
+        ),
+        Some(1)
+    );
+}
+
+#[test]
+fn global_workspace_indices_workspace_previous_stays_on_current_output() {
+    let ops = [Op::AddOutput(1), Op::AddOutput(2)];
+
+    let mut layout = check_ops_with_options(options_with_global_workspace_indices(), ops);
+
+    let MonitorSet::Normal { monitors, .. } = &layout.monitor_set else {
+        unreachable!()
+    };
+    let output1 = monitors[0].output.clone();
+
+    layout.focus_output(&output1);
+    layout.switch_workspace_down();
+    layout.switch_workspace_previous();
+
+    let MonitorSet::Normal {
+        monitors,
+        active_monitor_idx,
+        ..
+    } = &layout.monitor_set
+    else {
+        unreachable!()
+    };
+
+    assert_eq!(*active_monitor_idx, 0);
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[0].workspaces[monitors[0].active_workspace_idx].id(),
+            monitors[0].active_workspace_idx
+        ),
+        Some(1)
+    );
+    assert_eq!(
+        layout.workspace_display_idx(
+            monitors[1].workspaces[monitors[1].active_workspace_idx].id(),
+            monitors[1].active_workspace_idx
+        ),
+        Some(2)
+    );
 }
 
 #[test]

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -136,7 +136,7 @@ use crate::ipc::server::IpcServer;
 use crate::layer::mapped::LayerSurfaceRenderElement;
 use crate::layer::MappedLayer;
 use crate::layout::tile::TileRenderElement;
-use crate::layout::workspace::{Workspace, WorkspaceId};
+use crate::layout::workspace::Workspace;
 use crate::layout::{
     HitType, Layout, LayoutElement as _, LayoutElementRenderElement, MonitorRenderElement,
 };
@@ -3499,22 +3499,11 @@ impl Niri {
     }
 
     pub fn find_output_and_workspace_index(
-        &self,
+        &mut self,
         workspace_reference: WorkspaceReference,
     ) -> Option<(Option<Output>, usize)> {
-        let (target_workspace_index, target_workspace) = match workspace_reference {
-            WorkspaceReference::Index(index) => {
-                return Some((None, index.saturating_sub(1) as usize));
-            }
-            WorkspaceReference::Name(name) => self.layout.find_workspace_by_name(&name)?,
-            WorkspaceReference::Id(id) => {
-                let id = WorkspaceId::specific(id);
-                self.layout.find_workspace_by_id(id)?
-            }
-        };
-
-        let target_output = target_workspace.current_output();
-        Some((target_output.cloned(), target_workspace_index))
+        self.layout
+            .find_output_and_workspace_index(workspace_reference)
     }
 
     pub fn find_window_by_id(&self, id: MappedId) -> Option<Window> {

--- a/src/protocols/ext_workspace.rs
+++ b/src/protocols/ext_workspace.rs
@@ -90,7 +90,15 @@ pub fn refresh(state: &mut State) {
 
     // Remove workspaces that no longer exist (sending workspace_leave to workspace groups).
     let mut seen_workspaces = HashMap::new();
-    for (mon, _, ws) in state.niri.layout.workspaces() {
+    for (mon, ws_idx, ws) in state.niri.layout.workspaces() {
+        if state
+            .niri
+            .layout
+            .workspace_display_idx(ws.id(), ws_idx)
+            .is_none()
+        {
+            continue;
+        }
         let output = mon.map(|mon| mon.output());
         seen_workspaces.insert(ws.id(), output);
     }
@@ -133,7 +141,10 @@ pub fn refresh(state: &mut State) {
 
     // Update existing workspaces and create new ones.
     for (mon, ws_idx, ws) in state.niri.layout.workspaces() {
-        changed |= refresh_workspace(protocol_state, mon, ws_idx, ws);
+        let Some(display_idx) = state.niri.layout.workspace_display_idx(ws.id(), ws_idx) else {
+            continue;
+        };
+        changed |= refresh_workspace(protocol_state, mon, ws_idx, display_idx, ws);
     }
 
     // Update workspace groups and create new ones, sending workspace_enter events as needed.
@@ -250,17 +261,17 @@ fn remove_workspace_instances(
     }
 }
 
-fn build_name(ws: &Workspace<Mapped>, ws_idx: usize) -> String {
-    ws.name().cloned().unwrap_or_else(|| {
-        // Add 1 since this is a human-readable name, and our action indexing is 1-based.
-        (ws_idx + 1).to_string()
-    })
+fn build_name(ws: &Workspace<Mapped>, display_idx: usize) -> String {
+    ws.name()
+        .cloned()
+        .unwrap_or_else(|| display_idx.to_string())
 }
 
 fn refresh_workspace(
     protocol_state: &mut ExtWorkspaceManagerState,
     mon: Option<&Monitor<Mapped>>,
     ws_idx: usize,
+    display_idx: usize,
     ws: &Workspace<Mapped>,
 ) -> bool {
     let mut state = ext_workspace_handle_v1::State::empty();
@@ -291,8 +302,9 @@ fn refresh_workspace(
             }
 
             let mut coordinates_changed = false;
-            if data.coordinates[1] != ws_idx as u32 {
-                data.coordinates[1] = ws_idx as u32;
+            let display_coordinate = (display_idx.saturating_sub(1)) as u32;
+            if data.coordinates[1] != display_coordinate {
+                data.coordinates[1] = display_coordinate;
                 coordinates_changed = true;
             }
 
@@ -302,23 +314,13 @@ fn refresh_workspace(
                 state_changed = true;
             }
 
-            // Recreate means name got changed or unset (meaning data.name is back to ws_idx).
-            let check = recreate
-                || if data.id.is_some() {
-                    // True means workspace got named, going from ws_idx to name.
-                    id_set
-                } else {
-                    // The workspace is unnamed, check if ws_idx changed.
-                    coordinates_changed
-                };
+            // For unnamed workspaces, the advertised name is the display index. In global
+            // workspace mode that can change even when the monitor-local ws_idx does not.
             let mut name_changed = false;
-            if check {
-                let new_name = build_name(ws, ws_idx);
-                // This will likely be true, except if the workspace got named its index.
-                if data.name != new_name {
-                    data.name = new_name;
-                    name_changed = true;
-                }
+            let new_name = build_name(ws, display_idx);
+            if recreate || id_set || data.name != new_name {
+                data.name = new_name;
+                name_changed = true;
             }
 
             let mut output_changed = false;
@@ -378,8 +380,8 @@ fn refresh_workspace(
             // New workspace, start tracking it.
             let mut data = ExtWorkspaceData {
                 id: ws.name().cloned(),
-                name: build_name(ws, ws_idx),
-                coordinates: ArrayVec::from([0, ws_idx as u32]),
+                name: build_name(ws, display_idx),
+                coordinates: ArrayVec::from([0, (display_idx.saturating_sub(1)) as u32]),
                 state,
                 instances: Vec::new(),
                 output: output.cloned(),


### PR DESCRIPTION
## Summary
- add an opt-in `layout { global-workspace-indices; }` mode
- make numbered workspace references resolve to globally unique workspace numbers across outputs
- keep sequential workspace navigation output-local while stepping through global numbers
- export only real mapped workspaces through IPC/ext-workspace and align ext-workspace coordinates with the exported index
- add regression tests for focus, move, empty-workspace, and workspace-move behavior

## Context
- Implements the behavior discussed in https://github.com/niri-wm/niri/discussions/3639

## Validation
- `cargo fmt --all`
- `nix develop -c cargo build`
- manual runtime testing in a debug-built niri session across a two-monitor setup
