### PR TITLE
Better config error notification

### DIFF
--- a/niri-config/src/error.rs
+++ b/niri-config/src/error.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt;
 use std::path::PathBuf;
 
-use miette::Diagnostic;
+use miette::{Diagnostic, NarratableReportHandler};
 
 #[derive(Debug)]
 pub struct ConfigParseResult<T, E> {
@@ -42,6 +42,14 @@ impl<T, E> ConfigParseResult<T, E> {
             includes: self.includes,
         }
     }
+}
+
+pub fn format_error_report(err: &miette::Report) -> String {
+    let mut report = String::new();
+    NarratableReportHandler::new()
+        .render_report(&mut report, err.as_ref())
+        .expect("writing into a String should never fail");
+    report.trim_end().to_owned()
 }
 
 impl fmt::Display for ConfigIncludeError {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -48,7 +48,7 @@ pub use crate::animations::{Animation, Animations};
 pub use crate::appearance::*;
 pub use crate::binds::*;
 pub use crate::debug::Debug;
-pub use crate::error::{ConfigIncludeError, ConfigParseResult};
+pub use crate::error::{format_error_report, ConfigIncludeError, ConfigParseResult};
 pub use crate::gestures::Gestures;
 pub use crate::input::{Input, ModKey, ScrollMethod, TrackLayout, WarpMouseToFocusMode, Xkb};
 pub use crate::layer_rule::LayerRule;

--- a/src/a11y.rs
+++ b/src/a11y.rs
@@ -259,7 +259,9 @@ impl Niri {
             return;
         }
 
-        self.a11y_announce(crate::ui::config_error_notification::error_text(false));
+        self.a11y_announce(crate::ui::config_error_notification::error_text(
+            false, None,
+        ));
     }
 
     pub fn a11y_announce_hotkey_overlay(&mut self) {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -465,6 +465,16 @@ impl State {
                     }
                 }
 
