### PR TITLE
Add screenshot related events/state for `niri msg`

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1565,6 +1565,18 @@ pub enum CastTarget {
     },
 }
 
+/// Screenshot UI events.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub enum ScreenshotUiEvent {
+    /// Start the interactive screenshot.
+    Open,
+    /// Cancel the screenshot.
+    Cancel,
+    /// Confirm the screenshot.
+    Confirm,
+}
+
 /// A compositor event.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
@@ -1678,6 +1690,11 @@ pub enum Event {
         ///
         /// For example, the config file couldn't be parsed.
         failed: bool,
+    },
+    /// The screenshot UI was changed.
+    ScreenshotUiChanged {
+        /// Opened/dismissed/confirmed events of the screenshot UI.
+        event: ScreenshotUiEvent,
     },
     /// A screenshot was captured.
     ScreenshotCaptured {

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1586,7 +1586,13 @@ pub enum ScreenshotUiEvent {
     /// Cancel the screenshot.
     Cancel,
     /// Confirm the screenshot.
-    Confirm,
+    Confirm {
+        /// (x, y) coordinate of the selection origin (relative to the output top-left corner), in
+        /// physical pixels.
+        position: (i32, i32),
+        /// Width and height of the selection area, in physical pixels.
+        size: (i32, i32),
+    },
 }
 
 /// A compositor event.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -117,6 +117,8 @@ pub enum Request {
     ReturnError,
     /// Request information about the overview.
     OverviewState,
+    /// Request information about the screenshot.
+    ScreenshotState,
     /// Request information about screencasts.
     Casts,
 }
@@ -163,6 +165,8 @@ pub enum Response {
     OutputConfigChanged(OutputConfigChanged),
     /// Information about the overview.
     OverviewState(Overview),
+    /// Information about the screenshot UI.
+    ScreenshotState(ScreenshotUi),
     /// Information about screencasts.
     Casts(Vec<Cast>),
 }
