### PR TITLE
Feat/cursor-zoom(-output-scale)

### DIFF
--- a/niri-config/src/animations.rs
+++ b/niri-config/src/animations.rs
@@ -19,6 +19,8 @@ pub struct Animations {
     pub screenshot_ui_open: ScreenshotUiOpenAnim,
     pub overview_open_close: OverviewOpenCloseAnim,
     pub recent_windows_close: RecentWindowsCloseAnim,
+    pub zoom_level_change: ZoomLevelChangeAnim,
+    pub zoom_focal_pan: ZoomFocalPanAnim,
 }
 
 impl Default for Animations {
@@ -37,6 +39,8 @@ impl Default for Animations {
             screenshot_ui_open: Default::default(),
             overview_open_close: Default::default(),
             recent_windows_close: Default::default(),
+            zoom_level_change: Default::default(),
+            zoom_focal_pan: Default::default(),
         }
     }
 }
@@ -71,6 +75,10 @@ pub struct AnimationsPart {
     pub overview_open_close: Option<OverviewOpenCloseAnim>,
     #[knuffel(child)]
     pub recent_windows_close: Option<RecentWindowsCloseAnim>,
+    #[knuffel(child)]
+    pub zoom_level_change: Option<ZoomLevelChangeAnim>,
+    #[knuffel(child)]
+    pub zoom_focal_pan: Option<ZoomFocalPanAnim>,
 }
 
 impl MergeWith<AnimationsPart> for Animations {
@@ -97,6 +105,8 @@ impl MergeWith<AnimationsPart> for Animations {
             screenshot_ui_open,
             overview_open_close,
             recent_windows_close,
+            zoom_level_change,
+            zoom_focal_pan,
         );
     }
 }
@@ -326,6 +336,38 @@ impl Default for RecentWindowsCloseAnim {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ZoomLevelChangeAnim(pub Animation);
+
+impl Default for ZoomLevelChangeAnim {
+    fn default() -> Self {
+        Self(Animation {
+            off: false,
+            kind: Kind::Spring(SpringParams {
+                damping_ratio: 1.,
+                stiffness: 1200,
+                epsilon: 0.0001,
+            }),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ZoomFocalPanAnim(pub Animation);
+
+impl Default for ZoomFocalPanAnim {
+    fn default() -> Self {
+        Self(Animation {
+            off: false,
+            kind: Kind::Spring(SpringParams {
+                damping_ratio: 1.,
+                stiffness: 800,
+                epsilon: 0.0001,
+            }),
+        })
+    }
+}
+
 impl<S> knuffel::Decode<S> for WorkspaceSwitchAnim
 where
     S: knuffel::traits::ErrorSpan,
@@ -510,6 +552,36 @@ where
 }
 
 impl<S> knuffel::Decode<S> for RecentWindowsCloseAnim
+where
+    S: knuffel::traits::ErrorSpan,
+{
+    fn decode_node(
+        node: &knuffel::ast::SpannedNode<S>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        let default = Self::default().0;
+        Ok(Self(Animation::decode_node(node, ctx, default, |_, _| {
+            Ok(false)
+        })?))
+    }
+}
+
+impl<S> knuffel::Decode<S> for ZoomLevelChangeAnim
+where
+    S: knuffel::traits::ErrorSpan,
+{
+    fn decode_node(
+        node: &knuffel::ast::SpannedNode<S>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        let default = Self::default().0;
+        Ok(Self(Animation::decode_node(node, ctx, default, |_, _| {
+            Ok(false)
+        })?))
+    }
+}
+
+impl<S> knuffel::Decode<S> for ZoomFocalPanAnim
 where
     S: knuffel::traits::ErrorSpan,
 {

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -367,6 +367,11 @@ pub enum Action {
     SetWindowUrgent(u64),
     #[knuffel(skip)]
     UnsetWindowUrgent(u64),
+    SetZoomLevel(
+        #[knuffel(argument, str)] String,
+        #[knuffel(argument)] Option<String>,
+    ),
+    ToggleZoomLock(#[knuffel(argument)] Option<String>),
     #[knuffel(skip)]
     LoadConfigFile(#[knuffel(argument)] Option<String>),
     #[knuffel(skip)]
@@ -699,6 +704,8 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::ToggleWindowUrgent { id } => Self::ToggleWindowUrgent(id),
             niri_ipc::Action::SetWindowUrgent { id } => Self::SetWindowUrgent(id),
             niri_ipc::Action::UnsetWindowUrgent { id } => Self::UnsetWindowUrgent(id),
+            niri_ipc::Action::SetZoomLevel { level, output } => Self::SetZoomLevel(level, output),
+            niri_ipc::Action::ToggleZoomLock { output } => Self::ToggleZoomLock(output),
             niri_ipc::Action::LoadConfigFile { path } => Self::LoadConfigFile(path),
         }
     }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -89,6 +89,7 @@ pub struct Config {
     pub debug: Debug,
     pub workspaces: Vec<Workspace>,
     pub recent_windows: RecentWindows,
+    pub zoom: Zoom,
 }
 
 #[derive(Debug, Clone)]
@@ -196,6 +197,7 @@ where
                 "animations" => m_merge!(animations),
                 "gestures" => m_merge!(gestures),
                 "overview" => m_merge!(overview),
+                "zoom" => m_merge!(zoom),
                 "xwayland-satellite" => m_merge!(xwayland_satellite),
                 "switch-events" => m_merge!(switch_events),
                 "debug" => m_merge!(debug),
@@ -837,7 +839,7 @@ mod tests {
                 window-open { off; }
 
                 window-close {
-                    curve "cubic-bezier" 0.05 0.7 0.1 1  
+                    curve "cubic-bezier" 0.05 0.7 0.1 1
                 }
 
                 recent-windows-close {
@@ -1460,6 +1462,7 @@ mod tests {
                 hide_after_inactive_ms: Some(
                     3000,
                 ),
+                scale_with_zoom: false,
             },
             screenshot_path: ScreenshotPath(
                 Some(
@@ -1611,6 +1614,30 @@ mod tests {
                                 damping_ratio: 1.0,
                                 stiffness: 800,
                                 epsilon: 0.001,
+                            },
+                        ),
+                    },
+                ),
+                zoom_level_change: ZoomLevelChangeAnim(
+                    Animation {
+                        off: false,
+                        kind: Spring(
+                            SpringParams {
+                                damping_ratio: 1.0,
+                                stiffness: 1200,
+                                epsilon: 0.0001,
+                            },
+                        ),
+                    },
+                ),
+                zoom_focal_pan: ZoomFocalPanAnim(
+                    Animation {
+                        off: false,
+                        kind: Spring(
+                            SpringParams {
+                                damping_ratio: 1.0,
+                                stiffness: 800,
+                                epsilon: 0.0001,
                             },
                         ),
                     },
@@ -2322,6 +2349,12 @@ mod tests {
                         hotkey_overlay_title: None,
                     },
                 ],
+            },
+            zoom: Zoom {
+                movement_mode: CursorFollow,
+                increment_type: Linear,
+                pinch_sensitivity: 1.0,
+                max_zoom: 10.0,
             },
         }
         "#);

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2355,6 +2355,9 @@ mod tests {
                 increment_type: Linear,
                 pinch_sensitivity: 1.0,
                 max_zoom: 10.0,
+                use_fractional_scale: false,
+                max_fractional_scale: 5.0,
+                scale_sensitivity: 1.0,
             },
         }
         "#);

--- a/niri-config/src/misc.rs
+++ b/niri-config/src/misc.rs
@@ -14,12 +14,71 @@ pub struct SpawnShAtStartup {
     pub command: String,
 }
 
+#[derive(knuffel::DecodeScalar, Default, Clone, Debug, PartialEq)]
+pub enum ZoomMovementMode {
+    #[default]
+    CursorFollow,
+    Centered,
+    OnEdge,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, knuffel::DecodeScalar)]
+pub enum ZoomIncrementType {
+    #[default]
+    Linear,
+    Exponential,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Zoom {
+    pub movement_mode: ZoomMovementMode,
+    pub increment_type: ZoomIncrementType,
+    pub pinch_sensitivity: f64,
+    pub max_zoom: f64,
+}
+
+impl Default for Zoom {
+    fn default() -> Self {
+        Self {
+            movement_mode: ZoomMovementMode::CursorFollow,
+            increment_type: ZoomIncrementType::Linear,
+            pinch_sensitivity: 1.0,
+            max_zoom: 10.0,
+        }
+    }
+}
+
+#[derive(knuffel::Decode, Debug, PartialEq)]
+pub struct ZoomPart {
+    #[knuffel(child, unwrap(argument))]
+    pub movement_mode: Option<ZoomMovementMode>,
+    #[knuffel(child, unwrap(argument))]
+    pub increment_type: Option<ZoomIncrementType>,
+    #[knuffel(child, unwrap(argument))]
+    pub pinch_sensitivity: Option<f64>,
+    #[knuffel(child, unwrap(argument))]
+    pub max_zoom: Option<f64>,
+}
+
+impl MergeWith<ZoomPart> for Zoom {
+    fn merge_with(&mut self, part: &ZoomPart) {
+        merge_clone!(
+            (self, part),
+            movement_mode,
+            increment_type,
+            pinch_sensitivity,
+            max_zoom
+        );
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub struct Cursor {
     pub xcursor_theme: String,
     pub xcursor_size: u8,
     pub hide_when_typing: bool,
     pub hide_after_inactive_ms: Option<u32>,
+    pub scale_with_zoom: bool,
 }
 
 impl Default for Cursor {
@@ -29,6 +88,7 @@ impl Default for Cursor {
             xcursor_size: 24,
             hide_when_typing: false,
             hide_after_inactive_ms: None,
+            scale_with_zoom: false,
         }
     }
 }
@@ -43,12 +103,14 @@ pub struct CursorPart {
     pub hide_when_typing: Option<Flag>,
     #[knuffel(child, unwrap(argument))]
     pub hide_after_inactive_ms: Option<u32>,
+    #[knuffel(child)]
+    pub scale_with_zoom: Option<Flag>,
 }
 
 impl MergeWith<CursorPart> for Cursor {
     fn merge_with(&mut self, part: &CursorPart) {
         merge_clone!((self, part), xcursor_theme, xcursor_size);
-        merge!((self, part), hide_when_typing);
+        merge!((self, part), hide_when_typing, scale_with_zoom);
         merge_clone_opt!((self, part), hide_after_inactive_ms);
     }
 }

--- a/niri-config/src/misc.rs
+++ b/niri-config/src/misc.rs
@@ -35,6 +35,9 @@ pub struct Zoom {
     pub increment_type: ZoomIncrementType,
     pub pinch_sensitivity: f64,
     pub max_zoom: f64,
+    pub use_fractional_scale: bool,
+    pub max_fractional_scale: f64,
+    pub scale_sensitivity: f64,
 }
 
 impl Default for Zoom {
@@ -44,6 +47,9 @@ impl Default for Zoom {
             increment_type: ZoomIncrementType::Linear,
             pinch_sensitivity: 1.0,
             max_zoom: 10.0,
+            use_fractional_scale: false,
+            max_fractional_scale: 5.0,
+            scale_sensitivity: 1.0,
         }
     }
 }
@@ -58,6 +64,12 @@ pub struct ZoomPart {
     pub pinch_sensitivity: Option<f64>,
     #[knuffel(child, unwrap(argument))]
     pub max_zoom: Option<f64>,
+    #[knuffel(child)]
+    pub use_fractional_scale: Option<Flag>,
+    #[knuffel(child, unwrap(argument))]
+    pub max_fractional_scale: Option<f64>,
+    #[knuffel(child, unwrap(argument))]
+    pub scale_sensitivity: Option<f64>,
 }
 
 impl MergeWith<ZoomPart> for Zoom {
@@ -69,6 +81,8 @@ impl MergeWith<ZoomPart> for Zoom {
             pinch_sensitivity,
             max_zoom
         );
+        merge!((self, part), use_fractional_scale);
+        merge_clone!((self, part), max_fractional_scale, scale_sensitivity);
     }
 }
 

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -119,6 +119,8 @@ pub enum Request {
     OverviewState,
     /// Request information about screencasts.
     Casts,
+    /// Request information about zoom state.
+    ZoomState,
 }
 
 /// Reply from niri to client.
@@ -165,6 +167,8 @@ pub enum Response {
     OverviewState(Overview),
     /// Information about screencasts.
     Casts(Vec<Cast>),
+    /// Map from output name to zoom state.
+    ZoomState(HashMap<String, Zoom>),
 }
 
 /// Overview information.
@@ -932,6 +936,21 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(long))]
         id: u64,
     },
+    /// Set the zoom level of an output.
+    SetZoomLevel {
+        /// Zoom level to set (absolute like "2.0" or relative like "+0.5", "-0.5").
+        #[cfg_attr(feature = "clap", arg(allow_hyphen_values = true))]
+        level: String,
+        /// Optional Output name to set the zoom level for.
+        #[cfg_attr(feature = "clap", arg())]
+        output: Option<String>,
+    },
+    /// Toggle the zoom lock of an output.
+    ToggleZoomLock {
+        /// Optional Output name to toggle the zoom lock for.
+        #[cfg_attr(feature = "clap", arg())]
+        output: Option<String>,
+    },
     /// Reload the config file.
     ///
     /// Can be useful for scripts changing the config file, to avoid waiting the small duration for
@@ -1530,6 +1549,16 @@ pub struct Cast {
     /// This is `None` for wlr-screencopy casts, and also for PipeWire casts before the node is
     /// created (when the cast is just starting up).
     pub pw_node_id: Option<u32>,
+}
+
+/// Zoom State
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct Zoom {
+    /// Current zoom level
+    pub level: f64,
+    /// Whether zoom focal point is locked
+    pub is_locked: bool,
 }
 
 /// Kind of screencast.

--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use niri::animation::Clock;
 use niri::layout::{ActivateWindow, AddWindowTarget, LayoutElement as _, Options, SizingMode};
-use niri::render_helpers::RenderTarget;
+use niri::render_helpers::{RenderCtx, RenderTarget};
 use niri_config::{Color, OutputName, PresetSize};
 use smithay::backend::renderer::element::RenderElement;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -270,12 +270,14 @@ impl TestCase for Layout {
         self.layout.update_render_elements(Some(&self.output));
 
         let mut rv = Vec::new();
+        let ctx = RenderCtx {
+            renderer,
+            target: RenderTarget::Output,
+        };
         self.layout
             .monitor_for_output(&self.output)
             .unwrap()
-            .render_workspaces(renderer, RenderTarget::Output, true, &mut |elem| {
-                rv.push(Box::new(elem) as _)
-            });
+            .render_workspaces(ctx, true, &mut |elem| rv.push(Box::new(elem) as _));
         rv
     }
 }

--- a/niri-visual-tests/src/cases/tile.rs
+++ b/niri-visual-tests/src/cases/tile.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use niri::layout::Options;
-use niri::render_helpers::RenderTarget;
+use niri::render_helpers::{RenderCtx, RenderTarget};
 use niri_config::Color;
 use smithay::backend::renderer::element::RenderElement;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -121,13 +121,13 @@ impl TestCase for Tile {
         );
 
         let mut rv = Vec::new();
-        self.tile.render(
+        let ctx = RenderCtx {
             renderer,
-            location,
-            true,
-            RenderTarget::Output,
-            &mut |elem| rv.push(Box::new(elem) as _),
-        );
+            target: RenderTarget::Output,
+        };
+        self.tile.render(ctx, location, true, &mut |elem| {
+            rv.push(Box::new(elem) as _)
+        });
         rv
     }
 }

--- a/niri-visual-tests/src/cases/window.rs
+++ b/niri-visual-tests/src/cases/window.rs
@@ -1,5 +1,5 @@
 use niri::layout::{LayoutElement, SizingMode};
-use niri::render_helpers::RenderTarget;
+use niri::render_helpers::{RenderCtx, RenderTarget};
 use smithay::backend::renderer::element::RenderElement;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Physical, Point, Scale, Size};
@@ -53,14 +53,14 @@ impl TestCase for Window {
             .downscale(2.);
 
         let mut rv = Vec::new();
-        self.window.render_normal(
+        let ctx = RenderCtx {
             renderer,
-            location,
-            Scale::from(1.),
-            1.,
-            RenderTarget::Output,
-            &mut |elem| rv.push(Box::new(elem) as _),
-        );
+            target: RenderTarget::Output,
+        };
+        self.window
+            .render_normal(ctx, location, Scale::from(1.), 1., &mut |elem| {
+                rv.push(Box::new(elem) as _)
+            });
         rv
     }
 }

