### PR TITLE
Docs: document reverse switching functionality introduced in #1670

### DIFF
--- a/docs/wiki/Configuration:-Layout.md
+++ b/docs/wiki/Configuration:-Layout.md
@@ -177,6 +177,7 @@ layout {
 ### `preset-column-widths`
 
 Set the widths that the `switch-preset-column-width` action (Mod+R) toggles between.
+<sup>Since: 25.08</sup> Use `switch-preset-column-width-back` action (Unbound) to toggle in reverse.
 
 `proportion` sets the width as a fraction of the output width, taking gaps into account.
 For example, you can perfectly fit four windows sized `proportion 0.25` on an output, regardless of the gaps setting.
@@ -229,6 +230,8 @@ layout {
 <sup>Since: 0.1.9</sup>
 
 Set the heights that the `switch-preset-window-height` action (Mod+Shift+R) toggles between.
+<sup>Since: 25.08</sup> Use `switch-preset-window-height-back` action (Unbound) to toggle in reverse.
+
 
 `proportion` sets the height as a fraction of the output height, taking gaps into account.
 The default preset heights are <sup>1</sup>&frasl;<sub>3</sub>, <sup>1</sup>&frasl;<sub>2</sub> and <sup>2</sup>&frasl;<sub>3</sub> of the output.

--- a/docs/wiki/Configuration:-Layout.md
+++ b/docs/wiki/Configuration:-Layout.md
@@ -230,8 +230,7 @@ layout {
 <sup>Since: 0.1.9</sup>
 
 Set the heights that the `switch-preset-window-height` action (Mod+Shift+R) toggles between.
-<sup>Since: 25.08</sup> Use `switch-preset-window-height-back` action (Unbound) to toggle in reverse.
-
+<sup>Since: 25.08</sup> You can use the `switch-preset-column-width-back` action (not bound by default) to toggle in reverse.
 
 `proportion` sets the height as a fraction of the output height, taking gaps into account.
 The default preset heights are <sup>1</sup>&frasl;<sub>3</sub>, <sup>1</sup>&frasl;<sub>2</sub> and <sup>2</sup>&frasl;<sub>3</sub> of the output.

--- a/docs/wiki/Configuration:-Layout.md
+++ b/docs/wiki/Configuration:-Layout.md
@@ -177,7 +177,7 @@ layout {
 ### `preset-column-widths`
 
 Set the widths that the `switch-preset-column-width` action (Mod+R) toggles between.
-<sup>Since: 25.08</sup> Use `switch-preset-column-width-back` action (Unbound) to toggle in reverse.
+<sup>Since: 25.08</sup> You can use the `switch-preset-column-width-back` action (not bound by default) to toggle in reverse.
 
 `proportion` sets the width as a fraction of the output width, taking gaps into account.
 For example, you can perfectly fit four windows sized `proportion 0.25` on an output, regardless of the gaps setting.


### PR DESCRIPTION
Toggling in reverse through preset widths & heights was added in #1670.

However, it's really difficult to find in the docs. The sole exception is [a comment in the default config.kdl](https://github.com/niri-wm/niri/blob/d1a0380eed224363749f1704ca3ff2ab1690b7f2/resources/default-config.kdl#L553-L555), but that only documents one of the new settings (width).

I had to open up `bindings.rs` on github source code to even find the right setting for the other. This information should be available in the docs or config somewhere.

## Alternatives Considered

I considered documenting the preset-toggling functionality, including reverse toggling, in `bindings` wiki, but then the original (non-reversed) toggling would be documented in multiple places. More importantly, bindings seems to be a guide on how to set bindings, not what actions are available for use with bindings.