@@ -172,6 +176,14 @@ pub enum Response {
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Overview {
     /// Whether the overview is currently open.
+    pub is_open: bool,
+}
+
+/// Screenshot UI information.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct ScreenshotUi {
+    /// Whether the screenshot ui is currently open.
     pub is_open: bool,
 }
 

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -351,7 +351,9 @@ impl EventStreamStatePart for ScreenshotUiState {
         match event {
             Event::ScreenshotUiChanged { event } => match event {
                 ScreenshotUiEvent::Open => self.is_open = true,
-                ScreenshotUiEvent::Cancel | ScreenshotUiEvent::Confirm => self.is_open = false,
+                ScreenshotUiEvent::Cancel | ScreenshotUiEvent::Confirm { .. } => {
+                    self.is_open = false
+                }
             },
             event => return Some(event),
         }

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -9,7 +9,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
-use crate::{Cast, Event, KeyboardLayouts, Window, Workspace};
+use crate::{Cast, Event, KeyboardLayouts, ScreenshotUiEvent, Window, Workspace};
 
 /// Part of the state communicated via the event stream.
 pub trait EventStreamStatePart {
@@ -49,6 +49,9 @@ pub struct EventStreamState {
 
     /// State of screencasts.
     pub casts: CastsState,
+
+    /// State of the screenshot UI.
+    pub screenshot_ui: ScreenshotUiState,
 }
 
 /// The workspaces state communicated over the event stream.
@@ -93,6 +96,13 @@ pub struct CastsState {
     pub casts: HashMap<u64, Cast>,
 }
 
+/// The screenshot UI state communicated over the event stream.
+#[derive(Debug, Default)]
+pub struct ScreenshotUiState {
+    /// Indicates if the screenshot UI is currently open.
+    pub is_open: bool,
+}
+
 impl EventStreamStatePart for EventStreamState {
     fn replicate(&self) -> Vec<Event> {
         let mut events = Vec::new();
@@ -102,6 +112,7 @@ impl EventStreamStatePart for EventStreamState {
         events.extend(self.overview.replicate());
         events.extend(self.config.replicate());
         events.extend(self.casts.replicate());
+        events.extend(self.screenshot_ui.replicate());
         events
     }
 
@@ -112,6 +123,7 @@ impl EventStreamStatePart for EventStreamState {
         let event = self.overview.apply(event)?;
         let event = self.config.apply(event)?;
         let event = self.casts.apply(event)?;
+        let event = self.screenshot_ui.apply(event)?;
         Some(event)
     }
 }
@@ -316,6 +328,31 @@ impl EventStreamStatePart for CastsState {
                 let cast = self.casts.remove(&stream_id);
                 cast.expect("stopped cast was missing from the map");
             }
+            event => return Some(event),
+        }
+        None
+    }
+}
+
+impl EventStreamStatePart for ScreenshotUiState {
+    fn replicate(&self) -> Vec<Event> {
+        if self.is_open {
+            vec![Event::ScreenshotUiChanged {
+                event: ScreenshotUiEvent::Open,
+            }]
+        } else {
+            vec![Event::ScreenshotUiChanged {
+                event: ScreenshotUiEvent::Cancel,
+            }]
+        }
+    }
+
+    fn apply(&mut self, event: Event) -> Option<Event> {
+        match event {
+            Event::ScreenshotUiChanged { event } => match event {
+                ScreenshotUiEvent::Open => self.is_open = true,
+                ScreenshotUiEvent::Cancel | ScreenshotUiEvent::Confirm => self.is_open = false,
+            },
             event => return Some(event),
         }
         None

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,6 +107,8 @@ pub enum Msg {
     RequestError,
     /// Print the overview state.
     OverviewState,
+    /// Print the screenshot state.
+    ScreenshotState,
     /// List screencasts.
     Casts,
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -725,15 +725,7 @@ impl State {
                 self.confirm_screenshot(write_to_disk);
             }
             Action::CancelScreenshot => {
-                if !self.niri.screenshot_ui.is_open() {
-                    return;
-                }
-
-                self.niri.screenshot_ui.close();
-                self.niri
-                    .cursor_manager
-                    .set_cursor_image(CursorImageStatus::default_named());
-                self.niri.queue_redraw_all();
+                self.niri.cancel_screenshot();
             }
             Action::ScreenshotTogglePointer => {
                 self.niri.screenshot_ui.toggle_pointer();

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -493,7 +493,10 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
                     Event::ScreenshotUiChanged { event } => match event {
                         ScreenshotUiEvent::Open => println!("Screenshot UI opened"),
                         ScreenshotUiEvent::Cancel => println!("Screenshot UI canceled"),
-                        ScreenshotUiEvent::Confirm => println!("Screenshot UI confirmed"),
+                        ScreenshotUiEvent::Confirm {
+                            position,
+                            size: dimension,
+                        } => println!("Screenshot UI confirmed: {:?}", (position, dimension)),
                     },
                     Event::ScreenshotCaptured { path } => {
                         let mut parts = vec![];

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -8,7 +8,8 @@ use niri_config::OutputName;
 use niri_ipc::socket::Socket;
 use niri_ipc::{
     Action, Cast, CastKind, CastTarget, Event, KeyboardLayouts, LogicalOutput, Mode, Output,
-    OutputConfigChanged, Overview, Request, Response, Transform, Window, WindowLayout,
+    OutputConfigChanged, Overview, Request, Response, ScreenshotUiEvent, Transform, Window,
+    WindowLayout,
 };
 use serde_json::json;
 
@@ -488,6 +489,11 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
                         };
                         println!("Config loaded {status}");
                     }
+                    Event::ScreenshotUiChanged { event } => match event {
+                        ScreenshotUiEvent::Open => println!("Screenshot UI opened"),
+                        ScreenshotUiEvent::Cancel => println!("Screenshot UI canceled"),
+                        ScreenshotUiEvent::Confirm => println!("Screenshot UI confirmed"),
+                    },
                     Event::ScreenshotCaptured { path } => {
                         let mut parts = vec![];
                         parts.push("copied to clipboard".to_string());

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -49,6 +49,7 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
         Msg::EventStream => Request::EventStream,
         Msg::RequestError => Request::ReturnError,
         Msg::OverviewState => Request::OverviewState,
+        Msg::ScreenshotState => Request::ScreenshotState,
         Msg::Casts => Request::Casts,
     };
 
@@ -532,6 +533,25 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
                 println!("Overview is open.");
             } else {
                 println!("Overview is closed.");
+            }
+        }
+        Msg::ScreenshotState => {
+            let Response::ScreenshotState(response) = response else {
+                bail!("unexpected response: expected ScreenshotUi, got {response:?}");
+            };
+
+            if json {
+                let response =
+                    serde_json::to_string(&response).context("error formatting response")?;
+                println!("{response}");
+                return Ok(());
+            }
+
+            let is_open = response.is_open;
+            if is_open {
+                println!("Screenshot UI is open.");
+            } else {
+                println!("Screenshot UI is closed.");
             }
         }
         Msg::Casts => {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -942,4 +942,12 @@ impl State {
         state.apply(event.clone());
         server.send_event(event);
     }
+
+    pub fn ipc_screenshot_ui_event(&mut self, event: niri_ipc::ScreenshotUiEvent) {
+        let Some(server) = &self.niri.ipc_server else {
+            return;
+        };
+        let event = Event::ScreenshotUiChanged { event };
+        server.send_event(event);
+    }
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -18,7 +18,7 @@ use niri_config::OutputName;
 use niri_ipc::state::{EventStreamState, EventStreamStatePart as _};
 use niri_ipc::{
     Action, Event, KeyboardLayouts, OutputConfigChanged, Overview, Reply, Request, Response,
-    Timestamp, WindowLayout, Workspace,
+    ScreenshotUi, Timestamp, WindowLayout, Workspace,
 };
 use smithay::desktop::layer_map_for_output;
 use smithay::input::pointer::{
@@ -449,6 +449,11 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let state = ctx.event_stream_state.borrow();
             let is_open = state.overview.is_open;
             Response::OverviewState(Overview { is_open })
+        }
+        Request::ScreenshotState => {
+            let state = ctx.event_stream_state.borrow();
+            let is_open = state.screenshot_ui.is_open;
+            Response::ScreenshotState(ScreenshotUi { is_open })
         }
         Request::Casts => {
             let state = ctx.event_stream_state.borrow();
@@ -947,7 +952,10 @@ impl State {
         let Some(server) = &self.niri.ipc_server else {
             return;
         };
+        let mut state = server.event_stream_state.borrow_mut();
+
         let event = Event::ScreenshotUiChanged { event };
+        state.apply(event.clone());
         server.send_event(event);
     }
 }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -18,6 +18,7 @@ use niri_config::{
     Config, FloatOrInt, Key, Modifiers, OutputName, TrackLayout, WarpMouseToFocusMode,
     WorkspaceReference, Xkb,
 };
+use niri_ipc::ScreenshotUiEvent;
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::input::Keycode;
 use smithay::backend::renderer::damage::OutputDamageTracker;
@@ -1943,6 +1944,10 @@ impl State {
             return;
         }
 
+        self.niri.event_loop.insert_idle(|state| {
+            state.ipc_screenshot_ui_event(ScreenshotUiEvent::Open);
+        });
+
         let default_output = self
             .niri
             .output_under_cursor()
@@ -2002,6 +2007,11 @@ impl State {
         let ScreenshotUi::Open { path, .. } = &mut self.niri.screenshot_ui else {
             return;
         };
+
+        self.niri.event_loop.insert_idle(|state| {
+            state.ipc_screenshot_ui_event(ScreenshotUiEvent::Confirm);
+        });
+
         let path = path.take();
 
         self.backend.with_primary_renderer(|renderer| {
@@ -5385,6 +5395,21 @@ impl Niri {
         });
 
         Ok(())
+    }
+
+    pub fn cancel_screenshot(&mut self) {
+        if !self.screenshot_ui.is_open() {
+            return;
+        }
+
+        self.event_loop.insert_idle(|state| {
+            state.ipc_screenshot_ui_event(ScreenshotUiEvent::Cancel);
+        });
+
+        self.screenshot_ui.close();
+        self.cursor_manager
+            .set_cursor_image(CursorImageStatus::default_named());
+        self.queue_redraw_all();
     }
 
     #[cfg(feature = "dbus")]

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2004,12 +2004,21 @@ impl State {
     }
 
     pub fn confirm_screenshot(&mut self, write_to_disk: bool) {
-        let ScreenshotUi::Open { path, .. } = &mut self.niri.screenshot_ui else {
+        let ScreenshotUi::Open {
+            path, selection, ..
+        } = &mut self.niri.screenshot_ui
+        else {
             return;
         };
 
-        self.niri.event_loop.insert_idle(|state| {
-            state.ipc_screenshot_ui_event(ScreenshotUiEvent::Confirm);
+        let selection_start = (selection.1.x, selection.1.y);
+        let selection_dimension = (selection.2.x - selection.1.x, selection.2.y - selection.1.y);
+        debug_assert!(selection_dimension.0 >= 0 && selection_dimension.1 >= 0);
+        self.niri.event_loop.insert_idle(move |state| {
+            state.ipc_screenshot_ui_event(ScreenshotUiEvent::Confirm {
+                position: selection_start,
+                size: selection_dimension,
+            });
         });
 
         let path = path.take();


### PR DESCRIPTION
Currently actions sent via niri cmd are nonblocking. E.g. for screenshots, niri doesn't have a way other than monitoring the output path to query if the screenshot is finished, or the interactive screenshot UI is confirmed/canceled by the user.

This PR adds the following three `niri msg event-stream` events:

```jsonl
{"ScreenshotUiChanged":{"event":"Open"}}
{"ScreenshotUiChanged":{"event":"Confirm"}}
{"ScreenshotUiChanged":{"event":"Cancel"}}
```

and their corresponding EventStreamState, queried via command `niri msg screenshot-state`:

```console
❯ niri msg screenshot-state
Screenshot UI is closed.
```

Thus by wrapping `niri msg action screenshot*` and listening to these events, a blocked version of screenshot utility (like `grim`) can be implemented. This enables a more convenient script writing for post processing the produced screenshot images.

An example ["blocked niri-screenshot wrapper"](https://github.com/bczhc/dotfiles/blob/cd8c2dd9a92e2a82543a8541b117ed5513836795/bin/scripts/niri-ss-blocked)