--- a/niri-visual-tests/src/test_window.rs
+++ b/niri-visual-tests/src/test_window.rs
@@ -9,7 +9,7 @@ use niri::layout::{
 use niri::render_helpers::offscreen::OffscreenData;
 use niri::render_helpers::renderer::NiriRenderer;
 use niri::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
-use niri::render_helpers::RenderTarget;
+use niri::render_helpers::RenderCtx;
 use niri::utils::transaction::Transaction;
 use niri::window::ResolvedWindowRules;
 use smithay::backend::renderer::element::Kind;
@@ -151,11 +151,10 @@ impl LayoutElement for TestWindow {
 
     fn render_normal<R: NiriRenderer>(
         &self,
-        _renderer: &mut R,
+        _ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
         _scale: Scale<f64>,
         alpha: f32,
-        _target: RenderTarget,
         push: &mut dyn FnMut(LayoutElementRenderElement<R>),
     ) {
         let inner = self.inner.borrow();

--- a/niri-visual-tests/src/test_window.rs
+++ b/niri-visual-tests/src/test_window.rs
@@ -6,6 +6,7 @@ use niri::layout::{
     ConfigureIntent, InteractiveResizeData, LayoutElement, LayoutElementRenderElement,
     LayoutElementRenderSnapshot, SizingMode,
 };
+use niri::zoom::OutputZoomState;
 use niri::render_helpers::offscreen::OffscreenData;
 use niri::render_helpers::renderer::NiriRenderer;
 use niri::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
@@ -197,7 +198,17 @@ impl LayoutElement for TestWindow {
         false
     }
 
-    fn set_preferred_scale_transform(&self, _scale: output::Scale, _transform: Transform) {}
+    fn wl_surface(&self) -> Option<WlSurface> {
+        None
+    }
+
+    fn set_preferred_scale_transform(
+        &self,
+        _scale: output::Scale,
+        _transform: Transform,
+        _zoom_state: Option<&OutputZoomState>,
+    ) {
+    }
 
     fn has_ssd(&self) -> bool {
         false

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -69,7 +69,7 @@ use crate::frame_clock::FrameClock;
 use crate::niri::{Niri, RedrawState, State};
 use crate::render_helpers::debug::draw_damage;
 use crate::render_helpers::renderer::AsGlesRenderer;
-use crate::render_helpers::{resources, shaders, RenderTarget};
+use crate::render_helpers::{resources, shaders, RenderCtx, RenderTarget};
 use crate::utils::{get_monotonic_time, is_laptop_panel, logical_output, PanelOrientation};
 
 const SUPPORTED_COLOR_FORMATS: [Fourcc; 4] = [
@@ -1880,8 +1880,11 @@ impl Tty {
         let _ = renderer.downscale_filter(filter);
 
         // Render the elements.
-        let mut elements =
-            niri.render::<TtyRenderer>(&mut renderer, output, true, RenderTarget::Output);
+        let ctx = RenderCtx {
+            renderer: &mut renderer,
+            target: RenderTarget::Output,
+        };
+        let mut elements = niri.render_to_vec(ctx, output, true);
 
         // Visualize the damage, if enabled.
         if niri.debug_draw_damage {

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -32,7 +32,9 @@ use smithay::backend::libinput::{LibinputInputBackend, LibinputSessionInterface}
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::backend::renderer::multigpu::gbm::GbmGlesBackend;
 use smithay::backend::renderer::multigpu::{GpuManager, MultiFrame, MultiRenderer};
-use smithay::backend::renderer::{DebugFlags, ImportDma, ImportEgl, RendererSuper};
+use smithay::backend::renderer::{
+    DebugFlags, ImportDma, ImportEgl, Renderer, RendererSuper, TextureFilter,
+};
 use smithay::backend::session::libseat::LibSeatSession;
 use smithay::backend::session::{Event as SessionEvent, Session};
 use smithay::backend::udev::{self, UdevBackend, UdevEvent};
@@ -1370,6 +1372,7 @@ impl Tty {
             .user_data()
             .insert_if_missing(|| TtyOutputState { node, crtc });
         output.user_data().insert_if_missing(|| output_name.clone());
+
         if let Some(x) = orientation {
             output.user_data().insert_if_missing(|| PanelOrientation(x));
         }
@@ -1863,6 +1866,18 @@ impl Tty {
                 return rv;
             }
         };
+
+        let zoom_factor = niri.layout.zoom_level_for_output(output);
+
+        // Apply filter temporarily before rendering
+        // Set filter based on this output's zoom level
+        let filter = match zoom_factor {
+            z if z < 2.0 => TextureFilter::Linear,
+            _ => TextureFilter::Nearest,
+        };
+
+        let _ = renderer.upscale_filter(filter);
+        let _ = renderer.downscale_filter(filter);
 
         // Render the elements.
         let mut elements =

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -8,7 +8,7 @@ use niri_config::{Config, OutputName};
 use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::gles::GlesRenderer;
-use smithay::backend::renderer::{DebugFlags, ImportDma, ImportEgl, Renderer};
+use smithay::backend::renderer::{DebugFlags, ImportDma, ImportEgl, Renderer, TextureFilter};
 use smithay::backend::winit::{self, WinitEvent, WinitGraphicsBackend};
 use smithay::output::{Mode, Output, PhysicalProperties, Subpixel};
 use smithay::reexports::calloop::LoopHandle;
@@ -181,13 +181,22 @@ impl Winit {
     pub fn render(&mut self, niri: &mut Niri, output: &Output) -> RenderResult {
         let _span = tracy_client::span!("Winit::render");
 
+        let zoom_level = niri.layout.zoom_level_for_output(output);
+
+        // Apply filter temporarily before rendering
+        // based on this output's zoom level
+        let filter = match zoom_level {
+            z if z < 2.0 => TextureFilter::Linear,
+            _ => TextureFilter::Nearest,
+        };
+
+        let renderer = self.backend.renderer();
+        let _ = renderer.upscale_filter(filter);
+        let _ = renderer.downscale_filter(filter);
+
         // Render the elements.
-        let mut elements = niri.render::<GlesRenderer>(
-            self.backend.renderer(),
-            output,
-            true,
-            RenderTarget::Output,
-        );
+        let mut elements =
+            niri.render::<GlesRenderer>(renderer, output, true, RenderTarget::Output);
 
         // Visualize the damage, if enabled.
         if niri.debug_draw_damage {

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -21,7 +21,7 @@ use smithay::wayland::presentation::Refresh;
 use super::{IpcOutputMap, OutputId, RenderResult};
 use crate::niri::{Niri, RedrawState, State};
 use crate::render_helpers::debug::draw_damage;
-use crate::render_helpers::{resources, shaders, RenderTarget};
+use crate::render_helpers::{resources, shaders, RenderCtx, RenderTarget};
 use crate::utils::{get_monotonic_time, logical_output};
 
 pub struct Winit {
@@ -195,8 +195,11 @@ impl Winit {
         let _ = renderer.downscale_filter(filter);
 
         // Render the elements.
-        let mut elements =
-            niri.render::<GlesRenderer>(renderer, output, true, RenderTarget::Output);
+        let ctx = RenderCtx {
+            renderer: self.backend.renderer(),
+            target: RenderTarget::Output,
+        };
+        let mut elements = niri.render_to_vec(ctx, output, true);
 
         // Visualize the damage, if enabled.
         if niri.debug_draw_damage {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,8 @@ pub enum Msg {
     OverviewState,
     /// List screencasts.
     Casts,
+    /// List zoom state of outputs.
+    ZoomState,
 }
 
 #[derive(Clone, Debug, clap::ValueEnum)]

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -44,8 +44,9 @@ impl CompositorHandler for State {
         if let Some(output) = self.niri.output_for_root(&root) {
             let scale = output.current_scale();
             let transform = output.current_transform();
+            let zoom_state = self.niri.layout.zoom_state_for_output(output).cloned();
             with_states(surface, |data| {
-                send_scale_transform(surface, data, scale, transform);
+                send_scale_transform(surface, data, scale, transform, zoom_state.as_ref());
             });
         }
     }

--- a/src/handlers/layer_shell.rs
+++ b/src/handlers/layer_shell.rs
@@ -185,8 +185,9 @@ impl State {
                 if !initial_configure_sent {
                     let scale = output.current_scale();
                     let transform = output.current_transform();
+                    let zoom_state = self.niri.layout.zoom_state_for_output(&output).cloned();
                     with_states(surface, |data| {
-                        send_scale_transform(surface, data, scale, transform);
+                        send_scale_transform(surface, data, scale, transform, zoom_state.as_ref());
                     });
 
                     layer.layer_surface().send_configure();

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -224,9 +224,10 @@ impl InputMethodHandler for State {
         if let Some(output) = self.output_for_popup(&popup) {
             let scale = output.current_scale();
             let transform = output.current_transform();
+            let zoom_state = self.niri.layout.zoom_state_for_output(output).cloned();
             let wl_surface = popup.wl_surface();
             with_states(wl_surface, |data| {
-                send_scale_transform(wl_surface, data, scale, transform);
+                send_scale_transform(wl_surface, data, scale, transform, zoom_state.as_ref());
             });
         }
 
@@ -480,7 +481,7 @@ pub fn configure_lock_surface(surface: &LockSurface, output: &Output) {
     let transform = output.current_transform();
     let wl_surface = surface.wl_surface();
     with_states(wl_surface, |data| {
-        send_scale_transform(wl_surface, data, scale, transform);
+        send_scale_transform(wl_surface, data, scale, transform, None);
     });
     surface.send_configure();
 }

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -1211,8 +1211,16 @@ impl State {
                         {
                             let scale = output.current_scale();
                             let transform = output.current_transform();
+                            let zoom_state =
+                                self.niri.layout.zoom_state_for_output(output).cloned();
                             with_states(surface, |data| {
-                                send_scale_transform(surface, data, scale, transform);
+                                send_scale_transform(
+                                    surface,
+                                    data,
+                                    scale,
+                                    transform,
+                                    zoom_state.as_ref(),
+                                );
                             });
                         }
                         popup.send_configure().expect("initial configure failed");

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::cmp::min;
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
 use std::time::Duration;
@@ -8,6 +7,7 @@ use calloop::timer::{TimeoutAction, Timer};
 use input::event::gesture::GestureEventCoordinates as _;
 use niri_config::{
     Action, Bind, Binds, Config, Key, ModKey, Modifiers, MruDirection, SwitchBinds, Trigger,
+    ZoomIncrementType,
 };
 use niri_ipc::LayoutSwitchTarget;
 use smithay::backend::input::{
@@ -34,7 +34,7 @@ use smithay::input::SeatHandler;
 use smithay::output::Output;
 use smithay::reexports::wayland_server::protocol::wl_data_source::WlDataSource;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
-use smithay::utils::{Logical, Point, Rectangle, Transform, SERIAL_COUNTER};
+use smithay::utils::{Logical, Physical, Point, Rectangle, Scale, Transform, SERIAL_COUNTER};
 use smithay::wayland::keyboard_shortcuts_inhibit::KeyboardShortcutsInhibitor;
 use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraint};
 use smithay::wayland::tablet_manager::{TabletDescriptor, TabletSeatTrait};
@@ -111,6 +111,17 @@ impl<D: SeatHandler> PointerOrTouchStartData<D> {
 }
 
 impl State {
+    fn active_zoom_output(&self, requested_output: Option<&str>) -> Option<Output> {
+        let output = match requested_output {
+            Some(name) => self.niri.output_by_name_match(name).cloned(),
+            None => self.niri.layout.active_output().cloned(),
+        }?;
+        self.niri
+            .layout
+            .has_zoom_for_output(&output)
+            .then_some(output)
+    }
+
     pub fn process_input_event<I: InputBackend + 'static>(&mut self, event: InputEvent<I>)
     where
         I::Device: 'static, // Needed for downcasting.
@@ -2381,6 +2392,78 @@ impl State {
                     self.niri.queue_redraw_mru_output();
                 }
             }
+            Action::SetZoomLevel(level, output) => {
+                if let Some(output) = self.active_zoom_output(output.as_deref()) {
+                    let current_level = self.niri.layout.zoom_level_for_output(&output);
+                    let target_level = {
+                        let factor_str = level.trim();
+                        let is_relative =
+                            factor_str.starts_with('+') || factor_str.starts_with('-');
+                        match factor_str.parse::<f64>() {
+                            Ok(f) if !is_relative => f.max(1.0),
+                            Ok(delta) => {
+                                let increment_type = &self.niri.config.borrow().zoom.increment_type;
+                                let new_level = match increment_type {
+                                    ZoomIncrementType::Linear => current_level + delta,
+                                    ZoomIncrementType::Exponential => {
+                                        (current_level.ln() + delta).exp()
+                                    }
+                                };
+                                let max_zoom = self.niri.config.borrow().zoom.max_zoom;
+                                new_level.clamp(1.0, max_zoom)
+                            }
+                            Err(_) => {
+                                tracing::warn!("Failed to parse zoom level: {}", level);
+                                return;
+                            }
+                        }
+                    };
+
+                    let cursor_pos = self.niri.seat.get_pointer().unwrap().current_location();
+                    let output_geo = self
+                        .niri
+                        .global_space
+                        .output_geometry(&output)
+                        .unwrap()
+                        .to_f64();
+                    let cursor_local = cursor_pos - output_geo.loc;
+                    let movement_mode = self.niri.config.borrow().zoom.movement_mode.clone();
+                    let locked = self.niri.layout.zoom_locked_for_output(&output);
+
+                    self.niri.layout.set_zoom_level(
+                        &output,
+                        target_level,
+                        cursor_local,
+                        &movement_mode,
+                        locked,
+                    );
+
+                    // If the zoom is locked, we need to update the base focal point to keep the
+                    // content under the cursor consistent.
+                    self.niri.update_zoom_base_focal(&output, cursor_pos, None);
+
+                    self.niri.queue_redraw(&output);
+                }
+            }
+            Action::ToggleZoomLock(output) => {
+                if let Some(output) = self.active_zoom_output(output.as_deref()) {
+                    let was_locked = self.niri.layout.toggle_zoom_lock(&output);
+                    if was_locked {
+                        let cursor_pos = self.niri.seat.get_pointer().unwrap().current_location();
+                        let output_geo = self
+                            .niri
+                            .global_space
+                            .output_geometry(&output)
+                            .unwrap()
+                            .to_f64();
+                        let cursor_local = cursor_pos - output_geo.loc;
+                        let movement_mode = self.niri.config.borrow().zoom.movement_mode.clone();
+                        self.niri
+                            .layout
+                            .animate_zoom_unlock(&output, cursor_local, &movement_mode);
+                    }
+                }
+            }
         }
     }
 
@@ -2400,8 +2483,19 @@ impl State {
 
         let pos = pointer.current_location();
 
+        // Get the output under the current pointer position for zoom-aware acceleration.
+        let zoom_multiplier = if let Some((output, _)) = self.niri.output_under(pos) {
+            1.0 / self.niri.layout.zoom_level_for_output(output)
+        } else {
+            1.0
+        };
+
+        // Apply zoom-aware delta scaling: at higher zoom levels, reduce pointer
+        // deltas proportionally to maintain consistent visual cursor velocity.
+        let delta = event.delta().upscale(Scale::from(zoom_multiplier));
+
         // We have an output, so we can compute the new location and focus.
-        let mut new_pos = pos + event.delta();
+        let mut new_pos = pos + delta;
 
         // We received an event for the regular pointer, so show it now.
         self.niri.pointer_visibility = PointerVisibility::Visible;
@@ -2490,44 +2584,50 @@ impl State {
             }
         }
 
-        if self
-            .niri
-            .global_space
-            .output_under(new_pos)
-            .next()
-            .is_none()
-        {
-            // We ended up outside the outputs and need to clip the movement.
-            if let Some(output) = self.niri.global_space.output_under(pos).next() {
-                // The pointer was previously on some output. Clip the movement against its
-                // boundaries.
-                let geom = self.niri.global_space.output_geometry(output).unwrap();
-                new_pos.x = new_pos
-                    .x
-                    .clamp(geom.loc.x as f64, (geom.loc.x + geom.size.w - 1) as f64);
-                new_pos.y = new_pos
-                    .y
-                    .clamp(geom.loc.y as f64, (geom.loc.y + geom.size.h - 1) as f64);
-            } else {
-                // The pointer was not on any output in the first place. Find one for it.
-                // Let's do the simple thing and just put it on the first output.
-                let output = self.niri.global_space.outputs().next().unwrap();
-                let geom = self.niri.global_space.output_geometry(output).unwrap();
-                new_pos = center(geom).to_f64();
+        match self.niri.global_space.output_under(new_pos).next() {
+            None => {
+                // We ended up outside the outputs and need to clip the movement.
+                if let Some(output) = self.niri.global_space.output_under(pos).next() {
+                    // The pointer was previously on some output. Clip the movement against its
+                    // boundaries.
+                    let geom = self.niri.global_space.output_geometry(output).unwrap();
+                    new_pos.x = new_pos
+                        .x
+                        .clamp(geom.loc.x as f64, (geom.loc.x + geom.size.w - 1) as f64);
+                    new_pos.y = new_pos
+                        .y
+                        .clamp(geom.loc.y as f64, (geom.loc.y + geom.size.h - 1) as f64);
+                } else {
+                    // The pointer was not on any output in the first place. Find one for it.
+                    // Let's do the simple thing and just put it on the first output.
+                    let output = self.niri.global_space.outputs().next().unwrap();
+                    let geom = self.niri.global_space.output_geometry(output).unwrap();
+                    new_pos = center(geom).to_f64();
+                }
+            }
+            Some(output) => {
+                if self.niri.layout.zoom_locked_for_output(output)
+                    && self.niri.layout.zoom_is_active_for_output(output)
+                {
+                    let output_geometry = self
+                        .niri
+                        .global_space
+                        .output_geometry(output)
+                        .unwrap()
+                        .to_f64();
+                    if let Some(clamped) = self.niri.layout.zoom_clamp_to_viewport_for_output(
+                        output,
+                        new_pos,
+                        output_geometry,
+                    ) {
+                        new_pos = clamped;
+                    }
+                }
             }
         }
 
         if let Some(output) = self.niri.screenshot_ui.selection_output() {
-            let geom = self.niri.global_space.output_geometry(output).unwrap();
-            let mut point = (new_pos - geom.loc.to_f64())
-                .to_physical(output.current_scale().fractional_scale())
-                .to_i32_round::<i32>();
-
-            let size = output.current_mode().unwrap().size;
-            let transform = output.current_transform();
-            let size = transform.transform_size(size);
-            point.x = point.x.clamp(0, size.w - 1);
-            point.y = point.y.clamp(0, size.h - 1);
+            let point = self.screenshot_ui_point_on_output(output, pos);
 
             self.niri.screenshot_ui.pointer_motion(point, None);
         }
@@ -2629,6 +2729,19 @@ impl State {
             }
         }
 
+        // Handle cursor and focal center movement across outputs with different zoom levels or
+        // locked zoom.
+        if let Some((new_out, _)) = self.niri.output_under(new_pos) {
+            let new_out = new_out.clone();
+            self.niri
+                .update_zoom_base_focal(&new_out, new_pos, Some(pos));
+        }
+
+        if let Some(output) = self.niri.screenshot_ui.selection_output() {
+            let point = self.screenshot_ui_point_on_output(output, new_pos);
+            self.niri.screenshot_ui.pointer_motion(point, None);
+        }
+
         // Redraw to update the cursor position.
         // FIXME: redraw only outputs overlapping the cursor.
         self.niri.queue_redraw_all();
@@ -2649,23 +2762,14 @@ impl State {
         }) else {
             return;
         };
+        let pos = self.clamp_position_to_zoom(pos);
 
         let serial = SERIAL_COUNTER.next_serial();
 
         let pointer = self.niri.seat.get_pointer().unwrap();
 
         if let Some(output) = self.niri.screenshot_ui.selection_output() {
-            let geom = self.niri.global_space.output_geometry(output).unwrap();
-            let mut point = (pos - geom.loc.to_f64())
-                .to_physical(output.current_scale().fractional_scale())
-                .to_i32_round::<i32>();
-
-            let size = output.current_mode().unwrap().size;
-            let transform = output.current_transform();
-            let size = transform.transform_size(size);
-            point.x = point.x.clamp(0, size.w - 1);
-            point.y = point.y.clamp(0, size.h - 1);
-
+            let point = self.screenshot_ui_point_on_output(output, pos);
             self.niri.screenshot_ui.pointer_motion(point, None);
         }
 
@@ -2725,6 +2829,16 @@ impl State {
                 let output = output.clone();
                 self.niri.layout.dnd_update(output, pos_within_output);
             }
+        }
+
+        if let Some((output, _)) = self.niri.output_under(pos) {
+            let output = output.clone();
+            self.niri.update_zoom_base_focal(&output, pos, None);
+        }
+
+        if let Some(output) = self.niri.screenshot_ui.selection_output() {
+            let point = self.screenshot_ui_point_on_output(output, pos);
+            self.niri.screenshot_ui.pointer_motion(point, None);
         }
 
         // Redraw to update the cursor position.
@@ -3018,16 +3132,7 @@ impl State {
                 let pos = pointer.current_location();
                 if let Some((output, _)) = self.niri.output_under(pos) {
                     let output = output.clone();
-                    let geom = self.niri.global_space.output_geometry(&output).unwrap();
-                    let mut point = (pos - geom.loc.to_f64())
-                        .to_physical(output.current_scale().fractional_scale())
-                        .to_i32_round();
-
-                    let size = output.current_mode().unwrap().size;
-                    let transform = output.current_transform();
-                    let size = transform.transform_size(size);
-                    point.x = min(size.w - 1, point.x);
-                    point.y = min(size.h - 1, point.y);
+                    let point = self.screenshot_ui_point_on_output(&output, pos);
 
                     if self.niri.screenshot_ui.pointer_down(output, point, None) {
                         self.niri.queue_redraw_all();
@@ -3510,19 +3615,10 @@ impl State {
         let Some(pos) = self.compute_tablet_position(&event) else {
             return;
         };
+        let pos = self.clamp_position_to_zoom(pos);
 
         if let Some(output) = self.niri.screenshot_ui.selection_output() {
-            let geom = self.niri.global_space.output_geometry(output).unwrap();
-            let mut point = (pos - geom.loc.to_f64())
-                .to_physical(output.current_scale().fractional_scale())
-                .to_i32_round::<i32>();
-
-            let size = output.current_mode().unwrap().size;
-            let transform = output.current_transform();
-            let size = transform.transform_size(size);
-            point.x = point.x.clamp(0, size.w - 1);
-            point.y = point.y.clamp(0, size.h - 1);
-
+            let point = self.screenshot_ui_point_on_output(output, pos);
             self.niri.screenshot_ui.pointer_motion(point, None);
         }
 
@@ -3571,6 +3667,16 @@ impl State {
             self.niri.tablet_cursor_location = Some(pos);
         }
 
+        if let Some((output, _)) = self.niri.output_under(pos) {
+            let output = output.clone();
+            self.niri.update_zoom_base_focal(&output, pos, None);
+        }
+
+        if let Some(output) = self.niri.screenshot_ui.selection_output() {
+            let point = self.screenshot_ui_point_on_output(output, pos);
+            self.niri.screenshot_ui.pointer_motion(point, None);
+        }
+
         // Redraw to update the cursor position.
         // FIXME: redraw only outputs overlapping the cursor.
         self.niri.queue_redraw_all();
@@ -3596,16 +3702,7 @@ impl State {
 
                     if self.niri.screenshot_ui.is_open() {
                         if let Some(output) = under.output.clone() {
-                            let geom = self.niri.global_space.output_geometry(&output).unwrap();
-                            let mut point = (pos - geom.loc.to_f64())
-                                .to_physical(output.current_scale().fractional_scale())
-                                .to_i32_round();
-
-                            let size = output.current_mode().unwrap().size;
-                            let transform = output.current_transform();
-                            let size = transform.transform_size(size);
-                            point.x = min(size.w - 1, point.x);
-                            point.y = min(size.h - 1, point.y);
+                            let point = self.screenshot_ui_point_on_output(&output, pos);
 
                             if self.niri.screenshot_ui.pointer_down(output, point, None) {
                                 self.niri.queue_redraw_all();
@@ -3946,6 +4043,30 @@ impl State {
             pointer.frame(self);
         }
 
+        if event.fingers() == 3 {
+            if let Some(output) = self.niri.output_under_cursor() {
+                // Always intercept 2-finger pinch for zoom control when zoom state exists.
+                // This allows pinch-to-zoom from unzoomed state (level == 1.0).
+                if self.niri.layout.has_zoom_for_output(&output) {
+                    let cursor_global = self.niri.seat.get_pointer().unwrap().current_location();
+                    let output_geo = self
+                        .niri
+                        .global_space
+                        .output_geometry(&output)
+                        .map(|g| g.to_f64());
+                    let cursor_local = output_geo.map(|g| cursor_global - g.loc);
+                    let output_size = output_geo.map(|g| g.size);
+                    let movement_mode = Some(self.niri.config.borrow().zoom.movement_mode.clone());
+                    self.niri.layout.zoom_gesture_begin(
+                        &output,
+                        cursor_local,
+                        output_size,
+                        movement_mode,
+                    );
+                    return;
+                }
+            }
+        }
         pointer.gesture_pinch_begin(
             self,
             &GesturePinchBeginEvent {
@@ -3961,6 +4082,24 @@ impl State {
 
         if self.update_pointer_contents() {
             pointer.frame(self);
+        }
+
+        if let Some(output) = self.niri.output_under_cursor() {
+            let sensitivity = self.niri.config.borrow().zoom.pinch_sensitivity
+                * output.current_scale().fractional_scale();
+
+            let timestamp = Duration::from_millis(event.time_msec() as u64);
+            let scale = event.scale();
+
+            // Returns Some if a zoom gesture was active (avoids check-then-act race).
+            if let Some(_changed) =
+                self.niri
+                    .layout
+                    .zoom_gesture_update(&output, scale, sensitivity, timestamp)
+            {
+                self.niri.queue_redraw(&output);
+                return;
+            }
         }
 
         pointer.gesture_pinch_update(
@@ -3980,6 +4119,19 @@ impl State {
 
         if self.update_pointer_contents() {
             pointer.frame(self);
+        }
+
+        if let Some(output) = self.niri.output_under_cursor() {
+            let cancelled = event.cancelled();
+            if self
+                .niri
+                .layout
+                .zoom_gesture_end(&output, cancelled)
+                .unwrap_or(false)
+            {
+                self.niri.queue_redraw(&output);
+                return;
+            }
         }
 
         pointer.gesture_pinch_end(
@@ -4054,6 +4206,50 @@ impl State {
         self.compute_absolute_location(evt, self.niri.output_for_touch())
     }
 
+    /// Clamp a position to the zoomed viewport when zoom is locked.
+    ///
+    /// This ensures that touch events do not go outside the zoomed area.
+    fn clamp_position_to_zoom(&self, pos: Point<f64, Logical>) -> Point<f64, Logical> {
+        if let Some((output, _)) = self.niri.output_under(pos) {
+            if self.niri.layout.zoom_locked_for_output(output)
+                && self.niri.layout.zoom_is_active_for_output(output)
+            {
+                let output_geometry = self
+                    .niri
+                    .global_space
+                    .output_geometry(output)
+                    .unwrap()
+                    .to_f64();
+                if let Some(clamped) =
+                    self.niri
+                        .layout
+                        .zoom_clamp_to_viewport_for_output(output, pos, output_geometry)
+                {
+                    return clamped;
+                }
+            }
+        }
+        pos
+    }
+
+    fn screenshot_ui_point_on_output(
+        &self,
+        output: &Output,
+        pos: Point<f64, Logical>,
+    ) -> Point<i32, Physical> {
+        let geom = self.niri.global_space.output_geometry(output).unwrap();
+        let mut point = (pos - geom.loc.to_f64())
+            .to_physical(output.current_scale().fractional_scale())
+            .to_i32_round::<i32>();
+
+        let size = output.current_mode().unwrap().size;
+        let transform = output.current_transform();
+        let size = transform.transform_size(size);
+        point.x = point.x.clamp(0, size.w - 1);
+        point.y = point.y.clamp(0, size.h - 1);
+        point
+    }
+
     fn on_touch_down<I: InputBackend>(&mut self, evt: I::TouchDownEvent) {
         let Some(handle) = self.niri.seat.get_touch() else {
             return;
@@ -4061,6 +4257,7 @@ impl State {
         let Some(pos) = self.compute_touch_location(&evt) else {
             return;
         };
+        let pos = self.clamp_position_to_zoom(pos);
         let slot = evt.slot();
 
         let serial = SERIAL_COUNTER.next_serial();
@@ -4071,16 +4268,7 @@ impl State {
 
         if self.niri.screenshot_ui.is_open() {
             if let Some(output) = under.output.clone() {
-                let geom = self.niri.global_space.output_geometry(&output).unwrap();
-                let mut point = (pos - geom.loc.to_f64())
-                    .to_physical(output.current_scale().fractional_scale())
-                    .to_i32_round();
-
-                let size = output.current_mode().unwrap().size;
-                let transform = output.current_transform();
-                let size = transform.transform_size(size);
-                point.x = min(size.w - 1, point.x);
-                point.y = min(size.h - 1, point.y);
+                let point = self.screenshot_ui_point_on_output(&output, pos);
 
                 if self
                     .niri
@@ -4216,19 +4404,11 @@ impl State {
         let Some(pos) = self.compute_touch_location(&evt) else {
             return;
         };
+        let pos = self.clamp_position_to_zoom(pos);
         let slot = evt.slot();
 
         if let Some(output) = self.niri.screenshot_ui.selection_output().cloned() {
-            let geom = self.niri.global_space.output_geometry(&output).unwrap();
-            let mut point = (pos - geom.loc.to_f64())
-                .to_physical(output.current_scale().fractional_scale())
-                .to_i32_round::<i32>();
-
-            let size = output.current_mode().unwrap().size;
-            let transform = output.current_transform();
-            let size = transform.transform_size(size);
-            point.x = point.x.clamp(0, size.w - 1);
-            point.y = point.y.clamp(0, size.h - 1);
+            let point = self.screenshot_ui_point_on_output(&output, pos);
 
             self.niri.screenshot_ui.pointer_motion(point, Some(slot));
             self.niri.queue_redraw(&output);

--- a/src/input/pick_color_grab.rs
+++ b/src/input/pick_color_grab.rs
@@ -14,6 +14,7 @@ use smithay::utils::{Logical, Physical, Point, Scale, Size, Transform};
 
 use crate::niri::State;
 use crate::render_helpers::{render_and_download, RenderTarget};
+use crate::zoom::zoom_display_cursor_logical;
 
 pub struct PickColorGrab {
     start_data: PointerGrabStartData<State>,
@@ -39,6 +40,22 @@ impl PickColorGrab {
         let (output, pos_within_output) = data.niri.output_under(location)?;
         let output = output.clone();
 
+        // When zoom is active, the cursor is visually clamped to the zoom viewport.
+        // Compute the display position on-the-fly from viewport math.
+        let pos_within_output = if data.niri.layout.zoom_is_active_for_output(&output) {
+            let mode_size = output.current_mode().map(|m| m.size).unwrap_or_default();
+            let scale = output.current_scale().fractional_scale();
+            let output_size = mode_size.to_f64().to_logical(scale);
+            zoom_display_cursor_logical(
+                pos_within_output,
+                output_size,
+                data.niri.layout.zoom_level_for_output(&output),
+                data.niri.layout.zoom_focal_for_output(&output),
+            )
+        } else {
+            pos_within_output
+        };
+
         data.backend
             .with_primary_renderer(|renderer| {
                 data.niri.update_render_elements(Some(&output));
@@ -49,12 +66,14 @@ impl PickColorGrab {
                 let pos = pos_within_output.to_physical_precise_floor(scale);
                 let size = Size::<i32, Physical>::from((1, 1));
 
-                let elements = data.niri.render(
+                // Use un-zoomed elements and sample at logical position.
+                let mut elements = Vec::new();
+                data.niri.render_inner(
                     renderer,
                     &output,
                     false,
-                    // This is an interactive operation so we can render without blocking out.
                     RenderTarget::Output,
+                    &mut |elem| elements.push(elem),
                 );
 
                 let mapping = match render_and_download(

--- a/src/input/pick_color_grab.rs
+++ b/src/input/pick_color_grab.rs
@@ -13,7 +13,7 @@ use smithay::input::SeatHandler;
 use smithay::utils::{Logical, Physical, Point, Scale, Size, Transform};
 
 use crate::niri::State;
-use crate::render_helpers::{render_and_download, RenderTarget};
+use crate::render_helpers::{render_and_download, RenderCtx, RenderTarget};
 use crate::zoom::zoom_display_cursor_logical;
 
 pub struct PickColorGrab {
@@ -66,15 +66,16 @@ impl PickColorGrab {
                 let pos = pos_within_output.to_physical_precise_floor(scale);
                 let size = Size::<i32, Physical>::from((1, 1));
 
-                // Use un-zoomed elements and sample at logical position.
                 let mut elements = Vec::new();
-                data.niri.render_inner(
+                let ctx = RenderCtx {
                     renderer,
-                    &output,
-                    false,
-                    RenderTarget::Output,
-                    &mut |elem| elements.push(elem),
-                );
+                    // This is an interactive operation so we can render without blocking out.
+                    target: RenderTarget::Output,
+                };
+                data.niri.render(ctx, &output, false, &mut |elem| {
+                    // Use un-zoomed elements and sample at logical position.
+                    elements.push(elem)
+                });
 
                 let mapping = match render_and_download(
                     renderer,

--- a/src/input/swipe_tracker.rs
+++ b/src/input/swipe_tracker.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 const HISTORY_LIMIT: Duration = Duration::from_millis(150);
 const DECELERATION_TOUCHPAD: f64 = 0.997;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SwipeTracker {
     history: VecDeque<Event>,
     pos: f64,

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
@@ -454,6 +454,31 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let state = ctx.event_stream_state.borrow();
             let casts = state.casts.casts.values().cloned().collect();
             Response::Casts(casts)
+        }
+        Request::ZoomState => {
+            let (tx, rx) = async_channel::bounded(1);
+            ctx.event_loop.insert_idle(move |state| {
+                let zooms = state
+                    .niri
+                    .layout
+                    .outputs()
+                    .fold(HashMap::new(), |mut acc, output| {
+                        let level = state.niri.layout.zoom_level_for_output(output);
+                        acc.insert(
+                            output.name().clone(),
+                            niri_ipc::Zoom {
+                                is_locked: state.niri.layout.zoom_locked_for_output(output),
+                                level,
+                            },
+                        );
+                        acc
+                    });
+
+                let _ = tx.send_blocking(zooms);
+            });
+            let result = rx.recv().await;
+            let zooms = result.map_err(|_| String::from("error getting zoom states"))?;
+            Response::ZoomState(zooms)
         }
     };
 

--- a/src/layout/closing_window.rs
+++ b/src/layout/closing_window.rs
@@ -21,7 +21,7 @@ use crate::render_helpers::shader_element::ShaderRenderElement;
 use crate::render_helpers::shaders::{mat3_uniform, ProgramType, Shaders};
 use crate::render_helpers::snapshot::RenderSnapshot;
 use crate::render_helpers::texture::{TextureBuffer, TextureRenderElement};
-use crate::render_helpers::{render_to_encompassing_texture, RenderTarget};
+use crate::render_helpers::{render_to_encompassing_texture, RenderCtx};
 use crate::utils::transaction::TransactionBlocker;
 
 #[derive(Debug)]
@@ -159,12 +159,11 @@ impl ClosingWindow {
 
     pub fn render(
         &self,
-        renderer: &mut GlesRenderer,
+        ctx: RenderCtx<GlesRenderer>,
         view_rect: Rectangle<f64, Logical>,
         scale: Scale<f64>,
-        target: RenderTarget,
     ) -> ClosingWindowRenderElement {
-        let (buffer, offset) = if target.should_block_out(self.block_out_from) {
+        let (buffer, offset) = if ctx.target.should_block_out(self.block_out_from) {
             (&self.blocked_out_buffer, self.blocked_out_buffer_offset)
         } else {
             (&self.buffer, self.buffer_offset)
@@ -200,7 +199,10 @@ impl ClosingWindow {
         let progress = anim.value();
         let clamped_progress = anim.clamped_value().clamp(0., 1.);
 
-        if Shaders::get(renderer).program(ProgramType::Close).is_some() {
+        if Shaders::get(ctx.renderer)
+            .program(ProgramType::Close)
+            .is_some()
+        {
             let area_loc = Vec2::new(view_rect.loc.x as f32, view_rect.loc.y as f32);
             let area_size = Vec2::new(view_rect.size.w as f32, view_rect.size.h as f32);
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -65,7 +65,7 @@ use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::snapshot::RenderSnapshot;
 use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
 use crate::render_helpers::texture::TextureBuffer;
-use crate::render_helpers::{BakedBuffer, RenderTarget};
+use crate::render_helpers::{BakedBuffer, RenderCtx};
 use crate::rubber_band::RubberBand;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::{
@@ -164,41 +164,38 @@ pub trait LayoutElement {
     /// location.
     fn render<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        mut ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
         scale: Scale<f64>,
         alpha: f32,
-        target: RenderTarget,
         push: &mut dyn FnMut(LayoutElementRenderElement<R>),
     ) {
-        self.render_popups(renderer, location, scale, alpha, target, push);
-        self.render_normal(renderer, location, scale, alpha, target, push);
+        self.render_popups(ctx.r(), location, scale, alpha, push);
+        self.render_normal(ctx.r(), location, scale, alpha, push);
     }
 
     /// Renders the non-popup parts of the element.
     fn render_normal<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
         scale: Scale<f64>,
         alpha: f32,
-        target: RenderTarget,
         push: &mut dyn FnMut(LayoutElementRenderElement<R>),
     ) {
-        let _ = (renderer, location, scale, alpha, target, push);
+        let _ = (ctx, location, scale, alpha, push);
     }
 
     /// Renders the popups of the element.
     fn render_popups<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
         scale: Scale<f64>,
         alpha: f32,
-        target: RenderTarget,
         push: &mut dyn FnMut(LayoutElementRenderElement<R>),
     ) {
-        let _ = (renderer, location, scale, alpha, target, push);
+        let _ = (ctx, location, scale, alpha, push);
     }
 
     /// Requests the element to change its size.
@@ -5585,9 +5582,8 @@ impl<W: LayoutElement> Layout<W> {
 
     pub fn render_interactive_move_for_output<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        ctx: RenderCtx<R>,
         output: &Output,
-        target: RenderTarget,
         push: &mut dyn FnMut(RescaleRenderElement<TileRenderElement<R>>),
     ) {
         if self.update_render_elements_time != self.clock.now() {
@@ -5606,15 +5602,13 @@ impl<W: LayoutElement> Layout<W> {
         let scale = Scale::from(move_.output.current_scale().fractional_scale());
         let zoom = self.overview_zoom();
         let location = move_.tile_render_location(zoom);
-        move_
-            .tile
-            .render(renderer, location, true, target, &mut |elem| {
-                push(RescaleRenderElement::from_element(
-                    elem,
-                    location.to_physical_precise_round(scale),
-                    zoom,
-                ));
-            });
+        move_.tile.render(ctx, location, true, &mut |elem| {
+            push(RescaleRenderElement::from_element(
+                elem,
+                location.to_physical_precise_round(scale),
+                zoom,
+            ));
+        });
     }
 
     pub fn refresh(&mut self, is_active: bool) {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -40,6 +40,7 @@ use monitor::{InsertHint, InsertPosition, InsertWorkspace, MonitorAddWindowTarge
 use niri_config::utils::MergeWith as _;
 use niri_config::{
     Config, CornerRadius, LayoutPart, PresetSize, Workspace as WorkspaceConfig, WorkspaceReference,
+    ZoomMovementMode,
 };
 use niri_ipc::{ColumnDisplay, PositionChange, SizeChange, WindowLayout};
 use scrolling::{Column, ColumnWidth};
@@ -72,6 +73,10 @@ use crate::utils::{
     round_logical_in_physical_max1, ResizeEdge,
 };
 use crate::window::ResolvedWindowRules;
+pub use crate::zoom::OutputZoomState;
+use crate::zoom::{
+    compute_focal_for_cursor, compute_focal_for_on_edge_anchor, compute_on_edge_cursor_anchor,
+};
 
 pub mod closing_window;
 pub mod floating;
@@ -101,6 +106,11 @@ const INTERACTIVE_MOVE_ALPHA: f64 = 0.75;
 const OVERVIEW_GESTURE_MOVEMENT: f64 = 300.;
 
 const OVERVIEW_GESTURE_RUBBER_BAND: RubberBand = RubberBand {
+    stiffness: 0.5,
+    limit: 0.05,
+};
+
+pub const ZOOM_GESTURE_RUBBER_BAND: RubberBand = RubberBand {
     stiffness: 0.5,
     limit: 0.05,
 };
@@ -351,6 +361,7 @@ pub struct Options {
     pub animations: niri_config::Animations,
     pub gestures: niri_config::Gestures,
     pub overview: niri_config::Overview,
+    pub max_zoom: f64,
     // Debug flags.
     pub disable_resize_throttling: bool,
     pub disable_transactions: bool,
@@ -611,6 +622,7 @@ impl Options {
             animations: config.animations.clone(),
             gestures: config.gestures,
             overview: config.overview,
+            max_zoom: config.zoom.max_zoom.clamp(1.0, 100.0),
             disable_resize_throttling: config.debug.disable_resize_throttling,
             disable_transactions: config.debug.disable_transactions,
             deactivate_unfocused_windows: config.debug.deactivate_unfocused_windows,
@@ -644,6 +656,446 @@ impl OverviewProgress {
     }
 }
 
+/// Animation for zoom level changes.
+#[derive(Debug, Clone)]
+pub struct ZoomLevelAnimation {
+    anim: Animation,
+    target: f64,
+    cursor_pos: Option<Point<f64, Logical>>,
+    output_size: Option<Size<f64, Logical>>,
+    movement_mode: Option<ZoomMovementMode>,
+    on_edge_cursor_anchor: Option<(f64, f64)>,
+}
+
+impl ZoomLevelAnimation {
+    pub fn new(clock: Clock, from: f64, to: f64, config: niri_config::Animation) -> Self {
+        Self {
+            anim: Animation::new(clock, from, to, 0.0, config),
+            target: to,
+            cursor_pos: None,
+            output_size: None,
+            movement_mode: None,
+            on_edge_cursor_anchor: None,
+        }
+    }
+
+    pub fn with_cursor_tracking(
+        mut self,
+        cursor_pos: Point<f64, Logical>,
+        output_size: Size<f64, Logical>,
+        movement_mode: ZoomMovementMode,
+        on_edge_cursor_anchor: Option<(f64, f64)>,
+    ) -> Self {
+        self.on_edge_cursor_anchor = on_edge_cursor_anchor;
+        self.cursor_pos = Some(cursor_pos);
+        self.output_size = Some(output_size);
+        self.movement_mode = Some(movement_mode);
+        self
+    }
+
+    pub fn set_cursor_pos(&mut self, cursor_pos: Point<f64, Logical>) {
+        self.cursor_pos = Some(cursor_pos);
+    }
+
+    pub fn compute_focal_or(
+        &self,
+        level: f64,
+        fallback: Point<f64, Logical>,
+    ) -> Point<f64, Logical> {
+        compute_focal_with_cursor_policy(
+            level,
+            fallback,
+            self.cursor_pos,
+            self.output_size,
+            self.movement_mode.as_ref(),
+            self.on_edge_cursor_anchor,
+        )
+    }
+
+    pub fn value(&self) -> f64 {
+        if self.anim.is_done() {
+            self.target
+        } else {
+            self.anim.value()
+        }
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.anim.is_done()
+    }
+}
+
+/// Gesture tracking for zoom level changes.
+#[derive(Debug, Clone)]
+pub struct ZoomLevelGesture {
+    pub tracker: SwipeTracker,
+    pub start_level: f64,
+    pub current_level: f64,
+    pub current_focal: Point<f64, Logical>,
+    /// Last log-scale value for computing log-space deltas from Wayland pinch events.
+    /// Wayland provides absolute scale since gesture begin; we convert to log-space deltas.
+    /// `None` means the first update hasn't been received yet.
+    pub last_log_scale: Option<f64>,
+    pub cursor_pos: Option<Point<f64, Logical>>,
+    pub output_size: Option<Size<f64, Logical>>,
+    pub movement_mode: Option<ZoomMovementMode>,
+    pub on_edge_cursor_anchor: Option<(f64, f64)>,
+}
+
+impl ZoomLevelGesture {
+    pub fn compute_focal_or(
+        &self,
+        level: f64,
+        fallback: Point<f64, Logical>,
+    ) -> Point<f64, Logical> {
+        compute_focal_with_cursor_policy(
+            level,
+            fallback,
+            self.cursor_pos,
+            self.output_size,
+            self.movement_mode.as_ref(),
+            self.on_edge_cursor_anchor,
+        )
+    }
+}
+
+fn compute_focal_with_cursor_policy(
+    level: f64,
+    fallback: Point<f64, Logical>,
+    cursor_pos: Option<Point<f64, Logical>>,
+    output_size: Option<Size<f64, Logical>>,
+    movement_mode: Option<&ZoomMovementMode>,
+    on_edge_cursor_anchor: Option<(f64, f64)>,
+) -> Point<f64, Logical> {
+    let (Some(cursor), Some(size), Some(mode)) = (cursor_pos, output_size, movement_mode) else {
+        return fallback;
+    };
+
+    if matches!(mode, ZoomMovementMode::OnEdge) {
+        if let Some(anchor) = on_edge_cursor_anchor {
+            return compute_focal_for_on_edge_anchor(cursor, level, size, anchor);
+        }
+    }
+
+    compute_focal_for_cursor(cursor, level, size, mode)
+}
+
+fn should_use_dynamic_focal_tracking(
+    movement_mode: Option<&ZoomMovementMode>,
+    locked: bool,
+    target_level: f64,
+    level_changed: bool,
+    cursor_available: bool,
+    output_size_available: bool,
+) -> bool {
+    level_changed
+        && !locked
+        && target_level > 1.0
+        && cursor_available
+        && output_size_available
+        && matches!(
+            movement_mode,
+            Some(ZoomMovementMode::Centered | ZoomMovementMode::OnEdge)
+        )
+}
+
+fn compute_on_edge_tracking_anchor(
+    movement_mode: Option<&ZoomMovementMode>,
+    cursor_local: Point<f64, Logical>,
+    output_size: Size<f64, Logical>,
+    current_level: f64,
+    current_focal: Point<f64, Logical>,
+) -> Option<(f64, f64)> {
+    if matches!(movement_mode, Some(ZoomMovementMode::OnEdge)) {
+        Some(compute_on_edge_cursor_anchor(
+            cursor_local,
+            current_level,
+            current_focal,
+            output_size,
+        ))
+    } else {
+        None
+    }
+}
+
+fn build_zoom_level_animation(
+    clock: &Clock,
+    start_level: f64,
+    target_level: f64,
+    anim_config: niri_config::Animation,
+    dynamic_focal_tracking: bool,
+    cursor_pos: Option<Point<f64, Logical>>,
+    output_size: Option<Size<f64, Logical>>,
+    movement_mode: Option<ZoomMovementMode>,
+    on_edge_cursor_anchor: Option<(f64, f64)>,
+) -> ZoomLevelAnimation {
+    let mut level_anim =
+        ZoomLevelAnimation::new(clock.clone(), start_level, target_level, anim_config);
+
+    if dynamic_focal_tracking {
+        if let (Some(cursor), Some(size), Some(mode)) = (cursor_pos, output_size, movement_mode) {
+            level_anim = level_anim.with_cursor_tracking(cursor, size, mode, on_edge_cursor_anchor);
+        }
+    }
+
+    level_anim
+}
+
+/// Progress of zoom level changes - either animating or in a gesture.
+#[derive(Debug, Clone)]
+pub enum ZoomLevelProgress {
+    Animation(ZoomLevelAnimation),
+    Gesture(ZoomLevelGesture),
+}
+
+impl ZoomLevelProgress {
+    pub fn level(&self) -> f64 {
+        match self {
+            ZoomLevelProgress::Animation(anim) => anim.value(),
+            ZoomLevelProgress::Gesture(gesture) => gesture.current_level,
+        }
+    }
+
+    pub fn focal_point(
+        &self,
+        current_level: f64,
+        current_focal: Point<f64, Logical>,
+    ) -> Point<f64, Logical> {
+        match self {
+            ZoomLevelProgress::Animation(anim) => {
+                anim.compute_focal_or(current_level, current_focal)
+            }
+            ZoomLevelProgress::Gesture(gesture) => gesture.current_focal,
+        }
+    }
+
+    pub fn is_animation(&self) -> bool {
+        matches!(self, ZoomLevelProgress::Animation(_))
+    }
+
+    pub fn is_gesture(&self) -> bool {
+        matches!(self, ZoomLevelProgress::Gesture(_))
+    }
+
+    pub fn is_done(&self) -> bool {
+        match self {
+            ZoomLevelProgress::Animation(anim) => anim.is_done(),
+            ZoomLevelProgress::Gesture(_) => false,
+        }
+    }
+}
+
+/// Animation for focal point panning.
+/// Uses separate X and Y animations to handle Point interpolation.
+#[derive(Debug, Clone)]
+pub struct ZoomFocalAnimation {
+    pub x_anim: Animation,
+    pub y_anim: Animation,
+    pub target: Point<f64, Logical>,
+    pub start: Point<f64, Logical>,
+}
+
+impl ZoomFocalAnimation {
+    pub fn new(
+        clock: Clock,
+        from: Point<f64, Logical>,
+        to: Point<f64, Logical>,
+        config: niri_config::Animation,
+    ) -> Self {
+        Self {
+            x_anim: Animation::new(clock.clone(), from.x, to.x, 0.0, config),
+            y_anim: Animation::new(clock, from.y, to.y, 0.0, config),
+            target: to,
+            start: from,
+        }
+    }
+
+    /// Get the current focal point value.
+    /// When both animations are done, returns the target.
+    pub fn value(&self) -> Point<f64, Logical> {
+        if self.is_done() {
+            self.target
+        } else {
+            Point::from((self.x_anim.value(), self.y_anim.value()))
+        }
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.x_anim.is_done() && self.y_anim.is_done()
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ZoomTransition {
+    level_progress: Option<ZoomLevelProgress>,
+    focal_anim: Option<ZoomFocalAnimation>,
+}
+
+impl ZoomTransition {
+    pub fn current_level(&self, fallback: f64) -> f64 {
+        self.level_progress.as_ref().map_or(fallback, |p| p.level())
+    }
+
+    pub fn current_focal(
+        &self,
+        current_level: f64,
+        fallback: Point<f64, Logical>,
+    ) -> Point<f64, Logical> {
+        if let Some(anim) = self.focal_anim.as_ref() {
+            anim.value()
+        } else if let Some(progress) = self.level_progress.as_ref() {
+            progress.focal_point(current_level, fallback)
+        } else {
+            fallback
+        }
+    }
+
+    pub fn level_is_animation(&self) -> bool {
+        self.level_progress
+            .as_ref()
+            .is_some_and(|progress| progress.is_animation())
+    }
+
+    pub fn is_animation_ongoing(&self) -> bool {
+        self.level_is_animation() || self.focal_anim.is_some()
+    }
+
+    pub fn set_level_animation(&mut self, anim: ZoomLevelAnimation) {
+        self.level_progress = Some(ZoomLevelProgress::Animation(anim));
+    }
+
+    pub fn set_level_gesture(&mut self, gesture: ZoomLevelGesture) {
+        self.level_progress = Some(ZoomLevelProgress::Gesture(gesture));
+    }
+
+    pub fn begin_gesture(&mut self, gesture: ZoomLevelGesture) {
+        self.set_level_gesture(gesture);
+    }
+
+    pub fn take_level_gesture(&mut self) -> Option<ZoomLevelGesture> {
+        match self.level_progress.take() {
+            Some(ZoomLevelProgress::Gesture(gesture)) => Some(gesture),
+            Some(other) => {
+                self.level_progress = Some(other);
+                None
+            }
+            None => None,
+        }
+    }
+
+    pub fn level_gesture_mut(&mut self) -> Option<&mut ZoomLevelGesture> {
+        match self.level_progress.as_mut() {
+            Some(ZoomLevelProgress::Gesture(gesture)) => Some(gesture),
+            _ => None,
+        }
+    }
+
+    pub fn gesture_mut(&mut self) -> Option<&mut ZoomLevelGesture> {
+        self.level_gesture_mut()
+    }
+
+    pub fn set_focal_animation(&mut self, focal_anim: Option<ZoomFocalAnimation>) {
+        self.focal_anim = focal_anim;
+    }
+
+    pub fn clear_focal_animation(&mut self) {
+        self.focal_anim = None;
+    }
+
+    pub fn set_cursor_pos(&mut self, pos: Point<f64, Logical>) {
+        if let Some(progress) = &mut self.level_progress {
+            match progress {
+                ZoomLevelProgress::Gesture(gesture) => {
+                    gesture.cursor_pos = Some(pos);
+                    gesture.current_focal =
+                        gesture.compute_focal_or(gesture.current_level, gesture.current_focal);
+                }
+                ZoomLevelProgress::Animation(anim) => anim.set_cursor_pos(pos),
+            }
+        }
+    }
+
+    pub fn mark_transitioning(&self, zoom_state: &mut OutputZoomState) {
+        zoom_state.transitioning = self.transitioning();
+    }
+
+    pub fn begin_transition_from_state(
+        &self,
+        zoom_state: &mut OutputZoomState,
+        level: f64,
+        focal: Point<f64, Logical>,
+    ) {
+        zoom_state.level = level;
+        zoom_state.focal = focal;
+        self.mark_transitioning(zoom_state);
+    }
+
+    pub fn cancel_gesture_to_animation(
+        &mut self,
+        level_anim: ZoomLevelAnimation,
+        clear_focal_animation: bool,
+    ) {
+        self.set_level_animation(level_anim);
+        if clear_focal_animation {
+            self.clear_focal_animation();
+        }
+    }
+
+    pub fn finalize_gesture_to_animation(
+        &mut self,
+        level_anim: Option<ZoomLevelAnimation>,
+        focal_anim: Option<ZoomFocalAnimation>,
+        clear_focal_animation: bool,
+    ) {
+        if let Some(level_anim) = level_anim {
+            self.set_level_animation(level_anim);
+        }
+
+        if let Some(focal_anim) = focal_anim {
+            self.set_focal_animation(Some(focal_anim));
+        } else if clear_focal_animation {
+            self.clear_focal_animation();
+        }
+    }
+
+    pub fn apply_to_state(&self, zoom_state: &mut OutputZoomState) {
+        if let Some(progress) = self.level_progress.as_ref() {
+            let current_level = progress.level();
+            zoom_state.level = current_level;
+            if self.focal_anim.is_none() {
+                zoom_state.focal = progress.focal_point(current_level, zoom_state.focal);
+            }
+        }
+
+        if let Some(anim) = self.focal_anim.as_ref() {
+            zoom_state.focal = anim.value();
+        }
+
+        self.mark_transitioning(zoom_state);
+    }
+
+    pub fn transitioning(&self) -> bool {
+        !self.is_done()
+    }
+
+    pub fn is_done(&self) -> bool {
+        let level_done = self
+            .level_progress
+            .as_ref()
+            .is_none_or(|progress| progress.is_done());
+        let focal_done = self.focal_anim.as_ref().is_none_or(|anim| anim.is_done());
+
+        level_done && focal_done
+    }
+
+    pub fn clear_if_done(&mut self) {
+        if self.is_done() {
+            self.level_progress = None;
+            self.focal_anim = None;
+        }
+    }
+}
+
 impl<W: LayoutElement> Layout<W> {
     pub fn new(clock: Clock, config: &Config) -> Self {
         Self::with_options_and_workspaces(clock, config, Options::from_config(config))
@@ -662,6 +1114,10 @@ impl<W: LayoutElement> Layout<W> {
             overview_progress: None,
             options: Rc::new(options),
         }
+    }
+
+    pub fn clock(&self) -> &Clock {
+        &self.clock
     }
 
     fn with_options_and_workspaces(clock: Clock, config: &Config, options: Options) -> Self {
@@ -2671,6 +3127,11 @@ impl<W: LayoutElement> Layout<W> {
                 for mon in monitors {
                     mon.set_overview_progress(self.overview_progress.as_ref());
                     mon.advance_animations();
+
+                    // Sync zoom progress into OutputZoomState each frame.
+                    mon.zoom_transition.apply_to_state(&mut mon.zoom_state);
+
+                    mon.zoom_transition.clear_if_done();
                 }
             }
             MonitorSet::NoOutputs { workspaces, .. } => {
@@ -2718,9 +3179,136 @@ impl<W: LayoutElement> Layout<W> {
             if mon.are_animations_ongoing() {
                 return true;
             }
+
+            if mon.zoom_transition.is_animation_ongoing() {
+                return true;
+            }
         }
 
         false
+    }
+
+    /// Check if a zoom animation is currently ongoing for the given output.
+    pub fn is_zoom_animating(&self, output: &Output) -> bool {
+        self.monitor_for_output(output)
+            .is_some_and(|mon| mon.zoom_transition.is_animation_ongoing())
+    }
+
+    pub fn zoom_state_for_output(&self, output: &Output) -> Option<&OutputZoomState> {
+        self.monitor_for_output(output).map(|mon| &mon.zoom_state)
+    }
+
+    pub fn zoom_state_for_output_mut(&mut self, output: &Output) -> Option<&mut OutputZoomState> {
+        self.monitor_for_output_mut(output)
+            .map(|mon| &mut mon.zoom_state)
+    }
+
+    pub fn zoom_level_for_output(&self, output: &Output) -> f64 {
+        self.zoom_state_for_output(output).map_or(1.0, |z| z.level)
+    }
+
+    pub fn zoom_focal_for_output(&self, output: &Output) -> Point<f64, Logical> {
+        self.zoom_state_for_output(output)
+            .map_or(Point::from((0.0, 0.0)), |z| z.focal)
+    }
+
+    pub fn zoom_is_active_for_output(&self, output: &Output) -> bool {
+        self.zoom_state_for_output(output)
+            .is_some_and(|z| z.is_active())
+    }
+
+    pub fn zoom_locked_for_output(&self, output: &Output) -> bool {
+        self.zoom_state_for_output(output)
+            .map_or(false, |z| z.locked)
+    }
+
+    pub fn has_zoom_for_output(&self, output: &Output) -> bool {
+        self.zoom_state_for_output(output).is_some()
+    }
+
+    pub fn zoom_clamp_to_viewport_for_output(
+        &self,
+        output: &Output,
+        pos: Point<f64, Logical>,
+        output_geometry: Rectangle<f64, Logical>,
+    ) -> Option<Point<f64, Logical>> {
+        let zoom_state = self.zoom_state_for_output(output)?;
+        if zoom_state.is_active() {
+            Some(zoom_state.clamp_to_viewport(pos, output_geometry))
+        } else {
+            None
+        }
+    }
+
+    pub fn toggle_zoom_lock(&mut self, output: &Output) -> bool {
+        if let Some(zoom_state) = self.zoom_state_for_output_mut(output) {
+            let was = zoom_state.locked;
+            zoom_state.locked = !was;
+            was
+        } else {
+            false
+        }
+    }
+
+    /// Update the cursor position on an in-progress zoom animation/gesture.
+    ///
+    /// Called from niri when the cursor moves while a zoom transition is active,
+    /// so `focal_point()` tracks the live cursor and avoids jitter.
+    pub fn set_zoom_cursor_pos(&mut self, output: &Output, pos: Point<f64, Logical>) {
+        if let Some(mon) = self.monitor_for_output_mut(output) {
+            // Store cursor position in zoom state for gesture/animation coordination.
+            // The cursor position is used to compute focal points dynamically.
+            mon.zoom_transition.set_cursor_pos(pos);
+        }
+    }
+
+    /// Animate focal point when zoom is unlocked.
+    ///
+    /// Creates a focal animation from current focal to the cursor-based target.
+    /// This provides a smooth transition when unlocking zoom.
+    pub fn animate_zoom_unlock(
+        &mut self,
+        output: &Output,
+        cursor_local: Point<f64, Logical>,
+        movement_mode: &ZoomMovementMode,
+    ) {
+        let Some(mon) = self.monitor_for_output_mut(output) else {
+            return;
+        };
+
+        let current_level = mon.zoom_transition.current_level(mon.zoom_state.level);
+
+        let output_size = mon.view_size();
+        let target_focal = if current_level <= 1.0 {
+            mon.zoom_state.focal
+        } else {
+            compute_focal_for_cursor(cursor_local, current_level, output_size, movement_mode)
+        };
+
+        let current_focal = mon.zoom_state.focal;
+
+        let focal_changed = (current_focal.x - target_focal.x).abs() > 0.5
+            || (current_focal.y - target_focal.y).abs() > 0.5;
+
+        if !focal_changed {
+            return;
+        }
+
+        let focal_anim_config = mon.options.animations.zoom_focal_pan.0;
+
+        let focal_anim = ZoomFocalAnimation::new(
+            mon.clock.clone(),
+            current_focal,
+            target_focal,
+            focal_anim_config,
+        );
+
+        mon.zoom_transition.set_focal_animation(Some(focal_anim));
+        mon.zoom_transition.begin_transition_from_state(
+            &mut mon.zoom_state,
+            current_level,
+            current_focal,
+        );
     }
 
     pub fn update_render_elements(&mut self, output: Option<&Output>) {
@@ -3736,6 +4324,282 @@ impl<W: LayoutElement> Layout<W> {
         true
     }
 
+    /// Set the zoom level for the given output, computing the correct focal point
+    /// and creating an animation.
+    pub fn set_zoom_level(
+        &mut self,
+        output: &Output,
+        target_level: f64,
+        cursor_local: Point<f64, Logical>,
+        movement_mode: &ZoomMovementMode,
+        locked: bool,
+    ) {
+        let Some(mon) = self.monitor_for_output_mut(output) else {
+            return;
+        };
+
+        let current_level = mon.zoom_transition.current_level(mon.zoom_state.level);
+
+        let level_changed = (target_level - current_level).abs() >= 0.001;
+
+        let output_size = mon.view_size();
+
+        let target_focal = if locked || target_level <= 1.0 {
+            mon.zoom_state.focal
+        } else {
+            compute_focal_for_cursor(cursor_local, target_level, output_size, movement_mode)
+        };
+
+        let current_focal = mon
+            .zoom_transition
+            .current_focal(current_level, mon.zoom_state.focal);
+
+        let focal_changed = (current_focal.x - target_focal.x).abs() > 0.5
+            || (current_focal.y - target_focal.y).abs() > 0.5;
+
+        if !level_changed && !focal_changed {
+            return;
+        }
+
+        let dynamic_focal_tracking = should_use_dynamic_focal_tracking(
+            Some(movement_mode),
+            locked,
+            target_level,
+            level_changed,
+            true,
+            true,
+        );
+
+        let focal_anim_config = mon.options.animations.zoom_focal_pan.0;
+        let level_anim_config = mon.options.animations.zoom_level_change.0;
+
+        if level_changed {
+            let on_edge_cursor_anchor = compute_on_edge_tracking_anchor(
+                Some(movement_mode),
+                cursor_local,
+                output_size,
+                current_level,
+                current_focal,
+            );
+
+            let level_anim = build_zoom_level_animation(
+                &mon.clock,
+                current_level,
+                target_level,
+                level_anim_config,
+                dynamic_focal_tracking,
+                Some(cursor_local),
+                Some(output_size),
+                Some(movement_mode.clone()),
+                on_edge_cursor_anchor,
+            );
+            mon.zoom_transition.set_level_animation(level_anim);
+        }
+
+        if focal_changed && !dynamic_focal_tracking {
+            let focal_anim = ZoomFocalAnimation::new(
+                mon.clock.clone(),
+                current_focal,
+                target_focal,
+                focal_anim_config,
+            );
+            mon.zoom_transition.set_focal_animation(Some(focal_anim));
+        } else if dynamic_focal_tracking {
+            mon.zoom_transition.clear_focal_animation();
+        }
+
+        mon.zoom_transition.begin_transition_from_state(
+            &mut mon.zoom_state,
+            current_level,
+            current_focal,
+        );
+    }
+
+    pub fn zoom_gesture_begin(
+        &mut self,
+        output: &Output,
+        cursor_local: Option<Point<f64, Logical>>,
+        output_size: Option<Size<f64, Logical>>,
+        movement_mode: Option<ZoomMovementMode>,
+    ) {
+        let Some(mon) = self.monitor_for_output_mut(output) else {
+            return;
+        };
+
+        let current_level = mon.zoom_transition.current_level(mon.zoom_state.level);
+        let current_focal = mon
+            .zoom_transition
+            .current_focal(current_level, mon.zoom_state.focal);
+
+        let on_edge_cursor_anchor = if let (Some(cursor), Some(size)) = (cursor_local, output_size)
+        {
+            compute_on_edge_tracking_anchor(
+                movement_mode.as_ref(),
+                cursor,
+                size,
+                current_level,
+                current_focal,
+            )
+        } else {
+            None
+        };
+
+        let gesture = ZoomLevelGesture {
+            tracker: SwipeTracker::new(),
+            start_level: current_level,
+            current_level,
+            current_focal,
+            last_log_scale: None,
+            cursor_pos: cursor_local,
+            output_size,
+            movement_mode,
+            on_edge_cursor_anchor,
+        };
+        mon.zoom_transition.begin_gesture(gesture);
+
+        mon.zoom_transition.mark_transitioning(&mut mon.zoom_state);
+    }
+
+    pub fn zoom_gesture_update(
+        &mut self,
+        output: &Output,
+        scale: f64,
+        sensitivity: f64,
+        timestamp: Duration,
+    ) -> Option<bool> {
+        let mon = self.monitor_for_output_mut(output)?;
+
+        let gesture = mon.zoom_transition.gesture_mut()?;
+
+        let current_log_scale = scale.ln();
+        let log_delta = if let Some(last) = gesture.last_log_scale {
+            let delta = (current_log_scale - last) * sensitivity;
+            gesture.last_log_scale = Some(current_log_scale);
+            delta
+        } else {
+            gesture.last_log_scale = Some(current_log_scale);
+            0.0
+        };
+
+        gesture.tracker.push(log_delta, timestamp);
+
+        let log_pos = gesture.tracker.pos();
+        let raw_level = log_pos_to_zoom_level(gesture.start_level, log_pos);
+        let max_zoom = mon.options.max_zoom;
+        let new_level = clamp_zoom_level_with_rubber_band(raw_level, 1.0, max_zoom);
+
+        if (gesture.current_level - new_level).abs() < 0.0001 {
+            return Some(false);
+        }
+
+        gesture.current_level = new_level;
+
+        gesture.current_focal = gesture.compute_focal_or(new_level, gesture.current_focal);
+
+        Some(true)
+    }
+
+    pub fn zoom_gesture_end(&mut self, output: &Output, cancelled: bool) -> Option<bool> {
+        let mon = self.monitor_for_output_mut(output)?;
+
+        let mut gesture = mon.zoom_transition.take_level_gesture()?;
+
+        if cancelled {
+            let clear_focal_animation = gesture.start_level > 1.0
+                && matches!(
+                    gesture.movement_mode.as_ref(),
+                    Some(ZoomMovementMode::Centered | ZoomMovementMode::OnEdge)
+                );
+            let level_anim = build_zoom_level_animation(
+                &mon.clock,
+                gesture.current_level,
+                gesture.start_level,
+                mon.options.animations.zoom_level_change.0,
+                clear_focal_animation,
+                gesture.cursor_pos,
+                gesture.output_size,
+                gesture.movement_mode.clone(),
+                gesture.on_edge_cursor_anchor,
+            );
+            mon.zoom_transition
+                .cancel_gesture_to_animation(level_anim, clear_focal_animation);
+
+            mon.zoom_transition.begin_transition_from_state(
+                &mut mon.zoom_state,
+                gesture.current_level,
+                gesture.current_focal,
+            );
+            return Some(true);
+        }
+
+        let now = mon.clock.now_unadjusted();
+        gesture.tracker.push(0., now);
+
+        let current_log_pos = gesture.tracker.pos();
+        let raw_target = log_pos_to_zoom_level(gesture.start_level, current_log_pos);
+        let max_zoom = mon.options.max_zoom;
+        let mut target_level = raw_target.clamp(1.0, max_zoom);
+
+        if (target_level - 1.0).abs() < 0.05 {
+            target_level = 1.0;
+        }
+
+        let level_changed = (target_level - gesture.current_level).abs() >= 0.001;
+        let target_focal = gesture.compute_focal_or(target_level, gesture.current_focal);
+        let focal_changed = (gesture.current_focal.x - target_focal.x).abs() > 0.5
+            || (gesture.current_focal.y - target_focal.y).abs() > 0.5;
+
+        let dynamic_focal_tracking = should_use_dynamic_focal_tracking(
+            gesture.movement_mode.as_ref(),
+            false,
+            target_level,
+            level_changed,
+            gesture.cursor_pos.is_some(),
+            gesture.output_size.is_some(),
+        );
+
+        let level_anim = if level_changed {
+            Some(build_zoom_level_animation(
+                &mon.clock,
+                gesture.current_level,
+                target_level,
+                mon.options.animations.zoom_level_change.0,
+                dynamic_focal_tracking,
+                gesture.cursor_pos,
+                gesture.output_size,
+                gesture.movement_mode.clone(),
+                gesture.on_edge_cursor_anchor,
+            ))
+        } else {
+            None
+        };
+
+        let focal_anim = if focal_changed && !dynamic_focal_tracking {
+            Some(ZoomFocalAnimation::new(
+                mon.clock.clone(),
+                gesture.current_focal,
+                target_focal,
+                mon.options.animations.zoom_focal_pan.0,
+            ))
+        } else {
+            None
+        };
+
+        mon.zoom_transition.finalize_gesture_to_animation(
+            level_anim,
+            focal_anim,
+            dynamic_focal_tracking,
+        );
+
+        mon.zoom_transition.begin_transition_from_state(
+            &mut mon.zoom_state,
+            gesture.current_level,
+            gesture.current_focal,
+        );
+
+        Some(true)
+    }
+
     pub fn interactive_move_begin(
         &mut self,
         window_id: W::Id,
@@ -4728,6 +5592,7 @@ impl<W: LayoutElement> Layout<W> {
     ) {
         if self.update_render_elements_time != self.clock.now() {
             error!("clock moved between updating render elements and rendering");
+            return;
         }
 
         let Some(InteractiveMoveState::Moving(move_)) = &self.interactive_move else {
@@ -4932,4 +5797,20 @@ fn compute_overview_zoom(options: &Options, overview_progress: Option<f64>) -> f
     } else {
         1.
     }
+}
+
+/// Compute clamped zoom level with rubber-banding in log-space.
+/// min_level and max_level define the zoom bounds (typically 1.0 and some max like 10.0).
+pub fn clamp_zoom_level_with_rubber_band(level: f64, min_level: f64, max_level: f64) -> f64 {
+    let log_level = level.ln();
+    let log_min = min_level.ln();
+    let log_max = max_level.ln();
+    let clamped_log = ZOOM_GESTURE_RUBBER_BAND.clamp(log_min, log_max, log_level);
+    clamped_log.exp()
+}
+
+/// Convert log-space position to zoom level.
+/// start_level * exp(log_pos) gives the new zoom level.
+pub fn log_pos_to_zoom_level(start_level: f64, log_pos: f64) -> f64 {
+    start_level * log_pos.exp()
 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -47,9 +47,12 @@ use scrolling::{Column, ColumnWidth};
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::utils::RescaleRenderElement;
 use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
+use smithay::desktop::layer_map_for_output;
 use smithay::output::{self, Output};
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::{Logical, Point, Rectangle, Scale, Serial, Size, Transform};
+use smithay::wayland::compositor::with_states;
+use smithay::wayland::shell::wlr_layer::Layer;
 use tile::{Tile, TileRenderElement};
 use workspace::{WorkspaceAddWindowTarget, WorkspaceId};
 
@@ -70,12 +73,12 @@ use crate::rubber_band::RubberBand;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::{
     ensure_min_max_size_maybe_zero, output_matches_name, output_size,
-    round_logical_in_physical_max1, ResizeEdge,
+    round_logical_in_physical_max1, send_scale_transform, ResizeEdge,
 };
 use crate::window::ResolvedWindowRules;
-pub use crate::zoom::OutputZoomState;
 use crate::zoom::{
-    compute_focal_for_cursor, compute_focal_for_on_edge_anchor, compute_on_edge_cursor_anchor,
+    apply_zoom_viewport, calculate_visibility, compute_focal_for_cursor,
+    compute_focal_for_on_edge_anchor, compute_on_edge_cursor_anchor, OutputZoomState,
 };
 
 pub mod closing_window;
@@ -219,7 +222,13 @@ pub trait LayoutElement {
     fn max_size(&self) -> Size<i32, Logical>;
     fn is_wl_surface(&self, wl_surface: &WlSurface) -> bool;
     fn has_ssd(&self) -> bool;
-    fn set_preferred_scale_transform(&self, scale: output::Scale, transform: Transform);
+    fn wl_surface(&self) -> Option<WlSurface>;
+    fn set_preferred_scale_transform(
+        &self,
+        scale: output::Scale,
+        transform: Transform,
+        zoom_state: Option<&OutputZoomState>,
+    );
     fn output_enter(&self, output: &Output);
     fn output_leave(&self, output: &Output);
     fn set_offscreen_data(&self, data: Option<OffscreenData>);
@@ -359,6 +368,9 @@ pub struct Options {
     pub gestures: niri_config::Gestures,
     pub overview: niri_config::Overview,
     pub max_zoom: f64,
+    pub use_fractional_scale: bool,
+    pub max_fractional_scale: f64,
+    pub zoom_scale_sensitivity: f64,
     // Debug flags.
     pub disable_resize_throttling: bool,
     pub disable_transactions: bool,
@@ -620,6 +632,9 @@ impl Options {
             gestures: config.gestures,
             overview: config.overview,
             max_zoom: config.zoom.max_zoom.clamp(1.0, 100.0),
+            use_fractional_scale: config.zoom.use_fractional_scale,
+            max_fractional_scale: config.zoom.max_fractional_scale.clamp(1.0, 20.0),
+            zoom_scale_sensitivity: config.zoom.scale_sensitivity.clamp(0.0, 1.0),
             disable_resize_throttling: config.debug.disable_resize_throttling,
             disable_transactions: config.debug.disable_transactions,
             deactivate_unfocused_windows: config.debug.deactivate_unfocused_windows,
@@ -2990,6 +3005,75 @@ impl<W: LayoutElement> Layout<W> {
         }
     }
 
+    /// Associated function (not `&self`) to avoid borrow conflicts when the caller
+    /// must hold an immutable borrow of `monitors[mon_idx]` before writing results back.
+    fn compute_zoomed_surfaces_for_monitor(
+        monitors: &[Monitor<W>],
+        interactive_move: &Option<InteractiveMoveState<W>>,
+        mon_idx: usize,
+        max_fractional_scale: f64,
+        zoom_scale_sensitivity: f64,
+    ) -> HashMap<WlSurface, f64> {
+        let mon = &monitors[mon_idx];
+        if mon.zoom_state.level <= 1.0 {
+            return HashMap::new();
+        }
+
+        let output = &mon.output;
+        let output_geo = Rectangle::from_size(output_size(output).to_f64());
+        let focal = mon.zoom_state.focal;
+        let level = mon.zoom_state.level;
+        let zoom_rect = apply_zoom_viewport(output_geo, focal, level);
+        let zoom_boost = (level - 1.0) * zoom_scale_sensitivity;
+        let capped_zoom = (1.0 + zoom_boost).min(max_fractional_scale).max(1.0);
+
+        let mut result: HashMap<WlSurface, f64> = HashMap::new();
+
+        let ws_idx = mon.active_workspace_idx();
+        let ws = &mon.workspaces[ws_idx];
+        for (tile, pos, _visible) in ws.tiles_with_render_positions() {
+            let win = tile.window();
+            let window_geo = Rectangle::new(pos, win.size().to_f64());
+            if calculate_visibility(window_geo, zoom_rect) > 0.0 {
+                if let Some(surface) = win.wl_surface() {
+                    result.insert(surface, capped_zoom);
+                }
+            }
+        }
+
+        if let Some(InteractiveMoveState::Moving(move_data)) = interactive_move {
+            if move_data.output == *output {
+                let win = move_data.tile.window();
+                let win_size = win.size().to_f64();
+                let (rx, ry) = move_data.pointer_ratio_within_window;
+                let pos = Point::from((
+                    move_data.pointer_pos_within_output.x - win_size.w * rx,
+                    move_data.pointer_pos_within_output.y - win_size.h * ry,
+                ));
+                if calculate_visibility(Rectangle::new(pos, win_size), zoom_rect) > 0.0 {
+                    if let Some(surface) = win.wl_surface() {
+                        result.insert(surface, capped_zoom);
+                    }
+                }
+            }
+        }
+
+        let layer_map = layer_map_for_output(output);
+        for layer in layer_map.layers() {
+            if layer.layer() == Layer::Background {
+                continue;
+            }
+            if let Some(geo) = layer_map.layer_geometry(layer) {
+                let layer_rect = Rectangle::new(geo.loc.to_f64(), geo.size.to_f64());
+                if calculate_visibility(layer_rect, zoom_rect) > 0.0 {
+                    result.insert(layer.wl_surface().clone(), capped_zoom);
+                }
+            }
+        }
+
+        result
+    }
+
     pub fn advance_animations(&mut self) {
         let _span = tracy_client::span!("Layout::advance_animations");
 
@@ -3121,7 +3205,7 @@ impl<W: LayoutElement> Layout<W> {
 
         match &mut self.monitor_set {
             MonitorSet::Normal { monitors, .. } => {
-                for mon in monitors {
+                for mon in monitors.iter_mut() {
                     mon.set_overview_progress(self.overview_progress.as_ref());
                     mon.advance_animations();
 
@@ -3129,6 +3213,59 @@ impl<W: LayoutElement> Layout<W> {
                     mon.zoom_transition.apply_to_state(&mut mon.zoom_state);
 
                     mon.zoom_transition.clear_if_done();
+                }
+
+                if self.options.use_fractional_scale {
+                    for mon_idx in 0..monitors.len() {
+                        let zoom_level = monitors[mon_idx].zoom_state.level;
+                        if zoom_level <= 1.0 {
+                            if !monitors[mon_idx].zoom_state.zoomed_surfaces.is_empty() {
+                                let scale = monitors[mon_idx].output.current_scale();
+                                let transform = monitors[mon_idx].output.current_transform();
+                                let surfaces: Vec<WlSurface> = monitors[mon_idx]
+                                    .zoom_state
+                                    .zoomed_surfaces
+                                    .keys()
+                                    .cloned()
+                                    .collect();
+                                for surface in &surfaces {
+                                    with_states(surface, |data| {
+                                        send_scale_transform(surface, data, scale, transform, None);
+                                    });
+                                }
+                                monitors[mon_idx].zoom_state.zoomed_surfaces.clear();
+                                monitors[mon_idx].zoom_state.last_scale_update_level = None;
+                            }
+                            continue;
+                        }
+
+                        let new_surfaces = Self::compute_zoomed_surfaces_for_monitor(
+                            monitors,
+                            &self.interactive_move,
+                            mon_idx,
+                            self.options.max_fractional_scale,
+                            self.options.zoom_scale_sensitivity,
+                        );
+                        monitors[mon_idx].zoom_state.zoomed_surfaces = new_surfaces;
+                        monitors[mon_idx].zoom_state.last_scale_update_level = Some(zoom_level);
+
+                        let scale = monitors[mon_idx].output.current_scale();
+                        let transform = monitors[mon_idx].output.current_transform();
+                        let zoom_state_snap = monitors[mon_idx].zoom_state.clone();
+                        let surfaces: Vec<WlSurface> =
+                            zoom_state_snap.zoomed_surfaces.keys().cloned().collect();
+                        for surface in &surfaces {
+                            with_states(surface, |data| {
+                                send_scale_transform(
+                                    surface,
+                                    data,
+                                    scale,
+                                    transform,
+                                    Some(&zoom_state_snap),
+                                );
+                            });
+                        }
+                    }
                 }
             }
             MonitorSet::NoOutputs { workspaces, .. } => {
@@ -3214,9 +3351,28 @@ impl<W: LayoutElement> Layout<W> {
             .is_some_and(|z| z.is_active())
     }
 
+    /// Effective fractional-scale multiplier used when capturing screenshots for `output`.
+    /// Matches the scale sent to clients via `wp_fractional_scale_v1`; 1.0 when not applicable.
+    pub fn effective_zoom_for_output(&self, output: &Output) -> f64 {
+        if !self.options.use_fractional_scale {
+            return 1.0;
+        }
+        let Some(zoom_state) = self.zoom_state_for_output(output) else {
+            return 1.0;
+        };
+        if !zoom_state.is_active() {
+            return 1.0;
+        }
+        let level = zoom_state.level;
+        let zoom_boost = (level - 1.0) * self.options.zoom_scale_sensitivity;
+        (1.0 + zoom_boost)
+            .min(self.options.max_fractional_scale)
+            .max(1.0)
+    }
+
     pub fn zoom_locked_for_output(&self, output: &Output) -> bool {
         self.zoom_state_for_output(output)
-            .map_or(false, |z| z.locked)
+            .is_some_and(|z| z.locked)
     }
 
     pub fn has_zoom_for_output(&self, output: &Output) -> bool {
@@ -4780,6 +4936,7 @@ impl<W: LayoutElement> Layout<W> {
                 tile.window().set_preferred_scale_transform(
                     output.current_scale(),
                     output.current_transform(),
+                    None,
                 );
 
                 let view_size = output_size(&output);
@@ -4855,6 +5012,7 @@ impl<W: LayoutElement> Layout<W> {
                     move_.tile.window().set_preferred_scale_transform(
                         output.current_scale(),
                         output.current_transform(),
+                        None,
                     );
                     move_.output = output.clone();
                     self.focus_output(&output);

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -26,7 +26,7 @@ use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shadow::ShadowRenderElement;
 use crate::render_helpers::solid_color::SolidColorRenderElement;
-use crate::render_helpers::RenderTarget;
+use crate::render_helpers::RenderCtx;
 use crate::rubber_band::RubberBand;
 use crate::utils::transaction::Transaction;
 use crate::utils::{
@@ -1680,8 +1680,7 @@ impl<W: LayoutElement> Monitor<W> {
 
     pub fn render_workspaces<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        mut ctx: RenderCtx<R>,
         focus_ring: bool,
         push: &mut dyn FnMut(MonitorRenderElement<R>),
     ) {
@@ -1745,16 +1744,16 @@ impl<W: LayoutElement> Monitor<W> {
                 }};
             }
 
-            ws.render_floating(renderer, target, focus_ring, push!());
+            ws.render_floating(ctx.r(), focus_ring, push!());
 
             if let Some(loc) = insert_hint_render_loc {
                 if loc.workspace == InsertWorkspace::Existing(ws.id()) {
                     self.insert_hint_element
-                        .render(renderer, loc.location, push!());
+                        .render(ctx.renderer, loc.location, push!());
                 }
             }
 
-            ws.render_scrolling(renderer, target, focus_ring, push!());
+            ws.render_scrolling(ctx.r(), focus_ring, push!());
         }
     }
 

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -17,7 +17,9 @@ use super::workspace::{
     compute_working_area, OutputId, Workspace, WorkspaceAddWindowTarget, WorkspaceId,
     WorkspaceRenderElement,
 };
-use super::{compute_overview_zoom, ActivateWindow, HitType, LayoutElement, Options};
+use super::{
+    compute_overview_zoom, ActivateWindow, HitType, LayoutElement, Options, ZoomTransition,
+};
 use crate::animation::{Animation, Clock};
 use crate::input::swipe_tracker::SwipeTracker;
 use crate::niri_render_elements;
@@ -30,6 +32,7 @@ use crate::utils::transaction::Transaction;
 use crate::utils::{
     output_size, round_logical_in_physical, round_logical_in_physical_max1, ResizeEdge,
 };
+use crate::zoom::OutputZoomState;
 
 /// Amount of touchpad movement to scroll the height of one workspace.
 const WORKSPACE_GESTURE_MOVEMENT: f64 = 300.;
@@ -87,6 +90,10 @@ pub struct Monitor<W: LayoutElement> {
     pub(super) options: Rc<Options>,
     /// Layout config overrides for this monitor.
     layout_config: Option<niri_config::LayoutPart>,
+    /// In-progress zoom transition state for this monitor.
+    pub(super) zoom_transition: ZoomTransition,
+    /// Per-output zoom snapshot (level, focal, locked, transitioning).
+    pub(super) zoom_state: OutputZoomState,
 }
 
 #[derive(Debug)]
@@ -326,6 +333,8 @@ impl<W: LayoutElement> Monitor<W> {
         let ws = Workspace::new(output.clone(), clock.clone(), options.clone());
         workspaces.push(ws);
 
+        let zoom_state = OutputZoomState::new_for_output(&output);
+
         Self {
             output_name: output.name(),
             output,
@@ -345,6 +354,8 @@ impl<W: LayoutElement> Monitor<W> {
             base_options,
             options,
             layout_config,
+            zoom_transition: ZoomTransition::default(),
+            zoom_state,
         }
     }
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -21,7 +21,7 @@ use crate::input::swipe_tracker::SwipeTracker;
 use crate::layout::SizingMode;
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
-use crate::render_helpers::RenderTarget;
+use crate::render_helpers::RenderCtx;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::ResizeEdge;
 use crate::window::ResolvedWindowRules;
@@ -2899,8 +2899,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
     pub fn render<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        mut ctx: RenderCtx<R>,
         focus_ring: bool,
         push: &mut dyn FnMut(ScrollingSpaceRenderElement<R>),
     ) {
@@ -2909,7 +2908,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         // Draw the closing windows on top of the other windows.
         let view_rect = Rectangle::new(Point::from((self.view_pos(), 0.)), self.view_size);
         for closing in self.closing_windows.iter().rev() {
-            let elem = closing.render(renderer.as_gles_renderer(), view_rect, scale, target);
+            let elem = closing.render(ctx.as_gles(), view_rect, scale);
             push(elem.into());
         }
 
@@ -2930,7 +2929,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 let pos = view_off + col_off + col_render_off;
                 let pos = pos.to_physical_precise_round(scale).to_logical(scale);
                 col.tab_indicator
-                    .render(renderer, pos, &mut |elem| push(elem.into()));
+                    .render(ctx.renderer, pos, &mut |elem| push(elem.into()));
             }
 
             for (tile, tile_off, visible) in col.tiles_in_render_order() {
@@ -2955,9 +2954,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     continue;
                 }
 
-                tile.render(renderer, tile_pos, focus_ring, target, &mut |elem| {
-                    push(elem.into())
-                });
+                tile.render(ctx.r(), tile_pos, focus_ring, &mut |elem| push(elem.into()));
             }
         }
     }

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -15,6 +15,7 @@ use super::*;
 
 mod animations;
 mod fullscreen;
+mod zoom;
 
 impl<W: LayoutElement> Default for Layout<W> {
     fn default() -> Self {

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -198,7 +198,17 @@ impl LayoutElement for TestWindow {
         false
     }
 
-    fn set_preferred_scale_transform(&self, _scale: output::Scale, _transform: Transform) {}
+    fn wl_surface(&self) -> Option<WlSurface> {
+        None
+    }
+
+    fn set_preferred_scale_transform(
+        &self,
+        _scale: output::Scale,
+        _transform: Transform,
+        _zoom_state: Option<&OutputZoomState>,
+    ) {
+    }
 
     fn has_ssd(&self) -> bool {
         false

--- a/src/layout/tests/zoom.rs
+++ b/src/layout/tests/zoom.rs
@@ -1,0 +1,103 @@
+//! Tests for zoom animation state machine.
+
+use std::time::Duration;
+
+use niri_config::animations::{Kind, SpringParams};
+use smithay::utils::Point;
+
+use crate::animation::Clock;
+use crate::layout::{ZoomFocalAnimation, ZoomLevelAnimation, ZoomLevelProgress};
+use crate::zoom::OutputZoomState;
+
+fn test_animation_config() -> niri_config::Animation {
+    niri_config::Animation {
+        off: false,
+        kind: Kind::Spring(SpringParams {
+            damping_ratio: 1.0,
+            stiffness: 1000,
+            epsilon: 0.0001,
+        }),
+    }
+}
+
+#[test]
+fn zoom_level_animation_value() {
+    let clock = Clock::with_time(Duration::ZERO);
+    let anim = ZoomLevelAnimation::new(clock.clone(), 1.0, 3.0, test_animation_config());
+
+    // Animation just started, should be near 1.0
+    let level = anim.value();
+    assert!(
+        (1.0..1.5).contains(&level),
+        "level should be near start: {}",
+        level
+    );
+}
+
+#[test]
+fn zoom_focal_animation_value() {
+    let clock = Clock::with_time(Duration::ZERO);
+    let anim = ZoomFocalAnimation::new(
+        clock.clone(),
+        Point::from((0.0, 0.0)),
+        Point::from((50.0, 100.0)),
+        test_animation_config(),
+    );
+
+    // Animation just started, should be near start
+    let focal = anim.value();
+    assert!(focal.x < 10.0, "focal x should be near start: {}", focal.x);
+    assert!(focal.y < 20.0, "focal y should be near start: {}", focal.y);
+}
+
+#[test]
+fn zoom_level_progress_animation_variant() {
+    let clock = Clock::with_time(Duration::ZERO);
+    let level_anim = ZoomLevelAnimation::new(clock.clone(), 1.0, 2.0, test_animation_config());
+    let progress = ZoomLevelProgress::Animation(level_anim);
+
+    assert!(progress.is_animation());
+    assert!(!progress.is_gesture());
+    assert!(!progress.is_done());
+
+    let level = progress.level();
+    assert!(
+        (1.0..1.5).contains(&level),
+        "level should be near start: {}",
+        level
+    );
+}
+
+#[test]
+fn zoom_level_progress_is_done() {
+    let clock = Clock::with_time(Duration::ZERO);
+    let level_anim = ZoomLevelAnimation::new(clock.clone(), 1.0, 2.0, test_animation_config());
+    let progress = ZoomLevelProgress::Animation(level_anim);
+
+    // Should not be done at start
+    assert!(!progress.is_done());
+}
+
+#[test]
+fn output_zoom_state_default() {
+    let state = OutputZoomState::default();
+    assert_eq!(state.level, 1.0);
+    assert_eq!(state.focal.x, 0.0);
+    assert_eq!(state.focal.y, 0.0);
+    assert!(!state.locked);
+    assert!(!state.transitioning);
+}
+
+#[test]
+fn zoom_focal_animation_is_done() {
+    let clock = Clock::with_time(Duration::ZERO);
+    let anim = ZoomFocalAnimation::new(
+        clock.clone(),
+        Point::from((0.0, 0.0)),
+        Point::from((100.0, 100.0)),
+        test_animation_config(),
+    );
+
+    // Should not be done at start
+    assert!(!anim.is_done());
+}

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -27,7 +27,7 @@ use crate::render_helpers::resize::ResizeRenderElement;
 use crate::render_helpers::shadow::ShadowRenderElement;
 use crate::render_helpers::snapshot::RenderSnapshot;
 use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
-use crate::render_helpers::RenderTarget;
+use crate::render_helpers::{RenderCtx, RenderTarget};
 use crate::utils::transaction::Transaction;
 use crate::utils::{
     baba_is_float_offset, round_logical_in_physical, round_logical_in_physical_max1,
@@ -403,7 +403,6 @@ impl<W: LayoutElement> Tile<W> {
             .unwrap_or_default()
             .fit_to(window_size.w as f32, window_size.h as f32);
         self.rounded_corner_damage.set_corner_radius(radius);
-        self.rounded_corner_damage.set_size(window_size);
     }
 
     pub fn advance_animations(&mut self) {
@@ -1009,10 +1008,9 @@ impl<W: LayoutElement> Tile<W> {
 
     fn render_inner<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        mut ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
         focus_ring: bool,
-        target: RenderTarget,
         push: &mut dyn FnMut(TileRenderElement<R>),
     ) {
         let _span = tracy_client::span!("Tile::render_inner");
@@ -1058,48 +1056,43 @@ impl<W: LayoutElement> Tile<W> {
             .scaled_by(1. - expanded_progress as f32);
 
         // Popups go on top, whether it's resize or not.
-        self.window.render_popups(
-            renderer,
-            window_render_loc,
-            scale,
-            win_alpha,
-            target,
-            &mut |elem| push(elem.into()),
-        );
+        self.window
+            .render_popups(ctx.r(), window_render_loc, scale, win_alpha, &mut |elem| {
+                push(elem.into())
+            });
 
         // If we're resizing, try to render a shader, or a fallback.
         let mut pushed_resize = false;
         if let Some(resize) = &self.resize_animation {
-            if ResizeRenderElement::has_shader(renderer) {
-                let gles_renderer = renderer.as_gles_renderer();
+            if ResizeRenderElement::has_shader(ctx.renderer) {
+                let mut ctx = ctx.as_gles();
 
-                if let Some(texture_from) = resize.snapshot.texture(gles_renderer, scale, target) {
+                if let Some(texture_from) = resize.snapshot.texture(ctx.r(), scale) {
                     let mut window_elements = Vec::new();
                     self.window.render_normal(
-                        gles_renderer,
+                        ctx.r(),
                         Point::from((0., 0.)),
                         scale,
                         1.,
-                        target,
                         &mut |elem| window_elements.push(elem),
                     );
 
                     let current = resize
                         .offscreen
-                        .render(gles_renderer, scale, &window_elements)
+                        .render(ctx.renderer, scale, &window_elements)
                         .map_err(|err| warn!("error rendering window to texture: {err:?}"))
                         .ok();
 
                     // Clip blocked-out resizes unconditionally because they use solid color render
                     // elements.
-                    let clip_to_geometry = if target
-                        .should_block_out(resize.snapshot.block_out_from)
-                        && target.should_block_out(rules.block_out_from)
-                    {
-                        true
-                    } else {
-                        clip_to_geometry
-                    };
+                    let clip_to_geometry =
+                        if ctx.target.should_block_out(resize.snapshot.block_out_from)
+                            && ctx.target.should_block_out(rules.block_out_from)
+                        {
+                            true
+                        } else {
+                            clip_to_geometry
+                        };
 
                     if let Some((elem_current, _sync_point, mut data)) = current {
                         let texture_current = elem_current.texture().clone();
@@ -1148,12 +1141,12 @@ impl<W: LayoutElement> Tile<W> {
         }
 
         // If we're not resizing, render the window itself.
-        let has_border_shader = BorderRenderElement::has_shader(renderer);
+        let has_border_shader = BorderRenderElement::has_shader(ctx.renderer);
         if !pushed_resize {
             let geo = Rectangle::new(window_render_loc, window_size);
             let radius = radius.fit_to(window_size.w as f32, window_size.h as f32);
 
-            let clip_shader = ClippedSurfaceRenderElement::shader(renderer).cloned();
+            let clip_shader = ClippedSurfaceRenderElement::shader(ctx.renderer).cloned();
             let clip = |elem| match elem {
                 LayoutElementRenderElement::Wayland(elem) => {
                     // If we should clip to geometry, render a clipped window.
@@ -1206,18 +1199,14 @@ impl<W: LayoutElement> Tile<W> {
             };
 
             if clip_to_geometry && clip_shader.is_some() {
-                let damage = self.rounded_corner_damage.element();
-                push(damage.with_location(window_render_loc).into());
+                let damage = self.rounded_corner_damage.render(geo);
+                push(damage.into());
             }
 
-            self.window.render_normal(
-                renderer,
-                window_render_loc,
-                scale,
-                win_alpha,
-                target,
-                &mut |elem| push(clip(elem)),
-            );
+            self.window
+                .render_normal(ctx.r(), window_render_loc, scale, win_alpha, &mut |elem| {
+                    push(clip(elem))
+                });
         }
 
         if fullscreen_progress > 0. {
@@ -1264,7 +1253,7 @@ impl<W: LayoutElement> Tile<W> {
 
         if let Some(width) = self.visual_border_width() {
             self.border.render(
-                renderer,
+                ctx.renderer,
                 location + Point::from((width, width)),
                 &mut |elem| push(elem.into()),
             );
@@ -1276,21 +1265,20 @@ impl<W: LayoutElement> Tile<W> {
         // a bit weird).
         if focus_ring && expanded_progress < 1. {
             self.focus_ring
-                .render(renderer, location, &mut |elem| push(elem.into()));
+                .render(ctx.renderer, location, &mut |elem| push(elem.into()));
         }
 
         if expanded_progress < 1. {
             self.shadow
-                .render(renderer, location, &mut |elem| push(elem.into()));
+                .render(ctx.renderer, location, &mut |elem| push(elem.into()));
         }
     }
 
     pub fn render<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        mut ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
         focus_ring: bool,
-        target: RenderTarget,
         push: &mut dyn FnMut(TileRenderElement<R>),
     ) {
         let _span = tracy_client::span!("Tile::render");
@@ -1306,17 +1294,13 @@ impl<W: LayoutElement> Tile<W> {
         self.window().set_offscreen_data(None);
 
         if let Some(open) = &self.open_animation {
-            let renderer = renderer.as_gles_renderer();
+            let mut ctx = ctx.as_gles();
             let mut elements = Vec::new();
-            self.render_inner(
-                renderer,
-                Point::from((0., 0.)),
-                focus_ring,
-                target,
-                &mut |elem| elements.push(elem),
-            );
+            self.render_inner(ctx.r(), Point::from((0., 0.)), focus_ring, &mut |elem| {
+                elements.push(elem)
+            });
             match open.render(
-                renderer,
+                ctx.renderer,
                 &elements,
                 self.animated_tile_size(),
                 location,
@@ -1333,16 +1317,12 @@ impl<W: LayoutElement> Tile<W> {
                 }
             }
         } else if let Some(alpha) = &self.alpha_animation {
-            let renderer = renderer.as_gles_renderer();
+            let mut ctx = ctx.as_gles();
             let mut elements = Vec::new();
-            self.render_inner(
-                renderer,
-                Point::from((0., 0.)),
-                focus_ring,
-                target,
-                &mut |elem| elements.push(elem),
-            );
-            match alpha.offscreen.render(renderer, scale, &elements) {
+            self.render_inner(ctx.r(), Point::from((0., 0.)), focus_ring, &mut |elem| {
+                elements.push(elem)
+            });
+            match alpha.offscreen.render(ctx.renderer, scale, &elements) {
                 Ok((elem, _sync, data)) => {
                     let offset = elem.offset();
                     let elem = elem.with_alpha(tile_alpha).with_offset(location + offset);
@@ -1358,9 +1338,7 @@ impl<W: LayoutElement> Tile<W> {
         }
 
         if !pushed {
-            self.render_inner(renderer, location, focus_ring, target, &mut |elem| {
-                push(elem)
-            });
+            self.render_inner(ctx, location, focus_ring, &mut |elem| push(elem));
         }
     }
 
@@ -1377,20 +1355,24 @@ impl<W: LayoutElement> Tile<W> {
 
         let mut contents = Vec::new();
         self.render(
-            renderer,
+            RenderCtx {
+                renderer,
+                target: RenderTarget::Output,
+            },
             Point::from((0., 0.)),
             false,
-            RenderTarget::Output,
             &mut |elem| contents.push(elem),
         );
 
         // A bit of a hack to render blocked out as for screencast, but I think it's fine here.
         let mut blocked_out_contents = Vec::new();
         self.render(
-            renderer,
+            RenderCtx {
+                renderer,
+                target: RenderTarget::Screencast,
+            },
             Point::from((0., 0.)),
             false,
-            RenderTarget::Screencast,
             &mut |elem| blocked_out_contents.push(elem),
         );
 

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -32,7 +32,7 @@ use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shadow::ShadowRenderElement;
 use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderElement};
-use crate::render_helpers::RenderTarget;
+use crate::render_helpers::RenderCtx;
 use crate::utils::id::IdCounter;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::{
@@ -1626,22 +1626,18 @@ impl<W: LayoutElement> Workspace<W> {
 
     pub fn render_scrolling<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        ctx: RenderCtx<R>,
         focus_ring: bool,
         push: &mut dyn FnMut(WorkspaceRenderElement<R>),
     ) {
         let scrolling_focus_ring = focus_ring && !self.floating_is_active();
         self.scrolling
-            .render(renderer, target, scrolling_focus_ring, &mut |elem| {
-                push(elem.into())
-            });
+            .render(ctx, scrolling_focus_ring, &mut |elem| push(elem.into()));
     }
 
     pub fn render_floating<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        ctx: RenderCtx<R>,
         focus_ring: bool,
         push: &mut dyn FnMut(WorkspaceRenderElement<R>),
     ) {
@@ -1651,13 +1647,10 @@ impl<W: LayoutElement> Workspace<W> {
 
         let view_rect = Rectangle::from_size(self.view_size);
         let floating_focus_ring = focus_ring && self.floating_is_active();
-        self.floating.render(
-            renderer,
-            view_rect,
-            target,
-            floating_focus_ring,
-            &mut |elem| push(elem.into()),
-        );
+        self.floating
+            .render(ctx, view_rect, floating_focus_ring, &mut |elem| {
+                push(elem.into())
+            });
     }
 
     pub fn render_shadow<R: NiriRenderer>(

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -516,7 +516,7 @@ impl<W: LayoutElement> Workspace<W> {
 
     fn enter_output_for_window(&self, window: &W) {
         if let Some(output) = &self.output {
-            window.set_preferred_scale_transform(self.scale, self.transform);
+            window.set_preferred_scale_transform(self.scale, self.transform, None);
             window.output_enter(output);
         }
     }
@@ -578,7 +578,7 @@ impl<W: LayoutElement> Workspace<W> {
 
         if scale_transform_changed {
             for window in self.windows() {
-                window.set_preferred_scale_transform(self.scale, self.transform);
+                window.set_preferred_scale_transform(self.scale, self.transform, None);
             }
         }
     }
@@ -853,7 +853,7 @@ impl<W: LayoutElement> Workspace<W> {
         rules: &ResolvedWindowRules,
     ) {
         window.with_surfaces(|surface, data| {
-            send_scale_transform(surface, data, self.scale, self.transform);
+            send_scale_transform(surface, data, self.scale, self.transform, None);
         });
 
         let toplevel = window.toplevel().expect("no x11 support");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod screencasting;
 pub mod ui;
 pub mod utils;
 pub mod window;
+pub mod zoom;
 
 #[cfg(test)]
 mod tests;

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -165,7 +165,10 @@ use crate::ui::exit_confirm_dialog::{ExitConfirmDialog, ExitConfirmDialogRenderE
 use crate::ui::hotkey_overlay::HotkeyOverlay;
 use crate::ui::mru::{MruCloseRequest, WindowMruUi, WindowMruUiRenderElement};
 use crate::ui::screen_transition::{self, ScreenTransition};
-use crate::ui::screenshot_ui::{OutputScreenshot, ScreenshotUi, ScreenshotUiRenderElement};
+use crate::ui::screenshot_ui::{
+    HelpPanelElement, OutputScreenshot, ScreenshotPointerElement, ScreenshotUi,
+    ScreenshotUiRenderElement,
+};
 use crate::utils::scale::{closest_representable_scale, guess_monitor_scale};
 use crate::utils::spawning::{CHILD_DISPLAY, CHILD_ENV};
 use crate::utils::vblank_throttle::VBlankThrottle;
@@ -178,6 +181,10 @@ use crate::utils::{
 };
 use crate::window::mapped::MappedId;
 use crate::window::{InitialConfigureState, Mapped, ResolvedWindowRules, Unmapped, WindowRef};
+use crate::zoom::{
+    compute_zoom_base_focal_update, zoom_display_cursor_logical, zoom_subpixel_correction,
+    zoom_wrap, ZoomWrapper, ZoomedRenderElements,
+};
 
 const CLEAR_COLOR_LOCKED: [f32; 4] = [0.3, 0.1, 0.1, 1.];
 
@@ -860,7 +867,7 @@ impl State {
             self,
             under.surface,
             &MotionEvent {
-                location,
+                location: location,
                 serial: SERIAL_COUNTER.next_serial(),
                 time: get_monotonic_time().as_millis() as u32,
             },
@@ -1079,7 +1086,7 @@ impl State {
             self,
             under.surface,
             &MotionEvent {
-                location,
+                location: location,
                 serial: SERIAL_COUNTER.next_serial(),
                 time: get_monotonic_time().as_millis() as u32,
             },
@@ -1468,6 +1475,9 @@ impl State {
             self.niri.cursor_texture_cache.clear();
         }
 
+        // We need to check zoom movement mode change, but defer the action until after drop.
+        let zoom_movement_mode_changed = config.zoom.movement_mode != old_config.zoom.movement_mode;
+
         // We need &mut self to reload the xkb config, so just store it here.
         if config.input.keyboard.xkb != old_config.input.keyboard.xkb {
             reload_xkb = Some(config.input.keyboard.xkb.clone());
@@ -1596,6 +1606,40 @@ impl State {
 
         // Release the borrow.
         drop(old_config);
+
+        if zoom_movement_mode_changed {
+            let global_pointer_pos = self.niri.seat.get_pointer().unwrap().current_location();
+            if let Some((output, _)) = self.niri.output_under(global_pointer_pos) {
+                let output = output.clone();
+                let output_geo = self
+                    .niri
+                    .global_space
+                    .output_geometry(&output)
+                    .unwrap()
+                    .to_f64();
+                let cursor_local = global_pointer_pos - output_geo.loc;
+                let movement_mode = self.niri.config.borrow().zoom.movement_mode.clone();
+                let (locked, current_level) = (
+                    self.niri.layout.zoom_locked_for_output(&output),
+                    self.niri.layout.zoom_level_for_output(&output),
+                );
+
+                self.niri.layout.set_zoom_level(
+                    &output,
+                    current_level,
+                    cursor_local,
+                    &movement_mode,
+                    locked,
+                );
+
+                // Update the focal point so that if the user changes the movement mode again while
+                // zoomed, it will be correct.
+                self.niri
+                    .update_zoom_base_focal(&output, global_pointer_pos, None);
+
+                self.niri.queue_redraw(&output);
+            }
+        }
 
         // Now with a &mut self we can reload the xkb config.
         if let Some(mut xkb) = reload_xkb {
@@ -2004,8 +2048,25 @@ impl State {
         };
         let path = path.take();
 
+        let (zoom_active, zoom_level, zoom_focal) = self
+            .niri
+            .screenshot_ui
+            .selection_output()
+            .map(|output| {
+                (
+                    self.niri.layout.zoom_is_active_for_output(output),
+                    self.niri.layout.zoom_level_for_output(output),
+                    self.niri.layout.zoom_focal_for_output(output),
+                )
+            })
+            .unwrap_or((false, 1.0, Point::default()));
+
         self.backend.with_primary_renderer(|renderer| {
-            match self.niri.screenshot_ui.capture(renderer) {
+            match self
+                .niri
+                .screenshot_ui
+                .capture(renderer, zoom_active, zoom_level, zoom_focal)
+            {
                 Ok((size, pixels)) => {
                     if let Err(err) = self.niri.save_screenshot(size, pixels, write_to_disk, path) {
                         warn!("error saving screenshot: {err:?}");
@@ -2975,6 +3036,112 @@ impl Niri {
         Some((output, pos_within_output))
     }
 
+    /// Returns the effective cursor position for hit-testing, accounting for zoom.
+    pub fn effective_cursor_pos(&self, pos: Point<f64, Logical>) -> Point<f64, Logical> {
+        let Some((output, _pos_within_output)) = self.output_under(pos) else {
+            return pos;
+        };
+
+        if !self.layout.zoom_is_active_for_output(output) {
+            return pos;
+        }
+
+        let output_pos = self
+            .global_space
+            .output_geometry(output)
+            .unwrap()
+            .loc
+            .to_f64();
+
+        let pointer_local = pos - output_pos;
+        let mode_size = output.current_mode().map(|m| m.size).unwrap_or_default();
+        let scale = output.current_scale().fractional_scale();
+        let output_size = mode_size.to_f64().to_logical(scale);
+        zoom_display_cursor_logical(
+            pointer_local,
+            output_size,
+            self.layout.zoom_level_for_output(output),
+            self.layout.zoom_focal_for_output(output),
+        ) + output_pos
+    }
+
+    /// Update the zoom focal point for the given output based on cursor position.
+    ///
+    /// `old_pos_global` is the previous cursor pos (for OnEdge movement mode).
+    /// We pass `None` for absolute events or zoom changes, which will use
+    /// Centered/CursorFollow behavior.
+    pub fn update_zoom_base_focal(
+        &mut self,
+        output: &Output,
+        new_pos_global: Point<f64, Logical>,
+        old_pos_global: Option<Point<f64, Logical>>,
+    ) {
+        // Read zoom state fields into locals to avoid holding a borrow on self.layout
+        // while we need to call mut methods on it below.
+        let Some(zoom_state) = self.layout.zoom_state_for_output(output) else {
+            return;
+        };
+        let level = zoom_state.level;
+        let focal = zoom_state.focal;
+        let transitioning = zoom_state.transitioning;
+        let locked = zoom_state.locked;
+
+        let Some(output_geometry) = self.global_space.output_geometry(output) else {
+            return;
+        };
+        let output_geometry = output_geometry.to_f64();
+
+        let cursor_position = new_pos_global - output_geometry.loc;
+
+        tracing::trace!(
+            zoom_level = level,
+            transitioning = transitioning,
+            locked = locked,
+            cursor_x = cursor_position.x,
+            cursor_y = cursor_position.y,
+            "update_zoom_base_focal: begin"
+        );
+
+        if transitioning {
+            tracing::trace!("update_zoom_base_focal: transition-owned focal path");
+            self.layout.set_zoom_cursor_pos(output, cursor_position);
+            return;
+        }
+
+        if locked {
+            tracing::trace!("update_zoom_base_focal: locked path");
+            return;
+        }
+
+        let movement = &self.config.borrow().zoom.movement_mode;
+
+        let new_focal = compute_zoom_base_focal_update(
+            output,
+            output_geometry,
+            cursor_position,
+            old_pos_global,
+            focal,
+            level,
+            movement,
+        );
+
+        if let Some(new_focal) = new_focal {
+            if let Some(zoom_state) = self.layout.zoom_state_for_output_mut(output) {
+                zoom_state.focal = new_focal;
+            }
+        }
+
+        if let Some(zoom_state) = self.layout.zoom_state_for_output(output) {
+            tracing::trace!(
+                focal_x = zoom_state.focal.x,
+                focal_y = zoom_state.focal.y,
+                cursor_x = cursor_position.x,
+                cursor_y = cursor_position.y,
+                "update_zoom_base_focal: updated"
+            );
+        }
+    }
+
     fn is_inside_hot_corner(&self, output: &Output, pos: Point<f64, Logical>) -> bool {
         let config = self.config.borrow();
         let hot_corners = output
@@ -3165,6 +3332,8 @@ impl Niri {
             return None;
         }
 
+        let pos = self.effective_cursor_pos(pos);
+
         let (output, pos_within_output) = self.output_under(pos)?;
 
         if self.is_sticky_obscured_under(output, pos_within_output) {
@@ -3203,6 +3372,8 @@ impl Niri {
     /// This function does not take pointer or touch grabs into account.
     pub fn contents_under(&self, pos: Point<f64, Logical>) -> PointContents {
         let mut rv = PointContents::default();
+
+        let pos = self.effective_cursor_pos(pos);
 
         let Some((output, pos_within_output)) = self.output_under(pos) else {
             return rv;
@@ -3616,6 +3787,18 @@ impl Niri {
             .unwrap_or_else(|| self.seat.get_pointer().unwrap().current_location());
         let pointer_pos = pointer_pos - output_pos.to_f64();
 
+        let output_size = output_size(output).to_f64();
+        let output_rect: Rectangle<f64, Logical> = Rectangle::from_size(output_size);
+        let pointer_pos = if output_rect.contains(pointer_pos) {
+            zoom_display_cursor_logical(
+                pointer_pos,
+                output_size,
+                self.layout.zoom_level_for_output(output),
+                self.layout.zoom_focal_for_output(output),
+            )
+        } else {
+            pointer_pos
+        };
         // Get the render cursor to draw.
         let cursor_scale = output_scale.integer_scale();
         let render_cursor = self.cursor_manager.get_render_cursor(cursor_scale);
@@ -3645,6 +3828,7 @@ impl Niri {
             } => {
                 let (idx, frame) = cursor.frame(self.start_time.elapsed().as_millis() as u32);
                 let hotspot = XCursor::hotspot(frame).to_logical(scale);
+
                 let pointer_pos =
                     (pointer_pos - hotspot.to_f64()).to_physical_precise_round(output_scale);
 
@@ -4019,6 +4203,91 @@ impl Niri {
         }
     }
 
+    pub fn zoomed_element<R: NiriRenderer>(
+        &self,
+        element: OutputRenderElements<R>,
+        output: &Output,
+    ) -> OutputRenderElements<R> {
+        let is_wayland_pointer = matches!(
+            &element,
+            OutputRenderElements::Pointer(PointerRenderElements::Wayland(_))
+        );
+
+        // Apply zoom to the render elements when needed.
+        if !self.layout.has_zoom_for_output(output) {
+            return element;
+        }
+
+        let output_scale = Scale::from(output.current_scale().fractional_scale());
+
+        let (zoom_level, zoom_focal) = (
+            self.layout.zoom_level_for_output(output),
+            self.layout.zoom_focal_for_output(output),
+        );
+
+        let output_size_phys = output_size(output).to_physical_precise_round(output_scale);
+
+        let scale_with_zoom = self.config.borrow().cursor.scale_with_zoom;
+
+        // Compute cursor display position and hotspot on-demand for jitter-free
+        // pointer zoom. The f64 precision avoids i32 roundtrip errors that get
+        // amplified at high zoom levels. Only needed when actually zoomed.
+        let (cursor_logical_pos, cursor_hotspot) = if zoom_level > 1.0 {
+            let output_pos = self.global_space.output_geometry(output).unwrap().loc;
+            let pointer_pos = self
+                .tablet_cursor_location
+                .unwrap_or_else(|| self.seat.get_pointer().unwrap().current_location());
+            let pointer_local = pointer_pos - output_pos.to_f64();
+
+            let output_sz = output_size(output).to_f64();
+            let output_rect: Rectangle<f64, Logical> = Rectangle::from_size(output_sz);
+
+            if output_rect.contains(pointer_local) {
+                let display_pos =
+                    zoom_display_cursor_logical(pointer_local, output_sz, zoom_level, zoom_focal);
+
+                // Use cursor theme hotspot — stable per icon, avoids oscillating
+                // hotspot_in_elem = cursor_f64 - elem_pos_i32 computation.
+                let hotspot = if is_wayland_pointer {
+                    None
+                } else {
+                    let cursor_scale = output.current_scale().integer_scale();
+                    match self.cursor_manager.get_render_cursor(cursor_scale) {
+                        RenderCursor::Hidden => None,
+                        RenderCursor::Surface { hotspot, .. } => {
+                            Some(hotspot.to_physical_precise_round(output_scale))
+                        }
+                        RenderCursor::Named { scale, cursor, .. } => {
+                            let (_, frame) = cursor.frame(self.start_time.elapsed().as_millis() as u32);
+                            Some(
+                                XCursor::hotspot(frame)
+                                    .to_logical(scale)
+                                    .to_physical_precise_round(output_scale),
+                            )
+                        }
+                    }
+                };
+
+                (Some(display_pos), hotspot)
+            } else {
+                (None, None)
+            }
+        } else {
+            (None, None)
+        };
+
+        apply_zoom_to_render_element(
+            element,
+            zoom_level,
+            output_scale,
+            scale_with_zoom,
+            zoom_focal,
+            cursor_logical_pos,
+            cursor_hotspot,
+            output_size_phys,
+        )
+    }
+
     pub fn render<R: NiriRenderer>(
         &self,
         renderer: &mut R,
@@ -4027,9 +4296,13 @@ impl Niri {
         target: RenderTarget,
     ) -> Vec<OutputRenderElements<R>> {
         let mut elements = Vec::new();
+
         self.render_inner(renderer, output, include_pointer, target, &mut |elem| {
-            elements.push(elem)
+            let zoomed = self.zoomed_element(elem, output);
+
+            elements.push(zoomed);
         });
+
         elements
     }
 
@@ -5120,7 +5393,10 @@ impl Niri {
                 RenderTarget::ScreenCapture,
             ];
             let screenshot = targets.map(|target| {
-                let elements = self.render::<GlesRenderer>(renderer, &output, false, target);
+                let mut elements = Vec::new();
+                self.render_inner::<GlesRenderer>(renderer, &output, false, target, &mut |elem| {
+                    elements.push(elem)
+                });
                 let elements = elements.iter().rev();
 
                 let res = render_to_texture(
@@ -6127,6 +6403,199 @@ fn scale_relocate_crop<E: Element>(
     CropRenderElement::from_element(elem, output_scale, ws_geo)
 }
 
+#[allow(clippy::too_many_arguments)]
+fn apply_zoom_to_render_element<R: NiriRenderer>(
+    element: OutputRenderElements<R>,
+    zoom_factor: f64,
+    output_scale: Scale<f64>,
+    scale_with_zoom: bool,
+    zoom_focal_point: Point<f64, Logical>,
+    cursor_logical_pos: Option<Point<f64, Logical>>,
+    cursor_hotspot: Option<Point<i32, Physical>>,
+    output_size_phys: Size<i32, Physical>,
+) -> OutputRenderElements<R> {
+    // Generate match arms for each OutputRenderElement variant.
+    macro_rules! apply_zoom {
+        ($($variant:ident),*) => {
+            match element {
+                OutputRenderElements::Pointer(pointer_elem) => {
+                    let pointer_pos = pointer_elem.geometry(output_scale).loc;
+
+                    // Use f64 cursor position to avoid the i32 roundtrip that
+                    // causes jitter at high zoom. The elem position oscillates
+                    // by ±1px as the cursor crosses pixel boundaries, and zoom
+                    // amplifies this to ±zoom pixels.
+                    let cursor_pos_f64: Point<f64, Physical> = cursor_logical_pos
+                        .map(|p| p.to_physical(output_scale))
+                        .unwrap_or_else(|| {
+                            Point::from((pointer_pos.x as f64, pointer_pos.y as f64))
+                        });
+
+                    // Ideal cursor hotspot position with f64 precision.
+                    let focal_f64: Point<f64, Physical> =
+                        zoom_focal_point.to_physical(output_scale);
+                    let target: Point<f64, Physical> = Point::from((
+                        cursor_pos_f64.x * zoom_factor
+                            - focal_f64.x * (zoom_factor - 1.0),
+                        cursor_pos_f64.y * zoom_factor
+                            - focal_f64.y * (zoom_factor - 1.0),
+                    ));
+
+                    let target_rounded: Point<i32, Physical> = Point::from((
+                        target.x.round() as i32,
+                        target.y.round() as i32,
+                    ));
+
+                    // Use cursor theme hotspot (stable per-icon). Computing
+                    // hotspot = cursor_f64 - pointer_pos(i32) oscillates and
+                    // causes jitter.
+                    let hotspot: Point<i32, Physical> =
+                        cursor_hotspot.unwrap_or_else(|| {
+                            Point::from((
+                                (cursor_pos_f64.x - pointer_pos.x as f64).round() as i32,
+                                (cursor_pos_f64.y - pointer_pos.y as f64).round() as i32,
+                            ))
+                        });
+
+                    // Place cursor hotspot at target. hotspot_scaled accounts
+                    // for cursor scaling with zoom.
+                    let (cursor_zoom, final_pos) = if scale_with_zoom {
+                        let hotspot_scaled: Point<i32, Physical> = Point::from((
+                            (hotspot.x as f64 * zoom_factor).round() as i32,
+                            (hotspot.y as f64 * zoom_factor).round() as i32,
+                        ));
+                        let pos: Point<i32, Physical> = Point::from((
+                            target_rounded.x - hotspot_scaled.x,
+                            target_rounded.y - hotspot_scaled.y,
+                        ));
+                        (zoom_factor, pos)
+                    } else {
+                        let pos: Point<i32, Physical> = Point::from((
+                            target_rounded.x - hotspot.x,
+                            target_rounded.y - hotspot.y,
+                        ));
+                        (1.0, pos)
+                    };
+
+                    // Use origin=(0,0) and Relocate::Absolute to avoid focal
+                    // point rounding interference.
+                    let e = RelocateRenderElement::from_element(
+                        RescaleRenderElement::from_element(
+                            pointer_elem,
+                            Point::from((0, 0)),
+                            cursor_zoom,
+                        ),
+                        final_pos,
+                        Relocate::Absolute,
+                    );
+                    OutputRenderElements::Zoomed(ZoomedRenderElements::Pointer(e)).into()
+                }
+                OutputRenderElements::ScreenshotUi(inner) => match inner {
+                    ScreenshotUiRenderElement::Screenshot(elem) => {
+                        let e = zoom_wrap(elem, zoom_factor, output_scale, zoom_focal_point);
+                        OutputRenderElements::Zoomed(ZoomedRenderElements::Texture(e)).into()
+                    }
+                    ScreenshotUiRenderElement::SolidColor(elem) => {
+                        let focal: Point<i32, Physical> =
+                            zoom_focal_point.to_physical_precise_round(output_scale);
+                        let correction =
+                            zoom_subpixel_correction(zoom_focal_point, zoom_factor, output_scale);
+                        let w = output_size_phys.w;
+                        let h = output_size_phys.h;
+                        let w_zoomed = (w as f64 * zoom_factor).round() as i32;
+                        let h_zoomed = (h as f64 * zoom_factor).round() as i32;
+                        let base_x = (-(focal.x as f64) * zoom_factor).round() as i32
+                            + focal.x
+                            + correction.x;
+                        let base_y = (-(focal.y as f64) * zoom_factor).round() as i32
+                            + focal.y
+                            + correction.y;
+                        let phys = elem.geometry(output_scale);
+                        let map_x = |edge: i32| -> i32 {
+                            ((w_zoomed as i64 * edge as i64 + w as i64 / 2) / w as i64) as i32
+                        };
+                        let map_y = |edge: i32| -> i32 {
+                            ((h_zoomed as i64 * edge as i64 + h as i64 / 2) / h as i64) as i32
+                        };
+                        let left = base_x + map_x(phys.loc.x);
+                        let top = base_y + map_y(phys.loc.y);
+                        let right = base_x + map_x(phys.loc.x + phys.size.w);
+                        let bottom = base_y + map_y(phys.loc.y + phys.size.h);
+                        let zoomed_phys = Rectangle::new(
+                            Point::from((left, top)),
+                            Size::from(((right - left).max(0), (bottom - top).max(0))),
+                        );
+                        OutputRenderElements::SolidColor(
+                            elem.with_geometry_physical(zoomed_phys, output_scale),
+                        )
+                        .into()
+                    }
+                    ScreenshotUiRenderElement::Pointer(ScreenshotPointerElement(elem)) => {
+                        if scale_with_zoom {
+                            let e = zoom_wrap(
+                                elem, zoom_factor, output_scale, zoom_focal_point,
+                            );
+                            OutputRenderElements::Zoomed(ZoomedRenderElements::Texture(e)).into()
+                        } else {
+                            // Reposition without scaling: compute zoomed position, apply
+                            // Rescale(1.0) + Relocate::Absolute to preserve original size.
+                            let pos = elem.geometry(output_scale).loc;
+                            let focal_phys: Point<f64, Physical> =
+                                zoom_focal_point.to_physical(output_scale);
+                            let correction = zoom_subpixel_correction(
+                                zoom_focal_point,
+                                zoom_factor,
+                                output_scale,
+                            );
+                            let new_pos = Point::<i32, Physical>::from((
+                                (pos.x as f64 * zoom_factor
+                                    - focal_phys.x * (zoom_factor - 1.0))
+                                    .round() as i32
+                                    + correction.x,
+                                (pos.y as f64 * zoom_factor
+                                    - focal_phys.y * (zoom_factor - 1.0))
+                                    .round() as i32
+                                    + correction.y,
+                            ));
+                            let e = RelocateRenderElement::from_element(
+                                RescaleRenderElement::from_element(
+                                    elem,
+                                    Point::from((0, 0)),
+                                    1.0,
+                                ),
+                                new_pos,
+                                Relocate::Absolute,
+                            );
+                            OutputRenderElements::Zoomed(ZoomedRenderElements::Texture(e)).into()
+                        }
+                    }
+                    ScreenshotUiRenderElement::HelpPanel(HelpPanelElement(_)) => {
+                        OutputRenderElements::ScreenshotUi(inner)
+                    }
+                }
+                $(
+                    OutputRenderElements::$variant(elem) => {
+                        let e = zoom_wrap(elem, zoom_factor, output_scale, zoom_focal_point);
+                        OutputRenderElements::Zoomed(ZoomedRenderElements::$variant(e)).into()
+                    }
+                )*
+                _ => element,
+            }
+        }
+    }
+
+    apply_zoom!(
+        Monitor,
+        RescaledTile,
+        LayerSurface,
+        Wayland,
+        SolidColor,
+        Texture,
+        RelocatedColor,
+        RelocatedLayerSurface
+    )
+}
+
 niri_render_elements! {
     PointerRenderElements<R> => {
         Wayland = WaylandSurfaceRenderElement<R>,
@@ -6146,12 +6615,8 @@ niri_render_elements! {
         Monitor = MonitorRenderElement<R>,
         RescaledTile = RescaleRenderElement<TileRenderElement<R>>,
         LayerSurface = LayerSurfaceRenderElement<R>,
-        RelocatedLayerSurface = CropRenderElement<RelocateRenderElement<RescaleRenderElement<
-            LayerSurfaceRenderElement<R>
-        >>>,
-        RelocatedColor = CropRenderElement<RelocateRenderElement<RescaleRenderElement<
-            SolidColorRenderElement
-        >>>,
+        RelocatedLayerSurface = CropRenderElement<ZoomWrapper<LayerSurfaceRenderElement<R>>>,
+        RelocatedColor = CropRenderElement<ZoomWrapper<SolidColorRenderElement>>,
         Pointer = PointerRenderElements<R>,
         Wayland = WaylandSurfaceRenderElement<R>,
         SolidColor = SolidColorRenderElement,
@@ -6161,5 +6626,7 @@ niri_render_elements! {
         Texture = PrimaryGpuTextureRenderElement,
         // Used for the CPU-rendered panels.
         RelocatedMemoryBuffer = RelocateRenderElement<MemoryRenderBufferRenderElement<R>>,
+        // All zoomed elements wrapped in a single variant
+        Zoomed = ZoomedRenderElements<R>,
     }
 }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -156,7 +156,7 @@ use crate::render_helpers::surface::push_elements_from_surface_tree;
 use crate::render_helpers::texture::TextureBuffer;
 use crate::render_helpers::{
     encompassing_geo, render_to_dmabuf, render_to_encompassing_texture, render_to_shm,
-    render_to_texture, render_to_vec, shaders, RenderTarget,
+    render_to_texture, render_to_vec, shaders, RenderCtx, RenderTarget,
 };
 #[cfg(feature = "xdp-gnome-screencast")]
 use crate::screencasting::Screencasting;
@@ -4258,7 +4258,8 @@ impl Niri {
                             Some(hotspot.to_physical_precise_round(output_scale))
                         }
                         RenderCursor::Named { scale, cursor, .. } => {
-                            let (_, frame) = cursor.frame(self.start_time.elapsed().as_millis() as u32);
+                            let (_, frame) =
+                                cursor.frame(self.start_time.elapsed().as_millis() as u32);
                             Some(
                                 XCursor::hotspot(frame)
                                     .to_logical(scale)
@@ -4288,37 +4289,36 @@ impl Niri {
         )
     }
 
-    pub fn render<R: NiriRenderer>(
+    pub fn render_to_vec<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        ctx: RenderCtx<R>,
         output: &Output,
         include_pointer: bool,
-        target: RenderTarget,
     ) -> Vec<OutputRenderElements<R>> {
         let mut elements = Vec::new();
 
-        self.render_inner(renderer, output, include_pointer, target, &mut |elem| {
-            let zoomed = self.zoomed_element(elem, output);
+        self.render(ctx, output, include_pointer, &mut |elem| {
+            // Apply zoom to the render elements when needed.
+            let elem = self.zoomed_element(elem, output);
 
-            elements.push(zoomed);
+            elements.push(elem)
         });
 
         elements
     }
 
-    pub fn render_inner<R: NiriRenderer>(
+    pub fn render<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        mut ctx: RenderCtx<R>,
         output: &Output,
         include_pointer: bool,
-        mut target: RenderTarget,
         push: &mut dyn FnMut(OutputRenderElements<R>),
     ) {
         let _span = tracy_client::span!("Niri::render");
 
-        if target == RenderTarget::Output {
+        if ctx.target == RenderTarget::Output {
             if let Some(preview) = self.config.borrow().debug.preview_render {
-                target = match preview {
+                ctx.target = match preview {
                     PreviewRender::Screencast => RenderTarget::Screencast,
                     PreviewRender::ScreenCapture => RenderTarget::ScreenCapture,
                 };
@@ -4338,23 +4338,23 @@ impl Niri {
 
         // The pointer goes on the top.
         if include_pointer && self.pointer_visibility.is_visible() {
-            self.render_pointer(renderer, output, &mut |elem| push(elem.into()));
+            self.render_pointer(ctx.renderer, output, &mut |elem| push(elem.into()));
         }
 
         // Next, the screen transition texture.
         {
             let state = self.output_state.get(output).unwrap();
             if let Some(transition) = &state.screen_transition {
-                push(transition.render(target).into());
+                push(transition.render(ctx.target).into());
             }
         }
 
         // Next, the exit confirm dialog.
         self.exit_confirm_dialog
-            .render(renderer, output, &mut |elem| push(elem.into()));
+            .render(ctx.renderer, output, &mut |elem| push(elem.into()));
 
         // Next, the config error notification too.
-        if let Some(element) = self.config_error_notification.render(renderer, output) {
+        if let Some(element) = self.config_error_notification.render(ctx.renderer, output) {
             push(element.into());
         }
 
@@ -4363,7 +4363,7 @@ impl Niri {
             let state = self.output_state.get(output).unwrap();
             if let Some(surface) = state.lock_surface.as_ref() {
                 push_elements_from_surface_tree(
-                    renderer,
+                    ctx.renderer,
                     surface.wl_surface(),
                     Point::new(0, 0),
                     output_scale,
@@ -4400,7 +4400,7 @@ impl Niri {
         // If the screenshot UI is open, draw it.
         if self.screenshot_ui.is_open() {
             self.screenshot_ui
-                .render_output(output, target, &mut |elem| push(elem.into()));
+                .render_output(output, ctx.target, &mut |elem| push(elem.into()));
 
             // Add the backdrop for outputs that were connected while the screenshot UI was open.
             push(backdrop);
@@ -4409,15 +4409,13 @@ impl Niri {
         }
 
         // Draw the hotkey overlay on top.
-        if let Some(element) = self.hotkey_overlay.render(renderer, output) {
+        if let Some(element) = self.hotkey_overlay.render(ctx.renderer, output) {
             push(element.into());
         }
 
         // Then, the Alt-Tab switcher.
         self.window_mru_ui
-            .render_output(self, output, renderer, target, &mut |elem| {
-                push(elem.into())
-            });
+            .render_output(self, output, ctx.r(), &mut |elem| push(elem.into()));
 
         // Don't draw the focus ring on the workspaces while interactively moving above those
         // workspaces, since the interactively-moved window already has a focus ring.
@@ -4434,7 +4432,7 @@ impl Niri {
         // into different functions).
         macro_rules! push_popups_from_layer {
             ($layer:expr, $backdrop:expr, $push:expr) => {{
-                self.render_layer_popups(renderer, target, &layer_map, $layer, $backdrop, $push);
+                self.render_layer_popups(ctx.r(), &layer_map, $layer, $backdrop, $push);
             }};
             ($layer:expr, true) => {{
                 push_popups_from_layer!($layer, true, &mut |elem| push(elem.into()));
@@ -4448,7 +4446,7 @@ impl Niri {
         }
         macro_rules! push_normal_from_layer {
             ($layer:expr, $backdrop:expr, $push:expr) => {{
-                self.render_layer_normal(renderer, target, &layer_map, $layer, $backdrop, $push);
+                self.render_layer_normal(ctx.r(), &layer_map, $layer, $backdrop, $push);
             }};
             ($layer:expr, true) => {{
                 push_normal_from_layer!($layer, true, &mut |elem| push(elem.into()));
@@ -4469,13 +4467,11 @@ impl Niri {
         // Otherwise, we will render all layer-shell pop-ups and the top layer on top.
         if mon.render_above_top_layer() {
             self.layout
-                .render_interactive_move_for_output(renderer, output, target, &mut |elem| {
-                    push(elem.into())
-                });
+                .render_interactive_move_for_output(ctx.r(), output, &mut |elem| push(elem.into()));
 
-            mon.render_insert_hint_between_workspaces(renderer, &mut |elem| push(elem.into()));
+            mon.render_insert_hint_between_workspaces(ctx.renderer, &mut |elem| push(elem.into()));
 
-            mon.render_workspaces(renderer, target, focus_ring, &mut |elem| push(elem.into()));
+            mon.render_workspaces(ctx.r(), focus_ring, &mut |elem| push(elem.into()));
 
             push_popups_from_layer!(Layer::Top);
             push_normal_from_layer!(Layer::Top);
@@ -4494,11 +4490,9 @@ impl Niri {
             push_normal_from_layer!(Layer::Top);
 
             self.layout
-                .render_interactive_move_for_output(renderer, output, target, &mut |elem| {
-                    push(elem.into())
-                });
+                .render_interactive_move_for_output(ctx.r(), output, &mut |elem| push(elem.into()));
 
-            mon.render_insert_hint_between_workspaces(renderer, &mut |elem| push(elem.into()));
+            mon.render_insert_hint_between_workspaces(ctx.renderer, &mut |elem| push(elem.into()));
 
             // Macro instead of closure to avoid borrowing push().
             macro_rules! process {
@@ -4516,7 +4510,7 @@ impl Niri {
                 push_popups_from_layer!(Layer::Background, process!(geo));
             }
 
-            mon.render_workspaces(renderer, target, focus_ring, &mut |elem| push(elem.into()));
+            mon.render_workspaces(ctx.r(), focus_ring, &mut |elem| push(elem.into()));
 
             for (ws, geo) in mon.workspaces_with_render_geo() {
                 push_normal_from_layer!(Layer::Bottom, process!(geo));
@@ -4526,7 +4520,7 @@ impl Niri {
             }
         }
 
-        mon.render_workspace_shadows(renderer, &mut |elem| push(elem.into()));
+        mon.render_workspace_shadows(ctx.renderer, &mut |elem| push(elem.into()));
 
         // Then the backdrop.
         push_popups_from_layer!(Layer::Background, true);
@@ -4556,29 +4550,27 @@ impl Niri {
 
     fn render_layer_normal<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        mut ctx: RenderCtx<R>,
         layer_map: &LayerMap,
         layer: Layer,
         for_backdrop: bool,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
         for (mapped, geo) in self.layers_in_render_order(layer_map, layer, for_backdrop) {
-            mapped.render_normal(renderer, geo.loc.to_f64(), target, push);
+            mapped.render_normal(ctx.r(), geo.loc.to_f64(), push);
         }
     }
 
     fn render_layer_popups<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
-        target: RenderTarget,
+        mut ctx: RenderCtx<R>,
         layer_map: &LayerMap,
         layer: Layer,
         for_backdrop: bool,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
         for (mapped, geo) in self.layers_in_render_order(layer_map, layer, for_backdrop) {
-            mapped.render_popups(renderer, geo.loc.to_f64(), target, push);
+            mapped.render_popups(ctx.r(), geo.loc.to_f64(), push);
         }
     }
 
@@ -5202,7 +5194,11 @@ impl Niri {
             if let Some(screencopy) = screencopy {
                 if screencopy.output() == output {
                     let elements = elements.get_or_init(|| {
-                        self.render(renderer, output, true, RenderTarget::ScreenCapture)
+                        let ctx = RenderCtx {
+                            renderer,
+                            target: RenderTarget::ScreenCapture,
+                        };
+                        self.render_to_vec(ctx, output, true)
                     });
                     // FIXME: skip elements if not including pointers
                     let render_result = Self::render_for_screencopy_internal(
@@ -5265,12 +5261,12 @@ impl Niri {
 
         self.update_render_elements(Some(output));
 
-        let elements = self.render(
+        let ctx = RenderCtx {
             renderer,
-            output,
-            screencopy.overlay_cursor(),
-            RenderTarget::ScreenCapture,
-        );
+            target: RenderTarget::ScreenCapture,
+        };
+        let elements = self.render_to_vec(ctx, output, screencopy.overlay_cursor());
+
         let Some(damage_tracker) = self.screencopy_state.damage_tracker(manager) else {
             error!("screencopy queue must not be deleted as long as frames exist");
             bail!("screencopy queue missing");
@@ -5393,8 +5389,10 @@ impl Niri {
                 RenderTarget::ScreenCapture,
             ];
             let screenshot = targets.map(|target| {
+                let ctx = RenderCtx { renderer, target };
                 let mut elements = Vec::new();
-                self.render_inner::<GlesRenderer>(renderer, &output, false, target, &mut |elem| {
+                self.render(ctx, &output, false, &mut |elem| {
+                    // Use un-zoomed elements to sample at the correct position in the screenshot.
                     elements.push(elem)
                 });
                 let elements = elements.iter().rev();
@@ -5473,12 +5471,11 @@ impl Niri {
         let size = transform.transform_size(size);
 
         let scale = Scale::from(output.current_scale().fractional_scale());
-        let elements = self.render::<GlesRenderer>(
+        let ctx = RenderCtx {
             renderer,
-            output,
-            include_pointer,
-            RenderTarget::ScreenCapture,
-        );
+            target: RenderTarget::ScreenCapture,
+        };
+        let elements = self.render_to_vec(ctx, output, include_pointer);
         let elements = elements.iter().rev();
         let pixels = render_to_vec(
             renderer,
@@ -5528,12 +5525,15 @@ impl Niri {
         }
         let pointer_count = elements.len();
 
-        mapped.render(
+        let ctx = RenderCtx {
             renderer,
+            target: RenderTarget::ScreenCapture,
+        };
+        mapped.render(
+            ctx,
             mapped.window.geometry().loc.to_f64(),
             scale,
             alpha,
-            RenderTarget::ScreenCapture,
             &mut |elem| elements.push(elem.into()),
         );
 
@@ -5689,12 +5689,11 @@ impl Niri {
         let transform = output.current_transform();
         let size = transform.transform_size(size);
 
-        let elements = self.render::<GlesRenderer>(
+        let ctx = RenderCtx {
             renderer,
-            &output,
-            include_pointer,
-            RenderTarget::ScreenCapture,
-        );
+            target: RenderTarget::ScreenCapture,
+        };
+        let elements = self.render_to_vec(ctx, &output, include_pointer);
         let elements = elements.iter().rev();
         let pixels = render_to_vec(
             renderer,
@@ -6167,7 +6166,8 @@ impl Niri {
                     RenderTarget::ScreenCapture,
                 ];
                 let textures = targets.map(|target| {
-                    let elements = self.render::<GlesRenderer>(renderer, &output, false, target);
+                    let ctx = RenderCtx { renderer, target };
+                    let elements = self.render_to_vec(ctx, &output, false);
                     let elements = elements.iter().rev();
 
                     let res = render_to_texture(

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -867,7 +867,7 @@ impl State {
             self,
             under.surface,
             &MotionEvent {
-                location: location,
+                location,
                 serial: SERIAL_COUNTER.next_serial(),
                 time: get_monotonic_time().as_millis() as u32,
             },
@@ -1086,7 +1086,7 @@ impl State {
             self,
             under.surface,
             &MotionEvent {
-                location: location,
+                location,
                 serial: SERIAL_COUNTER.next_serial(),
                 time: get_monotonic_time().as_millis() as u32,
             },
@@ -1997,10 +1997,12 @@ impl State {
 
         self.niri.update_render_elements(None);
 
-        let Some(screenshots) = self
-            .backend
-            .with_primary_renderer(|renderer| self.niri.capture_screenshots(renderer).collect())
-        else {
+        let Some(screenshots) = self.backend.with_primary_renderer(|renderer| {
+            self.niri
+                .capture_screenshots(renderer)
+                .map(|(output, zoom, shots)| (output, (zoom, shots)))
+                .collect()
+        }) else {
             return;
         };
 
@@ -2958,11 +2960,12 @@ impl Niri {
         let scale = output.current_scale();
         let transform = output.current_transform();
 
+        let zoom_state = self.layout.zoom_state_for_output(output).cloned();
         {
             let mut layer_map = layer_map_for_output(output);
             for layer in layer_map.layers() {
                 layer.with_surfaces(|surface, data| {
-                    send_scale_transform(surface, data, scale, transform);
+                    send_scale_transform(surface, data, scale, transform, zoom_state.as_ref());
                 });
 
                 if let Some(mapped) = self.mapped_layer_surfaces.get_mut(layer) {
@@ -4002,6 +4005,7 @@ impl Niri {
                         data,
                         output::Scale::Fractional(cursor_scale),
                         cursor_transform,
+                        None,
                     )
                 });
                 if let Some((surface, _)) = dnd {
@@ -4011,6 +4015,7 @@ impl Niri {
                             data,
                             output::Scale::Fractional(dnd_scale),
                             dnd_transform,
+                            None,
                         );
                     });
                 }
@@ -4065,6 +4070,7 @@ impl Niri {
                         data,
                         output::Scale::Fractional(dnd_scale),
                         dnd_transform,
+                        None,
                     );
                 });
             }
@@ -5376,13 +5382,15 @@ impl Niri {
     pub fn capture_screenshots<'a>(
         &'a self,
         renderer: &'a mut GlesRenderer,
-    ) -> impl Iterator<Item = (Output, [OutputScreenshot; 3])> + 'a {
+    ) -> impl Iterator<Item = (Output, f64, [OutputScreenshot; 3])> + 'a {
         self.global_space.outputs().cloned().filter_map(|output| {
             let size = output.current_mode().unwrap().size;
             let transform = output.current_transform();
             let size = transform.transform_size(size);
 
             let scale = Scale::from(output.current_scale().fractional_scale());
+            let effective_zoom = self.layout.effective_zoom_for_output(&output);
+
             let targets = [
                 RenderTarget::Output,
                 RenderTarget::Screencast,
@@ -5409,6 +5417,34 @@ impl Niri {
                     warn!("error rendering output {}: {err:?}", output.name());
                 }
                 let res_output = res.ok();
+
+                let hr_texture = if target == RenderTarget::Output && effective_zoom > 1.0 {
+                    let hr_size = Size::from((
+                        (size.w as f64 * effective_zoom).round() as i32,
+                        (size.h as f64 * effective_zoom).round() as i32,
+                    ));
+                    let hr_scale = Scale::from(scale.x * effective_zoom);
+                    let mut hr_elements = Vec::new();
+                    let ctx = RenderCtx { renderer, target };
+                    self.render(ctx, &output, false, &mut |elem| hr_elements.push(elem));
+                    let hr_elements = hr_elements.iter().rev();
+                    match render_to_texture(
+                        renderer,
+                        hr_size,
+                        hr_scale,
+                        Transform::Normal,
+                        Fourcc::Abgr8888,
+                        hr_elements,
+                    ) {
+                        Ok((tex, _)) => Some(tex),
+                        Err(err) => {
+                            warn!("error rendering hr output {}: {err:?}", output.name());
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
 
                 let mut pointer = Vec::new();
 
@@ -5439,7 +5475,9 @@ impl Niri {
                     OutputScreenshot::from_textures(
                         renderer,
                         scale,
+                        effective_zoom,
                         texture,
+                        hr_texture,
                         res_pointer.map(|(texture, _, geo)| (texture, geo)),
                     )
                 })
@@ -5450,7 +5488,7 @@ impl Niri {
             }
 
             let screenshot = screenshot.map(|res| res.unwrap());
-            Some((output, screenshot))
+            Some((output, effective_zoom, screenshot))
         })
     }
 

--- a/src/render_helpers/clipped_surface.rs
+++ b/src/render_helpers/clipped_surface.rs
@@ -272,10 +272,6 @@ impl<'render> RenderElement<TtyRenderer<'render>>
 }
 
 impl RoundedCornerDamage {
-    pub fn set_size(&mut self, size: Size<f64, Logical>) {
-        self.damage.set_size(size);
-    }
-
     pub fn set_corner_radius(&mut self, corner_radius: CornerRadius) {
         if self.corner_radius == corner_radius {
             return;
@@ -286,7 +282,7 @@ impl RoundedCornerDamage {
         self.damage.damage_all();
     }
 
-    pub fn element(&self) -> ExtraDamage {
-        self.damage.clone()
+    pub fn render(&self, geometry: Rectangle<f64, Logical>) -> ExtraDamage {
+        self.damage.render(geometry)
     }
 }

--- a/src/render_helpers/damage.rs
+++ b/src/render_helpers/damage.rs
@@ -1,7 +1,7 @@
 use smithay::backend::renderer::element::{Element, Id, RenderElement};
 use smithay::backend::renderer::utils::CommitCounter;
 use smithay::backend::renderer::Renderer;
-use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size};
+use smithay::utils::{Buffer, Logical, Physical, Rectangle, Scale, Size};
 
 #[derive(Debug, Clone)]
 pub struct ExtraDamage {
@@ -19,22 +19,14 @@ impl ExtraDamage {
         }
     }
 
-    pub fn set_size(&mut self, size: Size<f64, Logical>) {
-        if self.geometry.size == size {
-            return;
-        }
-
-        self.geometry.size = size;
-        self.commit.increment();
-    }
-
     pub fn damage_all(&mut self) {
         self.commit.increment();
     }
 
-    pub fn with_location(mut self, location: Point<f64, Logical>) -> Self {
-        self.geometry.loc = location;
-        self
+    pub fn render(&self, geometry: Rectangle<f64, Logical>) -> Self {
+        let mut this = self.clone();
+        this.geometry = geometry;
+        this
     }
 }
 

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -1,14 +1,18 @@
 use std::ptr;
 
-use anyhow::{ensure, Context};
+use anyhow::{ensure, Context as _};
 use niri_config::BlockOutFrom;
 use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::allocator::{Buffer, Fourcc};
 use smithay::backend::renderer::element::utils::{Relocate, RelocateRenderElement};
 use smithay::backend::renderer::element::{Element, Kind, RenderElement};
-use smithay::backend::renderer::gles::{GlesMapping, GlesRenderer, GlesTarget, GlesTexture};
+use smithay::backend::renderer::gles::{
+    GlesError, GlesMapping, GlesRenderer, GlesTarget, GlesTexture,
+};
 use smithay::backend::renderer::sync::SyncPoint;
-use smithay::backend::renderer::{Bind, Color32F, ExportMem, Frame, Offscreen, Renderer};
+use smithay::backend::renderer::{
+    Bind, Color32F, ExportMem, Frame, Offscreen, Renderer, Texture as _,
+};
 use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
 use smithay::reexports::wayland_server::protocol::wl_shm;
 use smithay::utils::{Logical, Physical, Point, Rectangle, Scale, Size, Transform};
@@ -17,6 +21,7 @@ use solid_color::{SolidColorBuffer, SolidColorRenderElement};
 
 use self::primary_gpu_texture::PrimaryGpuTextureRenderElement;
 use self::texture::{TextureBuffer, TextureRenderElement};
+use crate::render_helpers::renderer::AsGlesRenderer;
 
 pub mod border;
 pub mod clipped_surface;
@@ -37,6 +42,34 @@ pub mod snapshot;
 pub mod solid_color;
 pub mod surface;
 pub mod texture;
+
+/// A rendering context.
+///
+/// Bundles together things needed by most rendering code.
+pub struct RenderCtx<'a, R> {
+    pub renderer: &'a mut R,
+    pub target: RenderTarget,
+}
+
+impl<'a, R> RenderCtx<'a, R> {
+    /// Reborrows this context with a smaller lifetime.
+    #[inline]
+    pub fn r<'b>(&'b mut self) -> RenderCtx<'b, R> {
+        RenderCtx {
+            renderer: self.renderer,
+            target: self.target,
+        }
+    }
+}
+
+impl<'a, R: AsGlesRenderer> RenderCtx<'a, R> {
+    pub fn as_gles<'b>(&'b mut self) -> RenderCtx<'b, GlesRenderer> {
+        RenderCtx {
+            renderer: self.renderer.as_gles_renderer(),
+            target: self.target,
+        }
+    }
+}
 
 /// What we're rendering for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -126,6 +159,23 @@ pub fn encompassing_geo(
         .unwrap_or_default()
 }
 
+pub fn create_texture(
+    renderer: &mut GlesRenderer,
+    size: Size<i32, Physical>,
+    fourcc: Fourcc,
+) -> Result<GlesTexture, GlesError> {
+    let buffer_size = size.to_logical(1).to_buffer(1, Transform::Normal);
+    renderer.create_buffer(fourcc, buffer_size)
+}
+
+pub fn copy_framebuffer(
+    renderer: &mut GlesRenderer,
+    target: &GlesTarget,
+    fourcc: Fourcc,
+) -> Result<GlesMapping, GlesError> {
+    renderer.copy_framebuffer(target, Rectangle::from_size(target.size()), fourcc)
+}
+
 pub fn render_to_encompassing_texture(
     renderer: &mut GlesRenderer,
     scale: Scale<f64>,
@@ -154,11 +204,7 @@ pub fn render_to_texture(
 ) -> anyhow::Result<(GlesTexture, SyncPoint)> {
     let _span = tracy_client::span!();
 
-    let buffer_size = size.to_logical(1).to_buffer(1, Transform::Normal);
-
-    let mut texture: GlesTexture = renderer
-        .create_buffer(fourcc, buffer_size)
-        .context("error creating texture")?;
+    let mut texture = create_texture(renderer, size, fourcc).context("error creating texture")?;
 
     let sync_point = {
         let mut target = renderer
@@ -181,18 +227,15 @@ pub fn render_and_download(
 ) -> anyhow::Result<GlesMapping> {
     let _span = tracy_client::span!();
 
-    let (mut texture, _) = render_to_texture(renderer, size, scale, transform, fourcc, elements)?;
-
-    let buffer_size = size.to_logical(1).to_buffer(1, Transform::Normal);
-    // FIXME: would be nice to avoid binding the second time here (after render_to_texture()), but
-    // borrowing makes this inconvenient.
-    let target = renderer
+    let mut texture = create_texture(renderer, size, fourcc).context("error creating texture")?;
+    let mut target = renderer
         .bind(&mut texture)
         .context("error binding texture")?;
-    let mapping = renderer
-        .copy_framebuffer(&target, Rectangle::from_size(buffer_size), fourcc)
-        .context("error copying framebuffer")?;
-    Ok(mapping)
+
+    let _sync = render_elements(renderer, &mut target, size, scale, transform, elements)
+        .context("error rendering")?;
+
+    copy_framebuffer(renderer, &target, fourcc).context("error copying framebuffer")
 }
 
 pub fn render_to_vec(

--- a/src/render_helpers/shaders/border.frag
+++ b/src/render_helpers/shaders/border.frag
@@ -208,35 +208,12 @@ vec4 gradient_color(vec2 coords) {
     return color_mix(color_from, color_to, frac);
 }
 
-float rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius) {
-    vec2 center;
-    float radius;
-
-    if (coords.x < corner_radius.x && coords.y < corner_radius.x) {
-        radius = corner_radius.x;
-        center = vec2(radius, radius);
-    } else if (size.x - corner_radius.y < coords.x && coords.y < corner_radius.y) {
-        radius = corner_radius.y;
-        center = vec2(size.x - radius, radius);
-    } else if (size.x - corner_radius.z < coords.x && size.y - corner_radius.z < coords.y) {
-        radius = corner_radius.z;
-        center = vec2(size.x - radius, size.y - radius);
-    } else if (coords.x < corner_radius.w && size.y - corner_radius.w < coords.y) {
-        radius = corner_radius.w;
-        center = vec2(radius, size.y - radius);
-    } else {
-        return 1.0;
-    }
-
-    float dist = distance(coords, center);
-    float half_px = 0.5 / niri_scale;
-    return 1.0 - smoothstep(radius - half_px, radius + half_px, dist);
-}
+float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius);
 
 void main() {
     vec3 coords_geo = input_to_geo * vec3(niri_v_coords, 1.0);
     vec4 color = gradient_color(coords_geo.xy);
-    color = color * rounding_alpha(coords_geo.xy, geo_size, outer_radius);
+    color = color * niri_rounding_alpha(coords_geo.xy, geo_size, outer_radius);
 
     if (border_width > 0.0) {
         coords_geo -= vec3(border_width);
@@ -245,7 +222,7 @@ void main() {
                 && 0.0 <= coords_geo.y && coords_geo.y <= inner_geo_size.y)
         {
             vec4 inner_radius = max(outer_radius - vec4(border_width), 0.0);
-            color = color * (1.0 - rounding_alpha(coords_geo.xy, inner_geo_size, inner_radius));
+            color = color * (1.0 - niri_rounding_alpha(coords_geo.xy, inner_geo_size, inner_radius));
         }
     }
 

--- a/src/render_helpers/shaders/clipped_surface.frag
+++ b/src/render_helpers/shaders/clipped_surface.frag
@@ -26,30 +26,7 @@ uniform vec2 geo_size;
 uniform vec4 corner_radius;
 uniform mat3 input_to_geo;
 
-float rounding_alpha(vec2 coords, vec2 size) {
-    vec2 center;
-    float radius;
-
-    if (coords.x < corner_radius.x && coords.y < corner_radius.x) {
-        radius = corner_radius.x;
-        center = vec2(radius, radius);
-    } else if (size.x - corner_radius.y < coords.x && coords.y < corner_radius.y) {
-        radius = corner_radius.y;
-        center = vec2(size.x - radius, radius);
-    } else if (size.x - corner_radius.z < coords.x && size.y - corner_radius.z < coords.y) {
-        radius = corner_radius.z;
-        center = vec2(size.x - radius, size.y - radius);
-    } else if (coords.x < corner_radius.w && size.y - corner_radius.w < coords.y) {
-        radius = corner_radius.w;
-        center = vec2(radius, size.y - radius);
-    } else {
-        return 1.0;
-    }
-
-    float dist = distance(coords, center);
-    float half_px = 0.5 / niri_scale;
-    return 1.0 - smoothstep(radius - half_px, radius + half_px, dist);
-}
+float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius);
 
 void main() {
     vec3 coords_geo = input_to_geo * vec3(v_coords, 1.0);
@@ -65,7 +42,7 @@ void main() {
         color = vec4(0.0);
     } else {
         // Apply corner rounding inside geometry.
-        color = color * rounding_alpha(coords_geo.xy * geo_size, geo_size);
+        color = color * niri_rounding_alpha(coords_geo.xy * geo_size, geo_size, corner_radius);
     }
 
     // Apply final alpha and tint.

--- a/src/render_helpers/shaders/mod.rs
+++ b/src/render_helpers/shaders/mod.rs
@@ -35,7 +35,10 @@ impl Shaders {
 
         let border = ShaderProgram::compile(
             renderer,
-            include_str!("border.frag"),
+            concat!(
+                include_str!("border.frag"),
+                include_str!("rounding_alpha.frag")
+            ),
             &[
                 UniformName::new("colorspace", UniformType::_1f),
                 UniformName::new("hue_interpolation", UniformType::_1f),
@@ -58,7 +61,10 @@ impl Shaders {
 
         let shadow = ShaderProgram::compile(
             renderer,
-            include_str!("shadow.frag"),
+            concat!(
+                include_str!("shadow.frag"),
+                include_str!("rounding_alpha.frag")
+            ),
             &[
                 UniformName::new("shadow_color", UniformType::_4f),
                 UniformName::new("sigma", UniformType::_1f),
@@ -78,7 +84,10 @@ impl Shaders {
 
         let clipped_surface = renderer
             .compile_custom_texture_shader(
-                include_str!("clipped_surface.frag"),
+                concat!(
+                    include_str!("clipped_surface.frag"),
+                    include_str!("rounding_alpha.frag")
+                ),
                 &[
                     UniformName::new("niri_scale", UniformType::_1f),
                     UniformName::new("geo_size", UniformType::_2f),
@@ -183,6 +192,7 @@ fn compile_resize_program(
     let mut program = include_str!("resize_prelude.frag").to_string();
     program.push_str(src);
     program.push_str(include_str!("resize_epilogue.frag"));
+    program.push_str(include_str!("rounding_alpha.frag"));
 
     ShaderProgram::compile(
         renderer,

--- a/src/render_helpers/shaders/resize_epilogue.frag
+++ b/src/render_helpers/shaders/resize_epilogue.frag
@@ -12,7 +12,7 @@ void main() {
             color = vec4(0.0);
         } else {
             // Apply corner rounding inside geometry.
-            color = color * niri_rounding_alpha(coords_curr_geo.xy * size_curr_geo.xy, size_curr_geo.xy);
+            color = color * niri_rounding_alpha(coords_curr_geo.xy * size_curr_geo.xy, size_curr_geo.xy, niri_corner_radius);
         }
     }
 

--- a/src/render_helpers/shaders/resize_prelude.frag
+++ b/src/render_helpers/shaders/resize_prelude.frag
@@ -27,27 +27,4 @@ uniform float niri_clip_to_geometry;
 uniform float niri_alpha;
 uniform float niri_scale;
 
-float niri_rounding_alpha(vec2 coords, vec2 size) {
-    vec2 center;
-    float radius;
-
-    if (coords.x < niri_corner_radius.x && coords.y < niri_corner_radius.x) {
-        radius = niri_corner_radius.x;
-        center = vec2(radius, radius);
-    } else if (size.x - niri_corner_radius.y < coords.x && coords.y < niri_corner_radius.y) {
-        radius = niri_corner_radius.y;
-        center = vec2(size.x - radius, radius);
-    } else if (size.x - niri_corner_radius.z < coords.x && size.y - niri_corner_radius.z < coords.y) {
-        radius = niri_corner_radius.z;
-        center = vec2(size.x - radius, size.y - radius);
-    } else if (coords.x < niri_corner_radius.w && size.y - niri_corner_radius.w < coords.y) {
-        radius = niri_corner_radius.w;
-        center = vec2(radius, size.y - radius);
-    } else {
-        return 1.0;
-    }
-
-    float dist = distance(coords, center);
-    float half_px = 0.5 / niri_scale;
-    return 1.0 - smoothstep(radius - half_px, radius + half_px, dist);
-}
+float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius);

--- a/src/render_helpers/shaders/rounding_alpha.frag
+++ b/src/render_helpers/shaders/rounding_alpha.frag
@@ -1,0 +1,27 @@
+float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius) {
+    vec2 center;
+    float radius;
+
+    if (coords.x < corner_radius.x && coords.y < corner_radius.x) {
+        radius = corner_radius.x;
+        center = vec2(radius, radius);
+    } else if (size.x - corner_radius.y < coords.x && coords.y < corner_radius.y) {
+        radius = corner_radius.y;
+        center = vec2(size.x - radius, radius);
+    } else if (size.x - corner_radius.z < coords.x && size.y - corner_radius.z < coords.y) {
+        radius = corner_radius.z;
+        center = vec2(size.x - radius, size.y - radius);
+    } else if (coords.x < corner_radius.w && size.y - corner_radius.w < coords.y) {
+        radius = corner_radius.w;
+        center = vec2(radius, size.y - radius);
+    } else {
+        return 1.0;
+    }
+
+    float dist = distance(coords, center);
+
+    // Manual smoothstep() between radius - half_px and radius + half_px
+    // to avoid a division in clamp().
+    float t = clamp((dist - radius) * niri_scale + 0.5, 0.0, 1.0);
+    return 1.0 - t * t * (3.0 - 2.0 * t);
+}

--- a/src/render_helpers/shaders/shadow.frag
+++ b/src/render_helpers/shaders/shadow.frag
@@ -72,30 +72,7 @@ float roundedBoxShadow(vec2 lower, vec2 upper, vec2 point, float sigma, float co
   return value;
 }
 
-float rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius) {
-    vec2 center;
-    float radius;
-
-    if (coords.x < corner_radius.x && coords.y < corner_radius.x) {
-        radius = corner_radius.x;
-        center = vec2(radius, radius);
-    } else if (size.x - corner_radius.y < coords.x && coords.y < corner_radius.y) {
-        radius = corner_radius.y;
-        center = vec2(size.x - radius, radius);
-    } else if (size.x - corner_radius.z < coords.x && size.y - corner_radius.z < coords.y) {
-        radius = corner_radius.z;
-        center = vec2(size.x - radius, size.y - radius);
-    } else if (coords.x < corner_radius.w && size.y - corner_radius.w < coords.y) {
-        radius = corner_radius.w;
-        center = vec2(radius, size.y - radius);
-    } else {
-        return 1.0;
-    }
-
-    float dist = distance(coords, center);
-    float half_px = 0.5 / niri_scale;
-    return 1.0 - smoothstep(radius - half_px, radius + half_px, dist);
-}
+float niri_rounding_alpha(vec2 coords, vec2 size, vec4 corner_radius);
 
 void main() {
     vec3 coords_geo = input_to_geo * vec3(niri_v_coords, 1.0);
@@ -106,7 +83,7 @@ void main() {
     float shadow_value;
     if (sigma < 0.1) {
         // With low enough sigma just draw a rounded rectangle.
-        shadow_value = rounding_alpha(coords_geo.xy, geo_size, corner_radius);
+        shadow_value = niri_rounding_alpha(coords_geo.xy, geo_size, corner_radius);
     } else {
         shadow_value = roundedBoxShadow(
             vec2(0.0, 0.0),
@@ -126,7 +103,7 @@ void main() {
     if (window_geo_size != vec2(0.0, 0.0)) {
         if (0.0 <= coords_window_geo.x && coords_window_geo.x <= window_geo_size.x
                 && 0.0 <= coords_window_geo.y && coords_window_geo.y <= window_geo_size.y) {
-            float alpha = rounding_alpha(coords_window_geo.xy, window_geo_size, window_corner_radius);
+            float alpha = niri_rounding_alpha(coords_window_geo.xy, window_geo_size, window_corner_radius);
             color = color * (1.0 - alpha);
         }
     }

--- a/src/render_helpers/snapshot.rs
+++ b/src/render_helpers/snapshot.rs
@@ -6,7 +6,8 @@ use smithay::backend::renderer::element::{Kind, RenderElement};
 use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
 use smithay::utils::{Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
-use super::{render_to_encompassing_texture, RenderTarget, ToRenderElement};
+use super::{render_to_encompassing_texture, ToRenderElement};
+use crate::render_helpers::RenderCtx;
 
 /// Snapshot of a render.
 #[derive(Debug)]
@@ -43,11 +44,10 @@ where
 {
     pub fn texture(
         &self,
-        renderer: &mut GlesRenderer,
+        ctx: RenderCtx<GlesRenderer>,
         scale: Scale<f64>,
-        target: RenderTarget,
     ) -> Option<&(GlesTexture, Rectangle<i32, Physical>)> {
-        if target.should_block_out(self.block_out_from) {
+        if ctx.target.should_block_out(self.block_out_from) {
             self.blocked_out_texture.get_or_init(|| {
                 let _span = tracy_client::span!("RenderSnapshot::texture");
 
@@ -60,7 +60,7 @@ where
                     .collect();
 
                 match render_to_encompassing_texture(
-                    renderer,
+                    ctx.renderer,
                     scale,
                     Transform::Normal,
                     Fourcc::Abgr8888,
@@ -86,7 +86,7 @@ where
                     .collect();
 
                 match render_to_encompassing_texture(
-                    renderer,
+                    ctx.renderer,
                     scale,
                     Transform::Normal,
                     Fourcc::Abgr8888,

--- a/src/render_helpers/solid_color.rs
+++ b/src/render_helpers/solid_color.rs
@@ -113,6 +113,24 @@ impl SolidColorRenderElement {
     pub fn geo(&self) -> Rectangle<f64, Logical> {
         self.geometry
     }
+
+    /// Return a copy of this element with a different geometry (physical integer rectangle).
+    ///
+    /// Used to produce pixel-exact geometry when independent rounding of `loc` and `size` in
+    /// `RescaleRenderElement` would otherwise create 1-pixel gaps at element boundaries.
+    pub fn with_geometry_physical(
+        &self,
+        geometry: Rectangle<i32, Physical>,
+        scale: Scale<f64>,
+    ) -> Self {
+        SolidColorRenderElement {
+            id: self.id.clone(),
+            geometry: geometry.to_f64().to_logical(scale),
+            commit: self.commit,
+            color: self.color,
+            kind: self.kind,
+        }
+    }
 }
 
 impl Element for SolidColorRenderElement {

--- a/src/screencasting/mod.rs
+++ b/src/screencasting/mod.rs
@@ -580,7 +580,10 @@ impl Niri {
                     output,
                     false,
                     RenderTarget::Screencast,
-                    &mut |elem| elements.push(elem.into()),
+                    &mut |elem| {
+                        let zoomed = self.zoomed_element(elem, output);
+                        elements.push(zoomed.into())
+                    },
                 );
 
                 let mut pointer_pos = Point::default();

--- a/src/screencasting/mod.rs
+++ b/src/screencasting/mod.rs
@@ -19,7 +19,7 @@ use zbus::object_server::SignalEmitter;
 use crate::dbus::mutter_screen_cast::{self, CursorMode, ScreenCastToNiri, StreamTargetId};
 use crate::niri::{CastTarget, Niri, OutputRenderElements, PointerRenderElements, State};
 use crate::niri_render_elements;
-use crate::render_helpers::RenderTarget;
+use crate::render_helpers::{RenderCtx, RenderTarget};
 use crate::utils::{get_monotonic_time, CastSessionId, CastStreamId};
 use crate::window::mapped::{MappedId, WindowCastRenderElements};
 
@@ -575,16 +575,17 @@ impl Niri {
             }
 
             if cursor_data.is_none() {
-                self.render_inner(
+                let ctx = RenderCtx {
                     renderer,
-                    output,
-                    false,
-                    RenderTarget::Screencast,
-                    &mut |elem| {
-                        let zoomed = self.zoomed_element(elem, output);
-                        elements.push(zoomed.into())
-                    },
-                );
+                    target: RenderTarget::Screencast,
+                };
+                self.render(ctx, output, false, &mut |elem| {
+                    // Apply zoom to the elements here since that's what the pointer will be
+                    // rendered on top of, and OBS will sample from the elements for the pointer
+                    // position regardless.
+                    let elem = self.zoomed_element(elem, output);
+                    elements.push(elem.into())
+                });
 
                 let mut pointer_pos = Point::default();
                 if self.pointer_visibility.is_visible() {

--- a/src/ui/screenshot_ui.rs
+++ b/src/ui/screenshot_ui.rs
@@ -14,14 +14,16 @@ use pangocairo::cairo::{self, ImageSurface};
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::input::TouchSlot;
 use smithay::backend::renderer::element::utils::{Relocate, RelocateRenderElement};
-use smithay::backend::renderer::element::Kind;
-use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
+use smithay::backend::renderer::element::{Element, Id, Kind, RenderElement, UnderlyingStorage};
+use smithay::backend::renderer::gles::{GlesError, GlesFrame, GlesRenderer, GlesTexture};
+use smithay::backend::renderer::utils::{CommitCounter, DamageSet, OpaqueRegions};
 use smithay::backend::renderer::{ExportMem, Texture as _};
 use smithay::input::keyboard::{Keysym, ModifiersState};
 use smithay::output::{Output, WeakOutput};
-use smithay::utils::{Buffer, Physical, Point, Rectangle, Scale, Size, Transform};
+use smithay::utils::{Buffer, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 
 use crate::animation::{Animation, Clock};
+use crate::backend::tty::{TtyFrame, TtyRenderer, TtyRendererError};
 use crate::layout::floating::DIRECTIONAL_MOVE_PX;
 use crate::niri_render_elements;
 use crate::render_helpers::primary_gpu_texture::PrimaryGpuTextureRenderElement;
@@ -29,6 +31,9 @@ use crate::render_helpers::solid_color::{SolidColorBuffer, SolidColorRenderEleme
 use crate::render_helpers::texture::{TextureBuffer, TextureRenderElement};
 use crate::render_helpers::{render_to_texture, RenderTarget};
 use crate::utils::to_physical_precise_round;
+use crate::zoom::{
+    zoom_subpixel_correction, zoom_transform_physical_point, zoom_wrap, ZoomWrapper,
+};
 
 const SELECTION_BORDER: i32 = 2;
 
@@ -103,10 +108,102 @@ pub struct OutputScreenshot {
     pointer: Option<PrimaryGpuTextureRenderElement>,
 }
 
+/// Generate Element + RenderElement delegation impls for marker newtypes that
+/// wrap PrimaryGpuTextureRenderElement. Follows the pattern in
+/// primary_gpu_texture.rs but delegates straight to the inner element.
+macro_rules! impl_screenshot_newtype {
+    ($($Name:ident),* $(,)?) => { $(
+        impl Element for $Name {
+            fn id(&self) -> &Id { self.0.id() }
+            fn current_commit(&self) -> CommitCounter { self.0.current_commit() }
+            fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
+                self.0.geometry(scale)
+            }
+            fn transform(&self) -> Transform { self.0.transform() }
+            fn src(&self) -> Rectangle<f64, Buffer> { self.0.src() }
+            fn damage_since(
+                &self,
+                scale: Scale<f64>,
+                commit: Option<CommitCounter>,
+            ) -> DamageSet<i32, Physical> {
+                self.0.damage_since(scale, commit)
+            }
+            fn opaque_regions(&self, scale: Scale<f64>) -> OpaqueRegions<i32, Physical> {
+                self.0.opaque_regions(scale)
+            }
+            fn alpha(&self) -> f32 { self.0.alpha() }
+            fn kind(&self) -> Kind { self.0.kind() }
+        }
+
+        impl RenderElement<GlesRenderer> for $Name {
+            fn draw(
+                &self,
+                frame: &mut GlesFrame<'_, '_>,
+                src: Rectangle<f64, Buffer>,
+                dst: Rectangle<i32, Physical>,
+                damage: &[Rectangle<i32, Physical>],
+                opaque_regions: &[Rectangle<i32, Physical>],
+            ) -> Result<(), GlesError> {
+                RenderElement::<GlesRenderer>::draw(&self.0, frame, src, dst, damage, opaque_regions)
+            }
+            fn underlying_storage(
+                &self,
+                renderer: &mut GlesRenderer,
+            ) -> Option<UnderlyingStorage<'_>> {
+                self.0.underlying_storage(renderer)
+            }
+        }
+
+        impl<'render> RenderElement<TtyRenderer<'render>> for $Name {
+            fn draw(
+                &self,
+                frame: &mut TtyFrame<'render, '_, '_>,
+                src: Rectangle<f64, Buffer>,
+                dst: Rectangle<i32, Physical>,
+                damage: &[Rectangle<i32, Physical>],
+                opaque_regions: &[Rectangle<i32, Physical>],
+            ) -> Result<(), TtyRendererError<'render>> {
+                RenderElement::<TtyRenderer>::draw(
+                    &self.0, frame, src, dst, damage, opaque_regions,
+                )
+            }
+            fn underlying_storage(
+                &self,
+                renderer: &mut TtyRenderer<'render>,
+            ) -> Option<UnderlyingStorage<'_>> {
+                self.0.underlying_storage(renderer)
+            }
+        }
+    )* };
+}
+
+/// Marker newtype for the help panel element (zoom-exempt in the main render
+/// path).
+#[derive(Debug, Clone)]
+pub struct HelpPanelElement(pub PrimaryGpuTextureRenderElement);
+
+/// Marker newtype for the screenshot pointer overlay (zoom-eligible with
+/// scale_with_zoom support).
+#[derive(Debug, Clone)]
+pub struct ScreenshotPointerElement(pub PrimaryGpuTextureRenderElement);
+
+impl_screenshot_newtype!(HelpPanelElement, ScreenshotPointerElement);
+
 niri_render_elements! {
     ScreenshotUiRenderElement => {
         Screenshot = PrimaryGpuTextureRenderElement,
         SolidColor = SolidColorRenderElement,
+        HelpPanel = HelpPanelElement,
+        Pointer = ScreenshotPointerElement,
+    }
+}
+
+// Internal render element for capture compositing. Only used in `capture()`
+// when zoom or pointer overlay requires compositing to an intermediate texture.
+niri_render_elements! {
+    CaptureRenderElement => {
+        Texture = PrimaryGpuTextureRenderElement,
+        Zoomed = ZoomWrapper<PrimaryGpuTextureRenderElement>,
     }
 }
 
@@ -127,6 +224,33 @@ impl Button {
 }
 
 impl ScreenshotUi {
+    fn capture_source_rect(
+        rect: Rectangle<i32, Physical>,
+        scale: Scale<f64>,
+        zoom_active: bool,
+        zoom_level: f64,
+        zoom_focal: Point<f64, Logical>,
+    ) -> Rectangle<i32, Physical> {
+        if !zoom_active {
+            return rect;
+        }
+
+        let correction_i32 = zoom_subpixel_correction(zoom_focal, zoom_level, scale);
+        let correction =
+            Point::<f64, Physical>::from((correction_i32.x as f64, correction_i32.y as f64));
+        let min =
+            zoom_transform_physical_point(rect.loc, zoom_level, zoom_focal, scale, correction);
+        let max = zoom_transform_physical_point(
+            rect.loc + rect.size,
+            zoom_level,
+            zoom_focal,
+            scale,
+            correction,
+        );
+
+        Rectangle::from_extremities(min, max)
+    }
+
     pub fn new(clock: Clock, config: Rc<RefCell<Config>>) -> Self {
         Self::Closed {
             last_selection: None,
@@ -645,7 +769,7 @@ impl ScreenshotUi {
         let scale = output_data.scale;
         let progress = open_anim.clamped_value().clamp(0., 1.) as f32;
 
-        // The help panel goes on top.
+        // The help panel goes on top (zoom-exempt via HelpPanelElement marker).
         if let Some((show, hide)) = &output_data.panel {
             let buffer = if *show_pointer { hide } else { show };
             let alpha = if button.is_dragging_selection() {
@@ -665,9 +789,10 @@ impl ScreenshotUi {
                 None,
                 Kind::Unspecified,
             ));
-            push(elem.into());
+            push(ScreenshotUiRenderElement::HelpPanel(HelpPanelElement(elem)));
         }
 
+        // Solid color overlays — zoomed externally by apply_zoom_to_render_element.
         for (buffer, loc) in zip(&output_data.buffers, &output_data.locations) {
             let elem = SolidColorRenderElement::from_buffer(
                 buffer,
@@ -678,7 +803,7 @@ impl ScreenshotUi {
             push(elem.into());
         }
 
-        // The screenshot itself goes last.
+        // The screenshot itself goes last — zoomed externally.
         let index = match target {
             RenderTarget::Output => 0,
             RenderTarget::Screencast => 1,
@@ -688,7 +813,9 @@ impl ScreenshotUi {
 
         if *show_pointer {
             if let Some(pointer) = screenshot.pointer.clone() {
-                push(pointer.into());
+                push(ScreenshotUiRenderElement::Pointer(
+                    ScreenshotPointerElement(pointer),
+                ));
             }
         }
         push(screenshot.buffer.clone().into());
@@ -697,6 +824,9 @@ impl ScreenshotUi {
     pub fn capture(
         &self,
         renderer: &mut GlesRenderer,
+        zoom_active: bool,
+        zoom_level: f64,
+        zoom_focal: Point<f64, Logical>,
     ) -> anyhow::Result<(Size<i32, Physical>, Vec<u8>)> {
         let _span = tracy_client::span!("ScreenshotUi::capture");
 
@@ -710,40 +840,55 @@ impl ScreenshotUi {
             panic!("screenshot UI must be open to capture");
         };
 
-        let data = &output_data[&selection.0];
+        let output = &selection.0;
+        let data = &output_data[output];
         let rect = rect_from_corner_points(selection.1, selection.2);
+        let scale = Scale::from(data.scale);
+        let source_rect =
+            Self::capture_source_rect(rect, scale, zoom_active, zoom_level, zoom_focal);
 
         let screenshot = &data.screenshot[0];
-
-        // Composite the pointer on top if needed.
         let mut tex_rect = None;
-        if *show_pointer {
-            if let Some(pointer) = screenshot.pointer.clone() {
-                let scale = pointer.0.buffer().texture_scale();
-                let offset = rect.loc.upscale(-1);
 
-                let mut elements = ArrayVec::<_, 2>::new();
-                elements.push(pointer);
-                elements.push(screenshot.buffer.clone());
-                let elements = elements.iter().rev().map(|elem| {
-                    RelocateRenderElement::from_element(elem, offset, Relocate::Relative)
-                });
+        if zoom_active || (*show_pointer && screenshot.pointer.is_some()) {
+            let output_scale = Scale::from(output.current_scale().fractional_scale());
 
-                let res = render_to_texture(
-                    renderer,
-                    rect.size,
-                    scale,
-                    Transform::Normal,
-                    Fourcc::Abgr8888,
-                    elements,
+            let mut elements = ArrayVec::<CaptureRenderElement, 2>::new();
+            if *show_pointer {
+                if let Some(pointer) = screenshot.pointer.clone() {
+                    elements.push(CaptureRenderElement::Texture(pointer));
+                }
+            }
+            if zoom_active {
+                let zoomed = zoom_wrap(
+                    screenshot.buffer.clone(),
+                    zoom_level,
+                    output_scale,
+                    zoom_focal,
                 );
-                match res {
-                    Ok((texture, _)) => {
-                        tex_rect = Some((texture, Rectangle::from_size(rect.size)));
-                    }
-                    Err(err) => {
-                        warn!("error compositing pointer onto screenshot: {err:?}");
-                    }
+                elements.push(CaptureRenderElement::Zoomed(zoomed));
+            } else {
+                elements.push(CaptureRenderElement::Texture(screenshot.buffer.clone()));
+            }
+
+            let elements = elements.iter().rev().map(|elem| {
+                RelocateRenderElement::from_element(elem, Point::from((0, 0)), Relocate::Relative)
+            });
+
+            let res = render_to_texture(
+                renderer,
+                data.size,
+                scale,
+                Transform::Normal,
+                Fourcc::Abgr8888,
+                elements,
+            );
+            match res {
+                Ok((texture, _)) => {
+                    tex_rect = Some((texture, source_rect));
+                }
+                Err(err) => {
+                    warn!("error compositing screenshot capture: {err:?}");
                 }
             }
         }

--- a/src/ui/screenshot_ui.rs
+++ b/src/ui/screenshot_ui.rs
@@ -95,6 +95,7 @@ pub struct OutputData {
     size: Size<i32, Physical>,
     scale: f64,
     transform: Transform,
+    capture_zoom: f64,
     // Output, screencast, screen capture.
     screenshot: [OutputScreenshot; 3],
     buffers: [SolidColorBuffer; 8],
@@ -104,6 +105,7 @@ pub struct OutputData {
 
 pub struct OutputScreenshot {
     texture: GlesTexture,
+    hr_texture: Option<GlesTexture>,
     buffer: PrimaryGpuTextureRenderElement,
     pointer: Option<PrimaryGpuTextureRenderElement>,
 }
@@ -262,8 +264,7 @@ impl ScreenshotUi {
     pub fn open(
         &mut self,
         renderer: &mut GlesRenderer,
-        // Output, screencast, screen capture.
-        screenshots: HashMap<Output, [OutputScreenshot; 3]>,
+        screenshots: HashMap<Output, (f64, [OutputScreenshot; 3])>,
         default_output: Output,
         show_pointer: bool,
         path: Option<String>,
@@ -309,7 +310,7 @@ impl ScreenshotUi {
 
         let output_data = screenshots
             .into_iter()
-            .map(|(output, screenshot)| {
+            .map(|(output, (capture_zoom, screenshot))| {
                 let transform = output.current_transform();
                 let output_mode = output.current_mode().unwrap();
                 let size = transform.transform_size(output_mode.size);
@@ -339,6 +340,7 @@ impl ScreenshotUi {
                     size,
                     scale,
                     transform,
+                    capture_zoom,
                     screenshot,
                     buffers,
                     locations,
@@ -844,10 +846,92 @@ impl ScreenshotUi {
         let data = &output_data[output];
         let rect = rect_from_corner_points(selection.1, selection.2);
         let scale = Scale::from(data.scale);
+
+        let screenshot = &data.screenshot[0];
+
+        if data.capture_zoom > 1.0 {
+            if let Some(hr_tex) = &screenshot.hr_texture {
+                let cz = data.capture_zoom;
+                let hr_rect: Rectangle<i32, Physical> = Rectangle::new(
+                    Point::from((
+                        (rect.loc.x as f64 * cz).round() as i32,
+                        (rect.loc.y as f64 * cz).round() as i32,
+                    )),
+                    Size::from((
+                        (rect.size.w as f64 * cz).round() as i32,
+                        (rect.size.h as f64 * cz).round() as i32,
+                    )),
+                );
+
+                let hr_size = Size::from((
+                    (data.size.w as f64 * cz).round() as i32,
+                    (data.size.h as f64 * cz).round() as i32,
+                ));
+                let hr_scale = Scale::from(scale.x * cz);
+
+                let source_tex = if *show_pointer && screenshot.pointer.is_some() {
+                    let hr_buffer =
+                        PrimaryGpuTextureRenderElement(TextureRenderElement::from_texture_buffer(
+                            TextureBuffer::from_texture(
+                                renderer,
+                                hr_tex.clone(),
+                                hr_scale,
+                                Transform::Normal,
+                                Vec::new(),
+                            ),
+                            (0., 0.),
+                            1.,
+                            None,
+                            None,
+                            Kind::Unspecified,
+                        ));
+                    let mut elements = ArrayVec::<CaptureRenderElement, 2>::new();
+                    if let Some(pointer) = screenshot.pointer.clone() {
+                        elements.push(CaptureRenderElement::Texture(pointer));
+                    }
+                    elements.push(CaptureRenderElement::Texture(hr_buffer));
+                    let elements = elements.iter().rev().map(|elem| {
+                        RelocateRenderElement::from_element(
+                            elem,
+                            Point::from((0, 0)),
+                            Relocate::Relative,
+                        )
+                    });
+                    match render_to_texture(
+                        renderer,
+                        hr_size,
+                        hr_scale,
+                        Transform::Normal,
+                        Fourcc::Abgr8888,
+                        elements,
+                    ) {
+                        Ok((tex, _)) => tex,
+                        Err(err) => {
+                            warn!("error compositing hr screenshot capture: {err:?}");
+                            hr_tex.clone()
+                        }
+                    }
+                } else {
+                    hr_tex.clone()
+                };
+
+                let buf_rect =
+                    hr_rect
+                        .to_logical(1)
+                        .to_buffer(1, Transform::Normal, &Size::from((1, 1)));
+                let mapping = renderer
+                    .copy_texture(&source_tex, buf_rect, Fourcc::Abgr8888)
+                    .context("error copying texture")?;
+                let copy = renderer
+                    .map_texture(&mapping)
+                    .context("error mapping texture")?;
+                return Ok((hr_rect.size, copy.to_vec()));
+            }
+        }
+
         let source_rect =
             Self::capture_source_rect(rect, scale, zoom_active, zoom_level, zoom_focal);
 
-        let screenshot = &data.screenshot[0];
         let mut tex_rect = None;
 
         if zoom_active || (*show_pointer && screenshot.pointer.is_some()) {
@@ -894,7 +978,6 @@ impl ScreenshotUi {
         }
 
         let (texture, rect) = tex_rect.unwrap_or_else(|| (screenshot.texture.clone(), rect));
-        // The size doesn't actually matter because we're not transforming anything.
         let buf_rect = rect
             .to_logical(1)
             .to_buffer(1, Transform::Normal, &Size::from((1, 1)));
@@ -1145,14 +1228,26 @@ impl OutputScreenshot {
     pub fn from_textures(
         renderer: &mut GlesRenderer,
         scale: Scale<f64>,
+        capture_zoom: f64,
         texture: GlesTexture,
+        hr_texture: Option<GlesTexture>,
         pointer: Option<(GlesTexture, Rectangle<i32, Physical>)>,
     ) -> Self {
+        let (buffer_tex, buffer_scale) = if capture_zoom > 1.0 {
+            if let Some(ref hr) = hr_texture {
+                (hr.clone(), Scale::from(scale.x * capture_zoom))
+            } else {
+                (texture.clone(), scale)
+            }
+        } else {
+            (texture.clone(), scale)
+        };
+
         let buffer = PrimaryGpuTextureRenderElement(TextureRenderElement::from_texture_buffer(
             TextureBuffer::from_texture(
                 renderer,
-                texture.clone(),
-                scale,
+                buffer_tex,
+                buffer_scale,
                 Transform::Normal,
                 Vec::new(),
             ),
@@ -1182,6 +1277,7 @@ impl OutputScreenshot {
 
         Self {
             texture,
+            hr_texture,
             buffer,
             pointer,
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -33,6 +33,7 @@ use wayland_backend::server::Credentials;
 
 use crate::handlers::KdeDecorationsModeState;
 use crate::niri::ClientState;
+use crate::zoom::OutputZoomState;
 
 pub mod id;
 pub mod scale;
@@ -257,10 +258,17 @@ pub fn send_scale_transform(
     data: &SurfaceData,
     scale: output::Scale,
     transform: Transform,
+    zoom_state: Option<&OutputZoomState>,
 ) {
+    let mut effective_scale = scale.fractional_scale();
+    if let Some(zoom) = zoom_state {
+        if let Some(&surface_zoom) = zoom.zoomed_surfaces.get(surface) {
+            effective_scale *= surface_zoom;
+        }
+    }
     send_surface_state(surface, data, scale.integer_scale(), transform);
     with_fractional_scale(data, |fractional| {
-        fractional.set_preferred_scale(scale.fractional_scale());
+        fractional.set_preferred_scale(effective_scale);
     });
 }
 

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -44,6 +44,7 @@ use crate::utils::{
     with_toplevel_last_uncommitted_configure, with_toplevel_role, with_toplevel_role_and_current,
     ResizeEdge,
 };
+use crate::zoom::OutputZoomState;
 
 #[derive(Debug)]
 pub struct Mapped {
@@ -825,9 +826,18 @@ impl LayoutElement for Mapped {
         self.toplevel().wl_surface() == wl_surface
     }
 
-    fn set_preferred_scale_transform(&self, scale: output::Scale, transform: Transform) {
+    fn wl_surface(&self) -> Option<WlSurface> {
+        Some(self.toplevel().wl_surface().clone())
+    }
+
+    fn set_preferred_scale_transform(
+        &self,
+        scale: output::Scale,
+        transform: Transform,
+        zoom_state: Option<&OutputZoomState>,
+    ) {
         self.window.with_surfaces(|surface, data| {
-            send_scale_transform(surface, data, scale, transform);
+            send_scale_transform(surface, data, scale, transform, zoom_state);
         });
     }
 

--- a/src/zoom.rs
+++ b/src/zoom.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use niri_config::ZoomMovementMode;
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::utils::{
@@ -5,6 +7,7 @@ use smithay::backend::renderer::element::utils::{
 };
 use smithay::backend::renderer::element::Element;
 use smithay::output::Output;
+use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::{Logical, Physical, Point, Rectangle, Scale, Size};
 
 use crate::layer::mapped::LayerSurfaceRenderElement;
@@ -53,6 +56,8 @@ niri_render_elements! {
     }
 }
 
+pub const SCALE_CHANGE_THRESHOLD: f64 = 0.25;
+
 /// Per-output zoom snapshot.
 ///
 /// This struct holds the effective zoom values that external consumers (backends,
@@ -75,6 +80,8 @@ pub struct OutputZoomState {
     pub locked: bool,
     /// Whether a zoom animation or gesture is currently in progress (layout-owned).
     pub transitioning: bool,
+    pub zoomed_surfaces: HashMap<WlSurface, f64>,
+    pub last_scale_update_level: Option<f64>,
 }
 
 impl OutputZoomState {
@@ -88,11 +95,17 @@ impl OutputZoomState {
             focal: Point::from((logical_size.w / 2.0, logical_size.h / 2.0)),
             locked: false,
             transitioning: false,
+            zoomed_surfaces: HashMap::new(),
+            last_scale_update_level: None,
         }
     }
 
     pub fn is_active(&self) -> bool {
         self.level > 1.0
+    }
+
+    pub fn get_surface_zoom_factor(&self, surface: &WlSurface) -> f64 {
+        self.zoomed_surfaces.get(surface).copied().unwrap_or(1.0)
     }
 
     pub fn viewport_global(
@@ -123,6 +136,8 @@ impl Default for OutputZoomState {
             focal: Point::from((0.0, 0.0)),
             locked: false,
             transitioning: false,
+            zoomed_surfaces: HashMap::new(),
+            last_scale_update_level: None,
         }
     }
 }
@@ -136,6 +151,23 @@ pub fn apply_zoom_viewport(
     output_rect = output_rect.downscale(zoom_factor);
     output_rect.loc += focal_point;
     output_rect
+}
+
+pub use apply_zoom_viewport as zoomed_viewport;
+
+pub fn calculate_visibility(
+    window_geo: Rectangle<f64, Logical>,
+    zoom_rect: Rectangle<f64, Logical>,
+) -> f64 {
+    let Some(intersect) = window_geo.intersection(zoom_rect) else {
+        return 0.0;
+    };
+    let intersect_area = intersect.size.w * intersect.size.h;
+    let window_area = window_geo.size.w * window_geo.size.h;
+    if window_area <= 0.0 {
+        return 0.0;
+    }
+    (intersect_area / window_area).clamp(0.0, 1.0)
 }
 
 pub fn compute_focal_for_cursor(

--- a/src/zoom.rs
+++ b/src/zoom.rs
@@ -1,0 +1,404 @@
+use niri_config::ZoomMovementMode;
+use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
+use smithay::backend::renderer::element::utils::{
+    CropRenderElement, Relocate, RelocateRenderElement, RescaleRenderElement,
+};
+use smithay::backend::renderer::element::Element;
+use smithay::output::Output;
+use smithay::utils::{Logical, Physical, Point, Rectangle, Scale, Size};
+
+use crate::layer::mapped::LayerSurfaceRenderElement;
+use crate::layout::tile::TileRenderElement;
+use crate::layout::MonitorRenderElement;
+use crate::niri::PointerRenderElements;
+use crate::niri_render_elements;
+use crate::render_helpers::primary_gpu_texture::PrimaryGpuTextureRenderElement;
+use crate::render_helpers::solid_color::SolidColorRenderElement;
+
+// Define a type alias for the common zoom wrapper: Relocate(Rescale(T))
+pub type ZoomWrapper<T> = RelocateRenderElement<RescaleRenderElement<T>>;
+
+/// Wrap an element with the standard zoom transform: Rescale around the focal
+/// point, then Relocate by the subpixel correction. This is the non-pointer
+/// path — all elements except the live cursor use this.
+pub fn zoom_wrap<E: Element>(
+    elem: E,
+    zoom_factor: f64,
+    output_scale: Scale<f64>,
+    zoom_focal: Point<f64, Logical>,
+) -> ZoomWrapper<E> {
+    let focal_physical: Point<i32, Physical> = zoom_focal.to_physical_precise_round(output_scale);
+    let correction = zoom_subpixel_correction(zoom_focal, zoom_factor, output_scale);
+    RelocateRenderElement::from_element(
+        RescaleRenderElement::from_element(elem, focal_physical, zoom_factor),
+        correction,
+        Relocate::Relative,
+    )
+}
+
+// Separate enum for all zoomed elements - this avoids type conflicts with
+// OutputRenderElements since zoomed types are wrapped in a different enum
+niri_render_elements! {
+    ZoomedRenderElements<R> => {
+        Monitor = ZoomWrapper<MonitorRenderElement<R>>,
+        RescaledTile = ZoomWrapper<RescaleRenderElement<TileRenderElement<R>>>,
+        LayerSurface = ZoomWrapper<LayerSurfaceRenderElement<R>>,
+        RelocatedLayerSurface = ZoomWrapper<CropRenderElement<ZoomWrapper<LayerSurfaceRenderElement<R>>>>,
+        RelocatedColor = ZoomWrapper<CropRenderElement<ZoomWrapper<SolidColorRenderElement>>>,
+        Pointer = ZoomWrapper<PointerRenderElements<R>>,
+        Wayland = ZoomWrapper<WaylandSurfaceRenderElement<R>>,
+        SolidColor = ZoomWrapper<SolidColorRenderElement>,
+        // ScreenshotUi = ZoomWrapper<ScreenshotUiRenderElement>,
+        Texture = ZoomWrapper<PrimaryGpuTextureRenderElement>,
+    }
+}
+
+/// Per-output zoom snapshot.
+///
+/// This struct holds the effective zoom values that external consumers (backends,
+/// input, niri rendering) read each frame. Layout writes these values every
+/// animation tick, so they always reflect the current animation/gesture state.
+///
+/// Animation and gesture tracking live in `Monitor` inside the layout module.
+///
+/// Mutable ownership boundaries:
+/// - Layout owns animated `level` / `focal` / `transitioning`.
+/// - Input owns `locked` toggling.
+#[derive(Debug, Clone)]
+pub struct OutputZoomState {
+    /// Current effective zoom level (layout-owned, updated each frame).
+    pub level: f64,
+    /// Current effective focal point in output-local logical coordinates
+    /// (layout-owned, updated each frame).
+    pub focal: Point<f64, Logical>,
+    /// Whether focal point is locked (input-owned toggle).
+    pub locked: bool,
+    /// Whether a zoom animation or gesture is currently in progress (layout-owned).
+    pub transitioning: bool,
+}
+
+impl OutputZoomState {
+    /// Create a new zoom state centered on the given output.
+    pub fn new_for_output(output: &Output) -> Self {
+        let mode_size = output.current_mode().map_or((0, 0).into(), |m| m.size);
+        let scale = output.current_scale().fractional_scale();
+        let logical_size = mode_size.to_f64().to_logical(scale);
+        Self {
+            level: 1.0,
+            focal: Point::from((logical_size.w / 2.0, logical_size.h / 2.0)),
+            locked: false,
+            transitioning: false,
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.level > 1.0
+    }
+
+    pub fn viewport_global(
+        &self,
+        output_geometry: Rectangle<f64, Logical>,
+    ) -> Rectangle<f64, Logical> {
+        let focal_global = self.focal + output_geometry.loc;
+        apply_zoom_viewport(output_geometry, focal_global, self.level)
+    }
+
+    pub fn clamp_to_viewport(
+        &self,
+        pos: Point<f64, Logical>,
+        output_geometry: Rectangle<f64, Logical>,
+    ) -> Point<f64, Logical> {
+        let vp = self.viewport_global(output_geometry);
+        Point::from((
+            pos.x.clamp(vp.loc.x, vp.loc.x + vp.size.w - f64::EPSILON),
+            pos.y.clamp(vp.loc.y, vp.loc.y + vp.size.h - f64::EPSILON),
+        ))
+    }
+}
+
+impl Default for OutputZoomState {
+    fn default() -> Self {
+        Self {
+            level: 1.0,
+            focal: Point::from((0.0, 0.0)),
+            locked: false,
+            transitioning: false,
+        }
+    }
+}
+
+pub fn apply_zoom_viewport(
+    mut output_rect: Rectangle<f64, Logical>,
+    focal_point: Point<f64, Logical>,
+    zoom_factor: f64,
+) -> Rectangle<f64, Logical> {
+    output_rect.loc -= focal_point;
+    output_rect = output_rect.downscale(zoom_factor);
+    output_rect.loc += focal_point;
+    output_rect
+}
+
+pub fn compute_focal_for_cursor(
+    cursor_local: Point<f64, Logical>,
+    zoom_level: f64,
+    output_size: Size<f64, Logical>,
+    movement_mode: &ZoomMovementMode,
+) -> Point<f64, Logical> {
+    if zoom_level <= 1.0 {
+        return cursor_local;
+    }
+
+    match movement_mode {
+        ZoomMovementMode::CursorFollow => cursor_local,
+        ZoomMovementMode::Centered | ZoomMovementMode::OnEdge => {
+            let viewport_size = output_size.downscale(zoom_level);
+            let viewport_loc = cursor_local - viewport_size.downscale(2.0).to_point();
+            let scale_factor = zoom_level / (zoom_level - 1.0).max(0.001);
+            let mut focal =
+                Point::from((viewport_loc.x * scale_factor, viewport_loc.y * scale_factor));
+            focal.x = focal.x.clamp(0.0, output_size.w - f64::EPSILON);
+            focal.y = focal.y.clamp(0.0, output_size.h - f64::EPSILON);
+            focal
+        }
+    }
+}
+
+pub fn compute_zoom_base_focal_update(
+    output: &Output,
+    output_geometry: Rectangle<f64, Logical>,
+    cursor_position: Point<f64, Logical>,
+    old_pos_global: Option<Point<f64, Logical>>,
+    focal_point: Point<f64, Logical>,
+    zoom_factor: f64,
+    movement_mode: &ZoomMovementMode,
+) -> Option<Point<f64, Logical>> {
+    match movement_mode {
+        ZoomMovementMode::CursorFollow => Some(cursor_position),
+        ZoomMovementMode::Centered => Some(compute_focal_for_cursor(
+            cursor_position,
+            zoom_factor,
+            output_geometry.size,
+            &ZoomMovementMode::Centered,
+        )),
+        ZoomMovementMode::OnEdge => compute_on_edge_zoom_update(
+            output,
+            output_geometry,
+            cursor_position,
+            old_pos_global,
+            focal_point,
+            zoom_factor,
+        ),
+    }
+}
+
+fn compute_on_edge_zoom_update(
+    output: &Output,
+    output_geometry: Rectangle<f64, Logical>,
+    cursor_position: Point<f64, Logical>,
+    old_pos_global: Option<Point<f64, Logical>>,
+    focal_point: Point<f64, Logical>,
+    zoom_factor: f64,
+) -> Option<Point<f64, Logical>> {
+    let recentered = || {
+        Some(compute_focal_for_cursor(
+            cursor_position,
+            zoom_factor,
+            output_geometry.size,
+            &ZoomMovementMode::Centered,
+        ))
+    };
+
+    let Some(old_pos) = old_pos_global else {
+        return recentered();
+    };
+
+    let focal_global = focal_point + output_geometry.loc;
+    let zoomed_geometry_global = apply_zoom_viewport(output_geometry, focal_global, zoom_factor);
+
+    let jump_threshold = (16.0 * output.current_scale().fractional_scale()) / zoom_factor;
+    let jump_detect_size: Size<f64, Logical> = (jump_threshold, jump_threshold).into();
+    let original_rect = Rectangle::new(
+        old_pos - jump_detect_size.downscale(2.0).to_point(),
+        jump_detect_size,
+    );
+
+    if !zoomed_geometry_global.overlaps_or_touches(original_rect) {
+        return recentered();
+    }
+
+    if zoomed_geometry_global.contains(cursor_position + output_geometry.loc) {
+        return None;
+    }
+
+    let scale = zoom_factor / (zoom_factor - 1.0);
+    let viewport_size = output_geometry.size.downscale(zoom_factor);
+    let output_rect = Rectangle::from_size(output_geometry.size);
+    let zoomed_geometry_local = apply_zoom_viewport(output_rect, focal_point, zoom_factor);
+
+    let mut new_focal = focal_point;
+    let vp_left = zoomed_geometry_local.loc.x;
+    let vp_right = vp_left + zoomed_geometry_local.size.w;
+    let vp_top = zoomed_geometry_local.loc.y;
+    let vp_bottom = vp_top + zoomed_geometry_local.size.h;
+
+    if cursor_position.x < vp_left {
+        new_focal.x = cursor_position.x * scale;
+    } else if cursor_position.x > vp_right {
+        new_focal.x = (cursor_position.x - viewport_size.w) * scale;
+    }
+
+    if cursor_position.y < vp_top {
+        new_focal.y = cursor_position.y * scale;
+    } else if cursor_position.y > vp_bottom {
+        new_focal.y = (cursor_position.y - viewport_size.h) * scale;
+    }
+
+    new_focal.x = new_focal
+        .x
+        .clamp(0.0, output_geometry.size.w - f64::EPSILON);
+    new_focal.y = new_focal
+        .y
+        .clamp(0.0, output_geometry.size.h - f64::EPSILON);
+
+    Some(new_focal)
+}
+
+pub fn zoom_display_cursor_logical(
+    pointer_local: Point<f64, Logical>,
+    output_size: Size<f64, Logical>,
+    zoom_level: f64,
+    zoom_focal: Point<f64, Logical>,
+) -> Point<f64, Logical> {
+    if zoom_level <= 1.0 {
+        return pointer_local;
+    }
+
+    let output_rect = Rectangle::from_size(output_size);
+    let viewport = apply_zoom_viewport(output_rect, zoom_focal, zoom_level);
+    Point::from((
+        pointer_local.x.clamp(
+            viewport.loc.x,
+            viewport.loc.x + viewport.size.w - f64::EPSILON,
+        ),
+        pointer_local.y.clamp(
+            viewport.loc.y,
+            viewport.loc.y + viewport.size.h - f64::EPSILON,
+        ),
+    ))
+}
+
+pub(crate) fn compute_on_edge_cursor_anchor(
+    cursor_local: Point<f64, Logical>,
+    zoom_level: f64,
+    focal: Point<f64, Logical>,
+    output_size: Size<f64, Logical>,
+) -> (f64, f64) {
+    let output_rect: Rectangle<f64, Logical> = Rectangle::from_size(output_size);
+    let viewport = apply_zoom_viewport(output_rect, focal, zoom_level);
+
+    let anchor_x = if viewport.size.w.abs() < f64::EPSILON {
+        0.5
+    } else {
+        ((cursor_local.x - viewport.loc.x) / viewport.size.w).clamp(0.0, 1.0)
+    };
+    let anchor_y = if viewport.size.h.abs() < f64::EPSILON {
+        0.5
+    } else {
+        ((cursor_local.y - viewport.loc.y) / viewport.size.h).clamp(0.0, 1.0)
+    };
+
+    (anchor_x, anchor_y)
+}
+
+pub(crate) fn compute_focal_for_on_edge_anchor(
+    cursor_local: Point<f64, Logical>,
+    zoom_level: f64,
+    output_size: Size<f64, Logical>,
+    cursor_anchor: (f64, f64),
+) -> Point<f64, Logical> {
+    if zoom_level <= 1.0 {
+        return cursor_local;
+    }
+
+    let viewport_size = output_size.downscale(zoom_level);
+    let viewport_loc: Point<f64, Logical> = Point::from((
+        cursor_local.x - viewport_size.w * cursor_anchor.0,
+        cursor_local.y - viewport_size.h * cursor_anchor.1,
+    ));
+    let scale_factor = zoom_level / (zoom_level - 1.0).max(0.001);
+
+    let mut focal = Point::from((viewport_loc.x * scale_factor, viewport_loc.y * scale_factor));
+    focal.x = focal.x.clamp(0.0, output_size.w - f64::EPSILON);
+    focal.y = focal.y.clamp(0.0, output_size.h - f64::EPSILON);
+    focal
+}
+
+pub fn zoom_subpixel_correction(
+    zoom_focal: Point<f64, Logical>,
+    zoom_level: f64,
+    output_scale: Scale<f64>,
+) -> Point<i32, Physical> {
+    let focal_i32: Point<i32, Physical> = zoom_focal.to_physical_precise_round(output_scale);
+    let focal_f64 = zoom_focal.to_physical(output_scale);
+    Point::from((
+        ((focal_i32.x as f64 - focal_f64.x) * (zoom_level - 1.0)).round() as i32,
+        ((focal_i32.y as f64 - focal_f64.y) * (zoom_level - 1.0)).round() as i32,
+    ))
+}
+
+pub fn zoom_transform_physical_point(
+    point: Point<i32, Physical>,
+    zoom_level: f64,
+    zoom_focal: Point<f64, Logical>,
+    output_scale: Scale<f64>,
+    correction: Point<f64, Physical>,
+) -> Point<i32, Physical> {
+    let focal: Point<i32, Physical> = zoom_focal.to_physical_precise_round(output_scale);
+    let p = point.to_f64();
+    let rounded = Point::<f64, Physical>::from((
+        p.x * zoom_level - focal.x as f64 * (zoom_level - 1.0),
+        p.y * zoom_level - focal.y as f64 * (zoom_level - 1.0),
+    ))
+    .to_i32_round::<i32>();
+    Point::from((
+        rounded.x + correction.x as i32,
+        rounded.y + correction.y as i32,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use niri_config::ZoomMovementMode;
+
+    use super::*;
+
+    #[test]
+    fn compute_focal_for_cursor_cursor_follow_returns_cursor() {
+        let cursor = Point::from((120.0, 45.0));
+        let output_size = Size::from((1920.0, 1080.0));
+        let focal =
+            compute_focal_for_cursor(cursor, 2.0, output_size, &ZoomMovementMode::CursorFollow);
+        assert_eq!(focal, cursor);
+    }
+
+    #[test]
+    fn compute_focal_for_cursor_on_edge_anchor_roundtrip() {
+        let cursor = Point::from((800.0, 450.0));
+        let focal = Point::from((900.0, 500.0));
+        let size = Size::from((1920.0, 1080.0));
+        let zoom = 2.5;
+
+        let anchor = compute_on_edge_cursor_anchor(cursor, zoom, focal, size);
+        let focal2 = compute_focal_for_on_edge_anchor(cursor, zoom, size, anchor);
+
+        assert!((focal.x - focal2.x).abs() < 1.0);
+        assert!((focal.y - focal2.y).abs() < 1.0);
+    }
+
+    #[test]
+    fn zoom_subpixel_correction_is_zero_at_unity_zoom() {
+        let correction =
+            zoom_subpixel_correction(Point::from((100.25, 200.75)), 1.0, Scale::from(1.5));
+        assert_eq!(correction, Point::from((0, 0)));
+    }
+}


### PR DESCRIPTION
This is the version of #3246 that uses fractional scale to achieve crisper and higher resolution display when zooming. It basically just makes the output scale value received by apps in the zoomed viewport a factor/multiple of the current zoom level.

It has the following config parameters:
```kdl
zoom {
          use_fractional_scale: false,
          max_fractional_scale: 5.0,
          scale_sensitivity: 1.0,
}
```

`scale_sensitivity` determines how strongly the scale is affected by zoom level. `max_fractional_scale` clamps the scale sent to applications, since it going too high can cause memory problems.

It's pretty jank, since it is likely to cause window resizes when zooming depending on how applications handle changes to output scale. Suggestions to better handle this would be appreciated.