### PR TITLE
include output in WorkspaceActivated event

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1596,6 +1596,8 @@ pub enum Event {
         /// If `true`, this is now the single focused workspace. All other workspaces are no longer
         /// focused, but they may remain active on their respective outputs.
         focused: bool,
+        /// The output name the workspace was activated on
+        output: Option<String>,
     },
     /// An active window changed on a workspace.
     WorkspaceActiveWindowChanged {

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -134,11 +134,11 @@ impl EventStreamStatePart for WorkspacesState {
                     }
                 }
             }
-            Event::WorkspaceActivated { id, focused } => {
-                let ws = self.workspaces.get(&id);
-                let ws = ws.expect("activated workspace was missing from the map");
-                let output = ws.output.clone();
-
+            Event::WorkspaceActivated {
+                id,
+                focused,
+                output,
+            } => {
                 for ws in self.workspaces.values_mut() {
                     let got_activated = ws.id == id;
                     if ws.output == output {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -434,9 +434,14 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
                     Event::WorkspaceUrgencyChanged { id, urgent } => {
                         println!("Workspace {id}: urgency changed to {urgent}");
                     }
-                    Event::WorkspaceActivated { id, focused } => {
+                    Event::WorkspaceActivated {
+                        id,
+                        focused,
+                        output,
+                    } => {
                         let word = if focused { "focused" } else { "activated" };
-                        println!("Workspace {word}: {id}");
+                        let output_state = output.map_or("".into(), |x| format!("on output {x}"));
+                        println!("Workspace {word}: {id} {output_state}");
                     }
                     Event::WorkspaceActiveWindowChanged {
                         workspace_id,

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -640,14 +640,22 @@ impl State {
             // Check if this workspace became focused.
             let is_focused = Some(id) == focused_ws_id;
             if is_focused && !ipc_ws.is_focused {
-                events.push(Event::WorkspaceActivated { id, focused: true });
+                events.push(Event::WorkspaceActivated {
+                    id,
+                    focused: true,
+                    output: ipc_ws.output.clone(),
+                });
                 continue;
             }
 
             // Check if this workspace became active.
             let is_active = mon.is_some_and(|mon| mon.active_workspace_idx() == ws_idx);
             if is_active && !ipc_ws.is_active {
-                events.push(Event::WorkspaceActivated { id, focused: false });
+                events.push(Event::WorkspaceActivated {
+                    id,
+                    focused: false,
+                    output: ipc_ws.output.clone(),
+                });
             }
         }
 


### PR DESCRIPTION
*(This was quite literally a 2 minute change. If this change is more breaking than it's worth feel free to close)*

This just adds an output property for `WorkspaceActivated` IPC events & for the event stream.

Currently, `WorkspaceActivated` events just contain the ID of the workspace, and whether it's focused. For my use case, a multi-monitor bar which shows the workspaces on each monitor individually, the bar has no way of knowing if the workspace was activated on the monitor it cares about, since the `WorkspacesChanged` event doesn't fire until a new window is added to said workspace

---

`niri msg --json event-stream`
```
{"WorkspaceActivated":{"id":9,"focused":true,"output":"DP-3"}}
{"WindowFocusChanged":{"id":null}}
{"WorkspaceActivated":{"id":6,"focused":true,"output":"DP-3"}}
{"WindowFocusChanged":{"id":46}}
```

`niri msg event-stream`
```
Workspace focused: 9 on output DP-3
Window focus changed: None
Workspace focused: 6 on output DP-3
Window focus changed: Some(46)
```