### PR TITLE
fix: force linear buffers for display-only devices (e.g. DisplayLink)

### DIFF
--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -872,7 +872,13 @@ impl Tty {
         } else {
             bail!("no allocator available for device");
         };
-        let gbm_flags = GbmBufferFlags::RENDERING | GbmBufferFlags::SCANOUT;
+        let mut gbm_flags = GbmBufferFlags::RENDERING | GbmBufferFlags::SCANOUT;
+        // Display-only devices (e.g. DisplayLink) require linear buffers. Without
+        // this flag, Modifier::Invalid lets the GPU driver pick a tiled layout
+        // (e.g. micro/macro-tiled on AMD Polaris) that the adapter cannot scan out.
+        if render_node.is_none() {
+            gbm_flags |= GbmBufferFlags::LINEAR;
+        }
         let allocator = GbmAllocator::new(allocator_gbm, gbm_flags);
 
         let token = niri
@@ -1382,7 +1388,9 @@ impl Tty {
         // Filter out the CCS modifiers as they have increased bandwidth, causing some monitor
         // configurations to stop working.
         //
-        // For display only devices, restrict to linear buffers for best compatibility.
+        // For display only devices, restrict to linear/invalid buffers for best compatibility.
+        // Some GPUs (e.g. AMD Polaris) only report Modifier::Invalid (implicit) rather than
+        // Modifier::Linear, so we must accept both for display-only devices.
         //
         // The invalid modifier attempt below should make this unnecessary in some cases, but it
         // would still be a bad idea to remove this until Smithay has some kind of full-device
@@ -1393,7 +1401,8 @@ impl Tty {
             .copied()
             .filter(|format| {
                 if device.render_node.is_none() {
-                    return format.modifier == Modifier::Linear;
+                    return format.modifier == Modifier::Linear
+                        || format.modifier == Modifier::Invalid;
                 }
 
                 let is_ccs = matches!(
@@ -1416,6 +1425,16 @@ impl Tty {
                 !is_ccs
             })
             .collect::<FormatSet>();
+
+        if device.render_node.is_none() {
+            debug!(
+                "display-only device format modifiers: {:?}",
+                render_formats
+                    .iter()
+                    .map(|f| f.modifier)
+                    .collect::<Vec<_>>()
+            );
+        }
 
         // Create the compositor.
         let res = DrmCompositor::new(
@@ -2787,8 +2806,10 @@ fn surface_dmabuf_feedback(
     // Also limit scan-out formats to Linear if we have a device without a render node (i.e.
     // we're rendering on a different device).
     if surface_render_node != Some(primary_render_node) {
-        primary_scanout_formats.retain(|f| f.modifier == Modifier::Linear);
-        primary_or_overlay_scanout_formats.retain(|f| f.modifier == Modifier::Linear);
+        primary_scanout_formats
+            .retain(|f| f.modifier == Modifier::Linear || f.modifier == Modifier::Invalid);
+        primary_or_overlay_scanout_formats
+            .retain(|f| f.modifier == Modifier::Linear || f.modifier == Modifier::Invalid);
     }
 
     let builder = DmabufFeedbackBuilder::new(primary_render_node.dev_id(), primary_formats);


### PR DESCRIPTION
A few notes for this patch:

- My displaylink monitor is an pretty old Azus ZenScreen 15inch, it worked out of box on Cosmic.
- My main GPU is an old AMD one
- When I switch to Niri, it's been powered off
- It's still not working after I include #2312
- Solved the bug with the help of Claude Code, full commit logs at https://github.com/yjpark/niri/commits/wip-display-port/
  - It first make the moniter light up, but having tiling issues
  - Later it identified it's related to AMD GPU, and add a couple extra patch
  - Everything worked as expected.

I'm running NixOS, using the fix for a few weeks, haven't met any issue. rebased to main, and cleanup a bit for this PR, using it for a few hours, so far so good.

https://github.com/yjpark/dotflakes/blob/979572b178eaeb77629e84f671e00fea91f90cfa/flake.nix#L51

The changes seems straight forward to me, though to be honest, I don't know whether it will cause side effects on other configurations.

Created this PR, hoping it can be reviewed by someone can fully understand, if can be mered, can save me some time for future merges, also might help other persons met similar issues.

---

Display-only devices (no render node) rely on the primary GPU for rendering. Some GPUs (e.g. AMD Polaris) report only Modifier::Invalid via EGL, which lets the driver pick tiled layouts that display-only adapters cannot scan out.

Fix by:
- Adding GbmBufferFlags::LINEAR to the allocator for display-only devices, ensuring GBM produces linear buffers even with implicit modifiers
- Accepting Modifier::Invalid alongside Linear in format filtering and dmabuf feedback for display-only/cross-device paths, so the format set is not empty on GPUs that only report Invalid

Follows up on #2312 and #2891.
Related to #3240.