### PR TITLE
config: add hide-from rule for screen capture targets

### DIFF
--- a/docs/wiki/Configuration:-Layer-Rules.md
+++ b/docs/wiki/Configuration:-Layer-Rules.md
@@ -93,6 +93,22 @@ layer-rule {
 }
 ```
 
+#### `hide-from`
+
+<sup>Since: 25.11</sup>
+
+Hide layer surfaces from xdg-desktop-portal screencasts or all screen captures.
+Unlike `block-out-from`, this omits the surface from the captured image rather than replacing it with a black rectangle.
+
+```kdl
+// Hide mako notifications from screencasts.
+layer-rule {
+    match namespace="^notifications$"
+
+    hide-from "screencast"
+}
+```
+
 #### `opacity`
 
 Set the opacity of the surface.

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -575,6 +575,30 @@ window-rule {
 > This is because window title (and app ID) are not double-buffered in the Wayland protocol, so they are not tied to specific window contents.
 > There's no robust way for Firefox to synchronize visibly showing a different tab and changing the window title.
 
+#### `hide-from`
+
+<sup>Since: 25.11</sup>
+
+Hide windows from xdg-desktop-portal screencasts or all screen captures.
+Unlike `block-out-from`, this rule does not draw a black rectangle: the window is omitted from the captured image entirely.
+
+This can be useful if you prefer to show the content behind the hidden window instead of a black placeholder.
+
+```kdl
+window-rule {
+    match app-id=r#"^org\.keepassxc\.KeePassXC$"#
+    hide-from "screencast"
+}
+```
+
+You can also hide the window from all screen capture paths, including third-party screenshot tools:
+
+```kdl
+window-rule {
+    hide-from "screen-capture"
+}
+```
+
 #### `opacity`
 
 Set the opacity of the window.

--- a/docs/wiki/Screencasting.md
+++ b/docs/wiki/Screencasting.md
@@ -44,6 +44,8 @@ layer-rule {
 
 Check [the corresponding wiki section](./Configuration:-Window-Rules.md#block-out-from) for more details and examples.
 
+If you prefer to omit windows from captures completely (without a black placeholder), use the `hide-from` window/layer rule instead.
+
 ### Dynamic screencast target
 
 <sup>Since: 25.05</sup>

--- a/niri-config/src/layer_rule.rs
+++ b/niri-config/src/layer_rule.rs
@@ -12,6 +12,8 @@ pub struct LayerRule {
     pub opacity: Option<f32>,
     #[knuffel(child, unwrap(argument))]
     pub block_out_from: Option<BlockOutFrom>,
+    #[knuffel(child, unwrap(argument))]
+    pub hide_from: Option<BlockOutFrom>,
     #[knuffel(child, default)]
     pub shadow: ShadowRule,
     #[knuffel(child)]

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -884,6 +884,8 @@ mod tests {
                 tab-indicator {
                     active-color "#f00"
                 }
+
+                hide-from "screencast"
             }
 
             layer-rule {
@@ -1828,6 +1830,9 @@ mod tests {
                     clip_to_geometry: None,
                     baba_is_float: None,
                     block_out_from: None,
+                    hide_from: Some(
+                        Screencast,
+                    ),
                     variable_refresh_rate: None,
                     default_column_display: Some(
                         Tabbed,
@@ -1866,6 +1871,7 @@ mod tests {
                     block_out_from: Some(
                         Screencast,
                     ),
+                    hide_from: None,
                     shadow: ShadowRule {
                         off: false,
                         on: false,

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -63,6 +63,8 @@ pub struct WindowRule {
     #[knuffel(child, unwrap(argument))]
     pub block_out_from: Option<BlockOutFrom>,
     #[knuffel(child, unwrap(argument))]
+    pub hide_from: Option<BlockOutFrom>,
+    #[knuffel(child, unwrap(argument))]
     pub variable_refresh_rate: Option<bool>,
     #[knuffel(child, unwrap(argument, str))]
     pub default_column_display: Option<ColumnDisplay>,

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -337,6 +337,10 @@ window-rule {
 
     // Use this instead if you want them visible on third-party screenshot tools.
     // block-out-from "screencast"
+
+    // Use this instead if you prefer removing the windows from captures
+    // entirely, rather than replacing them with black rectangles.
+    // hide-from "screen-capture"
 }
 
 // Example: enable rounded corners for all windows.

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -162,6 +162,10 @@ impl MappedLayer {
         target: RenderTarget,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
+        if target.should_hide(self.rules.hide_from) {
+            return;
+        }
+
         let scale = Scale::from(self.scale);
         let alpha = self.rules.opacity.unwrap_or(1.).clamp(0., 1.);
         let location = location + self.bob_offset();
@@ -206,6 +210,10 @@ impl MappedLayer {
         target: RenderTarget,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
+        if target.should_hide(self.rules.hide_from) {
+            return;
+        }
+
         let scale = Scale::from(self.scale);
         let alpha = self.rules.opacity.unwrap_or(1.).clamp(0., 1.);
         let location = location + self.bob_offset();

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -15,6 +15,9 @@ pub struct ResolvedLayerRules {
     /// Whether to block out this layer surface from certain render targets.
     pub block_out_from: Option<BlockOutFrom>,
 
+    /// Whether to hide this layer surface from certain render targets.
+    pub hide_from: Option<BlockOutFrom>,
+
     /// Shadow overrides.
     pub shadow: ShadowRule,
 
@@ -58,6 +61,9 @@ impl ResolvedLayerRules {
             }
             if let Some(x) = rule.block_out_from {
                 resolved.block_out_from = Some(x);
+            }
+            if let Some(x) = rule.hide_from {
+                resolved.hide_from = Some(x);
             }
             if let Some(x) = rule.geometry_corner_radius {
                 resolved.geometry_corner_radius = Some(x);

--- a/src/layout/closing_window.rs
+++ b/src/layout/closing_window.rs
@@ -35,6 +35,9 @@ pub struct ClosingWindow {
     /// Where the window should be blocked out from.
     block_out_from: Option<BlockOutFrom>,
 
+    /// Where the window should be hidden from.
+    hide_from: Option<BlockOutFrom>,
+
     /// Size of the window geometry.
     geo_size: Size<f64, Logical>,
 
@@ -122,13 +125,21 @@ impl ClosingWindow {
         let (buffer, buffer_offset) =
             render_to_texture(snapshot.contents).context("error rendering contents")?;
         let (blocked_out_buffer, blocked_out_buffer_offset) =
-            render_to_texture(snapshot.blocked_out_contents)
-                .context("error rendering blocked-out contents")?;
+            if snapshot.blocked_out_contents.is_empty() {
+                // Hidden snapshots can have no blocked-out render elements. Reuse the normal
+                // texture so the closing animation on Output target can still be
+                // created.
+                (buffer.clone(), buffer_offset)
+            } else {
+                render_to_texture(snapshot.blocked_out_contents)
+                    .context("error rendering blocked-out contents")?
+            };
 
         Ok(Self {
             buffer,
             blocked_out_buffer,
             block_out_from: snapshot.block_out_from,
+            hide_from: snapshot.hide_from,
             geo_size,
             pos,
             buffer_offset,
@@ -136,6 +147,10 @@ impl ClosingWindow {
             anim_state: AnimationState::new(blocker, anim),
             random_seed: fastrand::f32(),
         })
+    }
+
+    pub fn should_hide(&self, target: RenderTarget) -> bool {
+        target.should_hide(self.hide_from)
     }
 
     pub fn advance_animations(&mut self) {

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1067,6 +1067,9 @@ impl<W: LayoutElement> FloatingSpace<W> {
         //
         // FIXME: I guess this should rather preserve the stacking order when the window is closed.
         for closing in self.closing_windows.iter().rev() {
+            if closing.should_hide(target) {
+                continue;
+            }
             let elem = closing.render(renderer.as_gles_renderer(), view_rect, scale, target);
             push(elem.into());
         }

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2909,6 +2909,9 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         // Draw the closing windows on top of the other windows.
         let view_rect = Rectangle::new(Point::from((self.view_pos(), 0.)), self.view_size);
         for closing in self.closing_windows.iter().rev() {
+            if closing.should_hide(target) {
+                continue;
+            }
             let elem = closing.render(renderer.as_gles_renderer(), view_rect, scale, target);
             push(elem.into());
         }

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -118,6 +118,7 @@ impl TestWindow {
                         contents: Vec::new(),
                         blocked_out_contents: Vec::new(),
                         block_out_from: None,
+                        hide_from: None,
                         size: self.0.bbox.get().size.to_f64(),
                         texture: OnceCell::new(),
                         blocked_out_texture: OnceCell::new(),

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -1048,6 +1048,9 @@ impl<W: LayoutElement> Tile<W> {
         let area = Rectangle::new(window_render_loc, animated_window_size);
 
         let rules = self.window.rules();
+        if target.should_hide(rules.hide_from) {
+            return;
+        }
 
         // Clip to geometry including during the fullscreen animation to help with buggy clients
         // that submit a full-sized buffer before acking the fullscreen state (Firefox).
@@ -1398,6 +1401,7 @@ impl<W: LayoutElement> Tile<W> {
             contents,
             blocked_out_contents,
             block_out_from: self.window.rules().block_out_from,
+            hide_from: self.window.rules().hide_from,
             size: self.animated_tile_size(),
             texture: Default::default(),
             blocked_out_texture: Default::default(),

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -78,6 +78,14 @@ impl RenderTarget {
             Some(BlockOutFrom::ScreenCapture) => self != RenderTarget::Output,
         }
     }
+
+    pub fn should_hide(self, hide_from: Option<BlockOutFrom>) -> bool {
+        match hide_from {
+            None => false,
+            Some(BlockOutFrom::Screencast) => self == RenderTarget::Screencast,
+            Some(BlockOutFrom::ScreenCapture) => self != RenderTarget::Output,
+        }
+    }
 }
 
 impl ToRenderElement for BakedBuffer<TextureBuffer<GlesTexture>> {

--- a/src/render_helpers/snapshot.rs
+++ b/src/render_helpers/snapshot.rs
@@ -24,6 +24,9 @@ pub struct RenderSnapshot<C, B> {
     /// Where the contents were blocked out from at the time of the snapshot.
     pub block_out_from: Option<BlockOutFrom>,
 
+    /// Where the contents were hidden from at the time of the snapshot.
+    pub hide_from: Option<BlockOutFrom>,
+
     /// Visual size of the element at the point of the snapshot.
     pub size: Size<f64, Logical>,
 
@@ -47,6 +50,10 @@ where
         scale: Scale<f64>,
         target: RenderTarget,
     ) -> Option<&(GlesTexture, Rectangle<i32, Physical>)> {
+        if target.should_hide(self.hide_from) {
+            return None;
+        }
+
         if target.should_block_out(self.block_out_from) {
             self.blocked_out_texture.get_or_init(|| {
                 let _span = tracy_client::span!("RenderSnapshot::texture");

--- a/src/ui/mru.rs
+++ b/src/ui/mru.rs
@@ -350,6 +350,10 @@ impl Thumbnail {
     ) {
         let _span = tracy_client::span!("Thumbnail::render");
 
+        if target.should_hide(mapped.rules().hide_from) {
+            return;
+        }
+
         let round = move |logical: f64| round_logical_in_physical(scale, logical);
         let padding = round(config.highlight.padding);
         let title_gap = round(TITLE_GAP);

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -409,6 +409,7 @@ impl Mapped {
             contents,
             blocked_out_contents,
             block_out_from: self.rules().block_out_from,
+            hide_from: self.rules().hide_from,
             size,
             texture: Default::default(),
             blocked_out_texture: Default::default(),
@@ -620,6 +621,10 @@ impl LayoutElement for Mapped {
         target: RenderTarget,
         push: &mut dyn FnMut(LayoutElementRenderElement<R>),
     ) {
+        if target.should_hide(self.rules.hide_from) {
+            return;
+        }
+
         if target.should_block_out(self.rules.block_out_from) {
             let mut buffer = self.block_out_buffer.borrow_mut();
             buffer.resize(self.window.geometry().size.to_f64());
@@ -651,6 +656,10 @@ impl LayoutElement for Mapped {
         target: RenderTarget,
         push: &mut dyn FnMut(LayoutElementRenderElement<R>),
     ) {
+        if target.should_hide(self.rules.hide_from) {
+            return;
+        }
+
         if target.should_block_out(self.rules.block_out_from) {
             return;
         }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -111,6 +111,9 @@ pub struct ResolvedWindowRules {
     /// Whether to block out this window from certain render targets.
     pub block_out_from: Option<BlockOutFrom>,
 
+    /// Whether to hide this window from certain render targets.
+    pub hide_from: Option<BlockOutFrom>,
+
     /// Whether to enable VRR on this window's primary output if it is on-demand.
     pub variable_refresh_rate: Option<bool>,
 
@@ -286,6 +289,9 @@ impl ResolvedWindowRules {
                 }
                 if let Some(x) = rule.block_out_from {
                     resolved.block_out_from = Some(x);
+                }
+                if let Some(x) = rule.hide_from {
+                    resolved.hide_from = Some(x);
                 }
                 if let Some(x) = rule.variable_refresh_rate {
                     resolved.variable_refresh_rate = Some(x);


### PR DESCRIPTION
Add a new hide-from dynamic rule for both window-rule and layer-rule.

Unlike block-out-from, this omits matched content from capture render targets instead of drawing black placeholders.

Implementation details:
- extend config parsing and resolved rule structs with hide_from
- add RenderTarget::should_hide()
- skip rendering for hidden windows/layers in screencast and screen-capture targets
- hide tile-level decorations and closing-window animations for hidden targets
- propagate hide metadata through render snapshots
- update MRU previews to skip hidden windows
- document the new option and add default-config example
- update config parsing test expectations