+                if this.niri.config_error_notification.is_open() && pressed {
+                    if matches!(raw, Some(Keysym::Return | Keysym::space)) {
+                        this.niri.config_error_notification.hide();
+                        this.niri.queue_redraw_all();
+                    }
+
+                    this.niri.suppressed_keys.insert(key_code);
+                    return FilterResult::Intercept(None);
+                }
+
                 if this.niri.exit_confirm_dialog.is_open() && pressed {
                     if raw == Some(Keysym::Return) {
                         info!("quitting after confirming exit dialog");
@@ -2747,6 +2757,15 @@ impl State {
 
         // Ignore release events for mouse clicks that triggered a bind.
         if self.niri.suppressed_buttons.remove(&button_code) {
+            return;
+        }
+
+        if self.niri.config_error_notification.is_open() {
+            if ButtonState::Pressed == button_state {
+                self.niri.config_error_notification.hide();
+                self.niri.queue_redraw_all();
+                self.niri.suppressed_buttons.insert(button_code);
+            }
             return;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config_path = config_path(cli.config);
     env::remove_var("NIRI_CONFIG");
     let (config_created_at, config_load_result) = config_path.load_or_create();
-    let config_errored = config_load_result.config.is_err();
+    let config_error_report = config_load_result
+        .config
+        .as_ref()
+        .err()
+        .map(|err| format!("{err:?}"));
+    let config_errored = config_error_report.is_some();
     let mut config = config_load_result.config.unwrap_or_else(|err| {
         warn!("{err:?}");
         Config::load_default()
@@ -258,7 +263,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Show the config error notification right away if needed.
     if config_errored {
-        state.niri.config_error_notification.show();
+        state
+            .niri
+            .config_error_notification
+            .show(config_error_report.unwrap());
         state.ipc_config_loaded(true);
     } else if let Some(path) = config_created_at {
         state.niri.config_error_notification.show_created(path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .config
         .as_ref()
         .err()
-        .map(|err| format!("{err:?}"));
+        .map(niri_config::format_error_report);
     let config_errored = config_error_report.is_some();
     let mut config = config_load_result.config.unwrap_or_else(|err| {
         warn!("{err:?}");

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -509,6 +509,7 @@ pub enum KeyboardFocus {
     Layout { surface: Option<WlSurface> },
     LayerShell { surface: WlSurface },
     LockScreen { surface: Option<WlSurface> },
+    ConfigErrorNotification,
     ScreenshotUi,
     ExitConfirmDialog,
     Overview,
@@ -658,6 +659,7 @@ impl KeyboardFocus {
             KeyboardFocus::Layout { surface } => surface.as_ref(),
             KeyboardFocus::LayerShell { surface } => Some(surface),
             KeyboardFocus::LockScreen { surface } => surface.as_ref(),
+            KeyboardFocus::ConfigErrorNotification => None,
             KeyboardFocus::ScreenshotUi => None,
             KeyboardFocus::ExitConfirmDialog => None,
             KeyboardFocus::Overview => None,
@@ -670,6 +672,7 @@ impl KeyboardFocus {
             KeyboardFocus::Layout { surface } => surface,
             KeyboardFocus::LayerShell { surface } => Some(surface),
             KeyboardFocus::LockScreen { surface } => surface,
+            KeyboardFocus::ConfigErrorNotification => None,
             KeyboardFocus::ScreenshotUi => None,
             KeyboardFocus::ExitConfirmDialog => None,
             KeyboardFocus::Overview => None,
@@ -1018,7 +1021,8 @@ impl State {
         let pointer = &self.niri.seat.get_pointer().unwrap();
         let location = pointer.current_location();
 
-        if !self.niri.exit_confirm_dialog.is_open()
+        if !self.niri.config_error_notification.is_open()
+            && !self.niri.exit_confirm_dialog.is_open()
             && !self.niri.is_locked()
             && !self.niri.screenshot_ui.is_open()
         {
@@ -1127,7 +1131,9 @@ impl State {
         }
 
         // Compute the current focus.
-        let focus = if self.niri.exit_confirm_dialog.is_open() {
+        let focus = if self.niri.config_error_notification.is_open() {
+            KeyboardFocus::ConfigErrorNotification
+        } else if self.niri.exit_confirm_dialog.is_open() {
             KeyboardFocus::ExitConfirmDialog
         } else if self.niri.is_locked() {
             KeyboardFocus::LockScreen {
@@ -3898,6 +3904,7 @@ impl Niri {
             // FIXME: when going into the screenshot UI from a layer-shell focus, and then back to
             // layer-shell, the layout will briefly draw as active, despite never having focus.
             KeyboardFocus::LockScreen { .. } => true,
+            KeyboardFocus::ConfigErrorNotification => true,
             KeyboardFocus::ScreenshotUi => true,
             KeyboardFocus::ExitConfirmDialog => true,
             KeyboardFocus::Overview => true,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1401,13 +1401,13 @@ impl State {
         }
     }
 
-    pub fn reload_config(&mut self, config: Result<Config, ()>) {
+    pub fn reload_config(&mut self, config: Result<Config, String>) {
         let _span = tracy_client::span!("State::reload_config");
 
         let mut config = match config {
             Ok(config) => config,
-            Err(()) => {
-                self.niri.config_error_notification.show();
+            Err(summary) => {
+                self.niri.config_error_notification.show(summary);
                 self.niri.queue_redraw_all();
 
                 #[cfg(feature = "dbus")]

--- a/src/ui/config_error_notification.rs
+++ b/src/ui/config_error_notification.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
-use std::time::Duration;
 
 use niri_config::Config;
 use ordered_float::NotNan;
@@ -41,7 +40,7 @@ pub struct ConfigErrorNotification {
 enum State {
     Hidden,
     Showing(Animation),
-    Shown(Duration),
+    Shown,
     Hiding(Animation),
 }
 
@@ -102,27 +101,19 @@ impl ConfigErrorNotification {
         self.state = State::Hiding(self.animation(1., 0.));
     }
 
+    pub fn is_open(&self) -> bool {
+        matches!(self.state, State::Showing(_) | State::Shown)
+    }
+
     pub fn advance_animations(&mut self) {
         match &mut self.state {
             State::Hidden => (),
             State::Showing(anim) => {
                 if anim.is_done() {
-                    let duration = if self.created_path.is_some() {
-                        // Make this quite a bit longer because it comes with a monitor modeset
-                        // (can take a while) and an important hotkeys popup diverting the
-                        // attention.
-                        Duration::from_secs(8)
-                    } else {
-                        Duration::from_secs(4)
-                    };
-                    self.state = State::Shown(self.clock.now_unadjusted() + duration);
+                    self.state = State::Shown;
                 }
             }
-            State::Shown(deadline) => {
-                if self.clock.now_unadjusted() >= *deadline {
-                    self.hide();
-                }
-            }
+            State::Shown => (),
             State::Hiding(anim) => {
                 if anim.is_clamped_done() {
                     self.state = State::Hidden;
@@ -162,7 +153,7 @@ impl ConfigErrorNotification {
         let y = match &self.state {
             State::Hidden => unreachable!(),
             State::Showing(anim) | State::Hiding(anim) => -size.h + anim.value() * y_range,
-            State::Shown(_) => f64::from(PADDING) * 2.,
+            State::Shown => f64::from(PADDING) * 2.,
         };
 
         let location = Point::from((x, y));

--- a/src/ui/config_error_notification.rs
+++ b/src/ui/config_error_notification.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use niri_config::Config;
 use ordered_float::NotNan;
 use pangocairo::cairo::{self, ImageSurface};
+use pangocairo::pango::glib;
 use pangocairo::pango::FontDescription;
 use smithay::backend::renderer::element::Kind;
 use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
@@ -31,6 +32,7 @@ pub struct ConfigErrorNotification {
     // If set, this is a "Created config at {path}" notification. If unset, this is a config error
     // notification.
     created_path: Option<PathBuf>,
+    error_report: Option<String>,
 
     clock: Clock,
     config: Rc<RefCell<Config>>,
@@ -49,6 +51,7 @@ impl ConfigErrorNotification {
             state: State::Hidden,
             buffers: RefCell::new(HashMap::new()),
             created_path: None,
+            error_report: None,
             clock,
             config,
         }
@@ -68,20 +71,22 @@ impl ConfigErrorNotification {
     pub fn show_created(&mut self, created_path: &Path) {
         if self.created_path.as_deref() != Some(created_path) {
             self.created_path = Some(created_path.to_owned());
+            self.error_report = None;
             self.buffers.borrow_mut().clear();
         }
 
         self.state = State::Showing(self.animation(0., 1.));
     }
 
-    pub fn show(&mut self) {
+    pub fn show(&mut self, report: String) {
         let c = self.config.borrow();
         if c.config_notification.disable_failed {
             return;
         }
 
-        if self.created_path.is_some() {
+        if self.created_path.is_some() || self.error_report.as_deref() != Some(&report) {
             self.created_path = None;
+            self.error_report = Some(report);
             self.buffers.borrow_mut().clear();
         }
 
@@ -142,11 +147,12 @@ impl ConfigErrorNotification {
         let scale = output.current_scale().fractional_scale();
         let output_size = output_size(output);
         let path = self.created_path.as_deref();
+        let report = self.error_report.as_deref();
 
         let mut buffers = self.buffers.borrow_mut();
         let buffer = buffers
             .entry(NotNan::new(scale).unwrap())
-            .or_insert_with(move || render(renderer.as_gles_renderer(), scale, path).ok());
+            .or_insert_with(move || render(renderer.as_gles_renderer(), scale, path, report).ok());
         let buffer = buffer.clone()?;
 
         let size = buffer.logical_size();
@@ -178,12 +184,13 @@ fn render(
     renderer: &mut GlesRenderer,
     scale: f64,
     created_path: Option<&Path>,
+    error_report: Option<&str>,
 ) -> anyhow::Result<TextureBuffer<GlesTexture>> {
     let _span = tracy_client::span!("config_error_notification::render");
 
     let padding: i32 = to_physical_precise_round(scale, PADDING);
 
-    let mut text = error_text(true);
+    let mut text = error_text(true, error_report);
     let mut border_color = (1., 0.3, 0.3);
     if let Some(path) = created_path {
         text = format!(
@@ -247,12 +254,26 @@ fn render(
     Ok(buffer)
 }
 
-pub fn error_text(markup: bool) -> String {
+pub fn error_text(markup: bool, error_report: Option<&str>) -> String {
     let command = if markup {
         "<span face='monospace' bgcolor='#000000'>niri validate</span>"
     } else {
         "niri validate"
     };
 
-    format!("Failed to parse the config file. Please run {command} to see the errors.")
+    let mut text =
+        format!("Failed to parse the config file. Run {command} for the full error report.");
+
+    if let Some(report) = error_report.filter(|report| !report.is_empty()) {
+        if markup {
+            text.push_str("\n<span face='monospace' bgcolor='#000000' foreground='#ffb0b0'>");
+            text.push_str(&glib::markup_escape_text(report));
+            text.push_str("</span>");
+        } else {
+            text.push('\n');
+            text.push_str(report);
+        }
+    }
+
+    text
 }

--- a/src/utils/watcher.rs
+++ b/src/utils/watcher.rs
@@ -190,7 +190,7 @@ pub fn setup(state: &mut State, config_path: &ConfigPath, includes: Vec<PathBuf>
         path.load().map_config_res(|res| {
             res.map_err(|err| {
                 warn!("{err:?}");
-                format!("{err:?}")
+                niri_config::format_error_report(&err)
             })
         })
     };

--- a/src/utils/watcher.rs
+++ b/src/utils/watcher.rs
@@ -55,8 +55,8 @@ impl Watcher {
     pub fn new(
         path: ConfigPath,
         includes: Vec<PathBuf>,
-        mut process: impl FnMut(&ConfigPath) -> ConfigParseResult<Config, ()> + Send + 'static,
-        changed: SyncSender<Result<Config, ()>>,
+        mut process: impl FnMut(&ConfigPath) -> ConfigParseResult<Config, String> + Send + 'static,
+        changed: SyncSender<Result<Config, String>>,
     ) -> Self {
         let (load_config, load_config_rx) = mpsc::channel();
 
@@ -190,6 +190,7 @@ pub fn setup(state: &mut State, config_path: &ConfigPath, includes: Vec<PathBuf>
         path.load().map_config_res(|res| {
             res.map_err(|err| {
                 warn!("{err:?}");
+                format!("{err:?}")
             })
         })
     };
@@ -200,7 +201,7 @@ pub fn setup(state: &mut State, config_path: &ConfigPath, includes: Vec<PathBuf>
         .event_loop
         .insert_source(
             rx,
-            |event: calloop::channel::Event<Result<Config, ()>>, _, state| match event {
+            |event: calloop::channel::Event<Result<Config, String>>, _, state| match event {
                 calloop::channel::Event::Msg(config) => {
                     let failed = config.is_err();
                     state.reload_config(config);


### PR DESCRIPTION
- show actual config parse errors in the notification instead of only a generic failure message.
- keep notification open until dismissed so they can be read. (space/enter/mouseclick to dismiss)
- use `miette` to format errors better

<img width="967" height="310" alt="image" src="https://github.com/user-attachments/assets/c5489a58-6812-4dab-ad33-17fdc44fb78f" />
