### PR TITLE
ui/hotkey_overlay: prettify diaeresis keysyms

### DIFF
--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -579,6 +579,13 @@ fn prettify_keysym_name(screen_reader: bool, name: &str) -> String {
             "grave" => "`",
             "bracketleft" => "[",
             "bracketright" => "]",
+            "adiaeresis" => "Ä",
+            "ediaeresis" => "Ë",
+            "idiaeresis" => "Ï",
+            "odiaeresis" => "Ö",
+            "udiaeresis" => "Ü",
+            "ydiaeresis" => "Ÿ",
+            "wdiaeresis" => "Ẅ",
             _ => name,
         }
     };


### PR DESCRIPTION
The suggested default config contains `BracketLeft`/`BracketRight` keybinds. On my german keyboard they can't be input in a single keystroke, so I've bound them to the ö and ä keys in the same location.

This looks a bit ugly in the hotkey overlay, as they are rendered as `odiaeresis`/`adiaeresis`:
<img width="466" height="51" alt="image" src="https://github.com/user-attachments/assets/d63d07c5-65fc-4b72-a66a-3459a85b7f90" />

This PR adds those keys to `prettify_keysym_name` in order to display them as `Alt + Ö` instead.

---

Ö, Ä, and Ü are present in the german keyboard layout. Ï, Ë, Ÿ, Ẅ aren't, I added them for completeness and can remove them if you want.


<details>
<summary>Full list of .*diaeresis xkb keysyms</summary>

```
XKB_KEY_dead_diaeresis
XKB_KEY_dead_belowdiaeresis
XKB_KEY_diaeresis
# uppercase
XKB_KEY_Adiaeresis
XKB_KEY_Ediaeresis
XKB_KEY_Idiaeresis
XKB_KEY_Odiaeresis
XKB_KEY_Udiaeresis
XKB_KEY_Wdiaeresis
XKB_KEY_Ydiaeresis
# these I've mapped
XKB_KEY_adiaeresis
XKB_KEY_ediaeresis
XKB_KEY_idiaeresis
XKB_KEY_odiaeresis
XKB_KEY_udiaeresis
XKB_KEY_ydiaeresis
XKB_KEY_wdiaeresis
# even more niche
XKB_KEY_Greek_IOTAdiaeresis
XKB_KEY_Ddiaeresis
XKB_KEY_hpmute_diaeresis
XKB_KEY_hpYdiaeresis
XKB_KEY_mute_diaeresis
```
</details>