### PR TITLE
Add spawn-at-position overlay for directional window placement

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -110,6 +110,8 @@ pub enum Action {
     DebugToggleDamage,
     Spawn(#[knuffel(arguments)] Vec<String>),
     SpawnSh(#[knuffel(argument)] String),
+    SpawnAtPosition(#[knuffel(arguments)] Vec<String>),
+    SpawnShAtPosition(#[knuffel(argument)] String),
     DoScreenTransition(#[knuffel(property(name = "delay-ms"))] Option<u16>),
     #[knuffel(skip)]
     ConfirmScreenshot {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -76,6 +76,7 @@ pub struct Config {
     pub screenshot_path: ScreenshotPath,
     pub clipboard: Clipboard,
     pub hotkey_overlay: HotkeyOverlay,
+    pub spawn_overlay: SpawnOverlay,
     pub config_notification: ConfigNotification,
     pub animations: Animations,
     pub gestures: Gestures,
@@ -192,6 +193,7 @@ where
                 "cursor" => m_merge!(cursor),
                 "clipboard" => m_merge!(clipboard),
                 "hotkey-overlay" => m_merge!(hotkey_overlay),
+                "spawn-overlay" => m_merge!(spawn_overlay),
                 "config-notification" => m_merge!(config_notification),
                 "animations" => m_merge!(animations),
                 "gestures" => m_merge!(gestures),
@@ -1472,6 +1474,9 @@ mod tests {
             hotkey_overlay: HotkeyOverlay {
                 skip_at_startup: true,
                 hide_not_bound: false,
+            },
+            spawn_overlay: SpawnOverlay {
+                enable: false,
             },
             config_notification: ConfigNotification {
                 disable_failed: false,

--- a/niri-config/src/misc.rs
+++ b/niri-config/src/misc.rs
@@ -65,6 +65,23 @@ impl Default for ScreenshotPath {
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SpawnOverlay {
+    pub enable: bool,
+}
+
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SpawnOverlayPart {
+    #[knuffel(child)]
+    pub enable: Option<Flag>,
+}
+
+impl MergeWith<SpawnOverlayPart> for SpawnOverlay {
+    fn merge_with(&mut self, part: &SpawnOverlayPart) {
+        merge!((self, part), enable);
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct HotkeyOverlay {
     pub skip_at_startup: bool,
     pub hide_not_bound: bool,

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -219,6 +219,34 @@ impl CompositorHandler for State {
                     );
                     let output = output.cloned();
 
+                    // If a spawn position was requested, rearrange the newly added window.
+                    if let Some(direction) = self.niri.pending_spawn_position.take() {
+                        use crate::ui::spawn_overlay::SpawnDirection;
+                        // Close the overlay now that the window has been placed.
+                        self.niri.spawn_overlay.close();
+
+                        match direction {
+                            SpawnDirection::Left => {
+                                // Window was added as a new column to the right.
+                                // Move it to the left of where it was.
+                                self.niri.layout.move_left();
+                            }
+                            SpawnDirection::Right => {
+                                // Default behavior: new column to the right. Nothing extra.
+                            }
+                            SpawnDirection::Up | SpawnDirection::Down => {
+                                // Window was added as a new column to the right.
+                                // Consume it into the column on its left (the previously
+                                // focused column), which stacks it vertically.
+                                self.niri.layout.consume_or_expel_window_left(None);
+                                if direction == SpawnDirection::Up {
+                                    // It was added at the bottom; move it up.
+                                    self.niri.layout.move_up();
+                                }
+                            }
+                        }
+                    }
+
                     // The window state cannot contain Fullscreen and Maximized at once. Therefore,
                     // if the window ended up fullscreen, then we only know that it is also
                     // maximized from the is_pending_maximized variable. Tell the layout about it

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -476,6 +476,43 @@ impl State {
                     return FilterResult::Intercept(None);
                 }
 
+                // Handle spawn overlay input.
+                if this.niri.spawn_overlay.is_open() && pressed {
+                    use crate::ui::spawn_overlay::{SpawnCommand, SpawnDirection};
+
+                    let direction = match raw {
+                        Some(Keysym::Left) => Some(SpawnDirection::Left),
+                        Some(Keysym::Right) => Some(SpawnDirection::Right),
+                        Some(Keysym::Up) => Some(SpawnDirection::Up),
+                        Some(Keysym::Down) => Some(SpawnDirection::Down),
+                        Some(Keysym::h) => Some(SpawnDirection::Left),
+                        Some(Keysym::l) => Some(SpawnDirection::Right),
+                        Some(Keysym::k) => Some(SpawnDirection::Up),
+                        Some(Keysym::j) => Some(SpawnDirection::Down),
+                        _ => None,
+                    };
+
+                    if let Some(dir) = direction {
+                        this.niri.pending_spawn_position = Some(dir);
+                        if let Some(cmd) = this.niri.spawn_overlay.take_command() {
+                            let (token, _) =
+                                this.niri.activation_state.create_external_token(None);
+                            match cmd {
+                                SpawnCommand::Args(args) => spawn(args, Some(token.clone())),
+                                SpawnCommand::Shell(sh) => spawn_sh(sh, Some(token.clone())),
+                            }
+                        }
+                    } else if raw == Some(Keysym::Escape) {
+                        this.niri.spawn_overlay.close();
+                    } else {
+                        // Ignore other keys but don't forward them.
+                    }
+
+                    this.niri.queue_redraw_all();
+                    this.niri.suppressed_keys.insert(key_code);
+                    return FilterResult::Intercept(None);
+                }
+
                 // Check if all modifiers were released while the MRU UI was open. If so, close the
                 // UI (which will also transfer the focus to the current MRU UI selection).
                 if this.niri.window_mru_ui.is_open() && !pressed && modifiers.is_empty() {
@@ -699,6 +736,31 @@ impl State {
             Action::SpawnSh(command) => {
                 let (token, _) = self.niri.activation_state.create_external_token(None);
                 spawn_sh(command, Some(token.clone()));
+            }
+            Action::SpawnAtPosition(command) => {
+                if self.niri.config.borrow().spawn_overlay.enable {
+                    use crate::ui::spawn_overlay::SpawnCommand;
+                    self.niri
+                        .spawn_overlay
+                        .open(SpawnCommand::Args(command.clone()));
+                    self.niri.queue_redraw_all();
+                } else {
+                    // If overlay is not enabled, just spawn normally.
+                    let (token, _) = self.niri.activation_state.create_external_token(None);
+                    spawn(command, Some(token.clone()));
+                }
+            }
+            Action::SpawnShAtPosition(command) => {
+                if self.niri.config.borrow().spawn_overlay.enable {
+                    use crate::ui::spawn_overlay::SpawnCommand;
+                    self.niri
+                        .spawn_overlay
+                        .open(SpawnCommand::Shell(command.clone()));
+                    self.niri.queue_redraw_all();
+                } else {
+                    let (token, _) = self.niri.activation_state.create_external_token(None);
+                    spawn_sh(command, Some(token.clone()));
+                }
             }
             Action::DoScreenTransition(delay_ms) => {
                 self.backend.with_primary_renderer(|renderer| {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -164,6 +164,7 @@ use crate::ui::config_error_notification::ConfigErrorNotification;
 use crate::ui::exit_confirm_dialog::{ExitConfirmDialog, ExitConfirmDialogRenderElement};
 use crate::ui::hotkey_overlay::HotkeyOverlay;
 use crate::ui::mru::{MruCloseRequest, WindowMruUi, WindowMruUiRenderElement};
+use crate::ui::spawn_overlay::{SpawnDirection, SpawnOverlay};
 use crate::ui::screen_transition::{self, ScreenTransition};
 use crate::ui::screenshot_ui::{OutputScreenshot, ScreenshotUi, ScreenshotUiRenderElement};
 use crate::utils::scale::{closest_representable_scale, guess_monitor_scale};
@@ -381,6 +382,8 @@ pub struct Niri {
     pub screenshot_ui: ScreenshotUi,
     pub config_error_notification: ConfigErrorNotification,
     pub hotkey_overlay: HotkeyOverlay,
+    pub spawn_overlay: SpawnOverlay,
+    pub pending_spawn_position: Option<SpawnDirection>,
     pub exit_confirm_dialog: ExitConfirmDialog,
 
     pub window_mru_ui: WindowMruUi,
@@ -510,6 +513,7 @@ pub enum KeyboardFocus {
     LayerShell { surface: WlSurface },
     LockScreen { surface: Option<WlSurface> },
     ScreenshotUi,
+    SpawnOverlay,
     ExitConfirmDialog,
     Overview,
     Mru,
@@ -659,6 +663,7 @@ impl KeyboardFocus {
             KeyboardFocus::LayerShell { surface } => Some(surface),
             KeyboardFocus::LockScreen { surface } => surface.as_ref(),
             KeyboardFocus::ScreenshotUi => None,
+            KeyboardFocus::SpawnOverlay => None,
             KeyboardFocus::ExitConfirmDialog => None,
             KeyboardFocus::Overview => None,
             KeyboardFocus::Mru => None,
@@ -671,6 +676,7 @@ impl KeyboardFocus {
             KeyboardFocus::LayerShell { surface } => Some(surface),
             KeyboardFocus::LockScreen { surface } => surface,
             KeyboardFocus::ScreenshotUi => None,
+            KeyboardFocus::SpawnOverlay => None,
             KeyboardFocus::ExitConfirmDialog => None,
             KeyboardFocus::Overview => None,
             KeyboardFocus::Mru => None,
@@ -1135,6 +1141,8 @@ impl State {
             }
         } else if self.niri.screenshot_ui.is_open() {
             KeyboardFocus::ScreenshotUi
+        } else if self.niri.spawn_overlay.is_open() {
+            KeyboardFocus::SpawnOverlay
         } else if self.niri.window_mru_ui.is_open() {
             KeyboardFocus::Mru
         } else if let Some(output) = self.niri.layout.active_output() {
@@ -1518,6 +1526,10 @@ impl State {
             self.niri.mods_with_wheel_binds = mods_with_wheel_binds(new_mod_key, &config.binds);
             self.niri.mods_with_finger_scroll_binds =
                 mods_with_finger_scroll_binds(new_mod_key, &config.binds);
+        }
+
+        if config.layout != old_config.layout {
+            self.niri.spawn_overlay.on_config_updated();
         }
 
         if config.window_rules != old_config.window_rules {
@@ -2353,6 +2365,8 @@ impl Niri {
             hotkey_overlay.show();
         }
 
+        let spawn_overlay = SpawnOverlay::new(config.clone());
+
         let exit_confirm_dialog = ExitConfirmDialog::new(animation_clock.clone(), config.clone());
 
         #[cfg(feature = "dbus")]
@@ -2534,6 +2548,8 @@ impl Niri {
             screenshot_ui,
             config_error_notification,
             hotkey_overlay,
+            spawn_overlay,
+            pending_spawn_position: None,
             exit_confirm_dialog,
 
             window_mru_ui,
@@ -3899,6 +3915,7 @@ impl Niri {
             // layer-shell, the layout will briefly draw as active, despite never having focus.
             KeyboardFocus::LockScreen { .. } => true,
             KeyboardFocus::ScreenshotUi => true,
+            KeyboardFocus::SpawnOverlay => true,
             KeyboardFocus::ExitConfirmDialog => true,
             KeyboardFocus::Overview => true,
             KeyboardFocus::Mru => true,
@@ -4137,6 +4154,11 @@ impl Niri {
 
         // Draw the hotkey overlay on top.
         if let Some(element) = self.hotkey_overlay.render(renderer, output) {
+            push(element.into());
+        }
+
+        // Draw the spawn position overlay.
+        for element in self.spawn_overlay.render(renderer, output) {
             push(element.into());
         }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,3 +4,4 @@ pub mod hotkey_overlay;
 pub mod mru;
 pub mod screen_transition;
 pub mod screenshot_ui;
+pub mod spawn_overlay;

--- a/src/ui/spawn_overlay.rs
+++ b/src/ui/spawn_overlay.rs
@@ -1,0 +1,401 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use niri_config::Config;
+use pangocairo::cairo::{self, ImageSurface};
+use pangocairo::pango::{AttrInt, AttrList, FontDescription, Weight};
+use smithay::backend::renderer::element::Kind;
+use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
+use smithay::output::{Output, WeakOutput};
+use smithay::reexports::gbm::Format as Fourcc;
+use smithay::utils::{Logical, Point, Transform};
+
+use crate::render_helpers::primary_gpu_texture::PrimaryGpuTextureRenderElement;
+use crate::render_helpers::renderer::NiriRenderer;
+use crate::render_helpers::texture::{TextureBuffer, TextureRenderElement};
+use crate::utils::{output_size, to_physical_precise_round};
+
+const ARROW_SIZE: i32 = 64;
+const ARROW_MARGIN: i32 = 48;
+const ARROW_OPACITY: f32 = 0.85;
+const LABEL_FONT: &str = "sans 11px";
+const LABEL_OFFSET: i32 = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpawnDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+#[derive(Debug, Clone)]
+pub enum SpawnCommand {
+    Args(Vec<String>),
+    Shell(String),
+}
+
+pub struct SpawnOverlay {
+    is_open: bool,
+    command: Option<SpawnCommand>,
+    config: Rc<RefCell<Config>>,
+    buffers: RefCell<HashMap<WeakOutput, RenderedArrows>>,
+}
+
+struct RenderedArrows {
+    // One texture per arrow: [left, right, up, down]
+    arrows: [Option<TextureBuffer<GlesTexture>>; 4],
+    scale: f64,
+}
+
+impl SpawnOverlay {
+    pub fn new(config: Rc<RefCell<Config>>) -> Self {
+        Self {
+            is_open: false,
+            command: None,
+            config,
+            buffers: RefCell::new(HashMap::new()),
+        }
+    }
+
+    pub fn open(&mut self, command: SpawnCommand) -> bool {
+        if !self.is_open {
+            self.is_open = true;
+            self.command = Some(command);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn close(&mut self) -> Option<SpawnCommand> {
+        if self.is_open {
+            self.is_open = false;
+            self.command.take()
+        } else {
+            None
+        }
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.is_open
+    }
+
+    pub fn take_command(&mut self) -> Option<SpawnCommand> {
+        self.is_open = false;
+        self.command.take()
+    }
+
+    pub fn on_config_updated(&mut self) {
+        self.buffers.borrow_mut().clear();
+    }
+
+    pub fn render<R: NiriRenderer>(
+        &self,
+        renderer: &mut R,
+        output: &Output,
+    ) -> Vec<PrimaryGpuTextureRenderElement> {
+        if !self.is_open {
+            return vec![];
+        }
+
+        let scale = output.current_scale().fractional_scale();
+        let output_sz = output_size(output);
+
+        let mut buffers = self.buffers.borrow_mut();
+        buffers.retain(|output, _| output.is_alive());
+
+        let weak = output.downgrade();
+        if let Some(rendered) = buffers.get(&weak) {
+            if rendered.scale != scale {
+                buffers.remove(&weak);
+            }
+        }
+
+        let config = self.config.borrow();
+        let rendered = buffers.entry(weak).or_insert_with(|| {
+            let gles = renderer.as_gles_renderer();
+            render_arrows(gles, &config, scale).unwrap_or_else(|err| {
+                warn!("error rendering spawn overlay arrows: {err:?}");
+                RenderedArrows {
+                    arrows: [None, None, None, None],
+                    scale,
+                }
+            })
+        });
+
+        let mut elements = Vec::new();
+
+        // Position each arrow at a screen edge, centered on the opposite axis.
+        let arrow_logical = ARROW_SIZE as f64;
+        let margin_logical = ARROW_MARGIN as f64;
+
+        let positions: [Point<f64, Logical>; 4] = [
+            // Left: left edge, vertically centered
+            Point::from((margin_logical, (output_sz.h - arrow_logical) / 2.)),
+            // Right: right edge, vertically centered
+            Point::from((
+                output_sz.w - arrow_logical - margin_logical,
+                (output_sz.h - arrow_logical) / 2.,
+            )),
+            // Up: top edge, horizontally centered
+            Point::from(((output_sz.w - arrow_logical) / 2., margin_logical)),
+            // Down: bottom edge, horizontally centered
+            Point::from((
+                (output_sz.w - arrow_logical) / 2.,
+                output_sz.h - arrow_logical - margin_logical,
+            )),
+        ];
+
+        for (i, pos) in positions.iter().enumerate() {
+            if let Some(buffer) = &rendered.arrows[i] {
+                let location = pos.to_physical_precise_round(scale).to_logical(scale);
+                let elem = TextureRenderElement::from_texture_buffer(
+                    buffer.clone(),
+                    location,
+                    ARROW_OPACITY,
+                    None,
+                    None,
+                    Kind::Unspecified,
+                );
+                elements.push(PrimaryGpuTextureRenderElement(elem));
+            }
+        }
+
+        elements
+    }
+}
+
+fn render_arrows(
+    renderer: &mut GlesRenderer,
+    config: &Config,
+    scale: f64,
+) -> anyhow::Result<RenderedArrows> {
+    let _span = tracy_client::span!("spawn_overlay::render_arrows");
+
+    // Use active color from border (if enabled) or focus ring for theme compliance.
+    let color = if !config.layout.border.off {
+        config.layout.border.active_color
+    } else {
+        config.layout.focus_ring.active_color
+    };
+
+    let r = color.r as f64;
+    let g = color.g as f64;
+    let b = color.b as f64;
+    let a = color.a as f64;
+
+    let size: i32 = to_physical_precise_round(scale, ARROW_SIZE);
+
+    let labels = ["New Column\nLeft", "New Column\nRight", "Above in\nColumn", "Below in\nColumn"];
+
+    let arrows = [
+        render_single_arrow(renderer, size, scale, r, g, b, a, ArrowDir::Left, labels[0])?,
+        render_single_arrow(renderer, size, scale, r, g, b, a, ArrowDir::Right, labels[1])?,
+        render_single_arrow(renderer, size, scale, r, g, b, a, ArrowDir::Up, labels[2])?,
+        render_single_arrow(renderer, size, scale, r, g, b, a, ArrowDir::Down, labels[3])?,
+    ];
+
+    Ok(RenderedArrows {
+        arrows: arrows.map(Some),
+        scale,
+    })
+}
+
+#[derive(Clone, Copy)]
+enum ArrowDir {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+fn render_single_arrow(
+    renderer: &mut GlesRenderer,
+    size: i32,
+    scale: f64,
+    r: f64,
+    g: f64,
+    b: f64,
+    a: f64,
+    direction: ArrowDir,
+    label: &str,
+) -> anyhow::Result<TextureBuffer<GlesTexture>> {
+    // Measure the label text first so we can size the surface accordingly.
+    let mut font = FontDescription::from_string(LABEL_FONT);
+    font.set_absolute_size(to_physical_precise_round(scale, font.size()));
+
+    let measure_surface = ImageSurface::create(cairo::Format::ARgb32, 0, 0)?;
+    let measure_cr = cairo::Context::new(&measure_surface)?;
+    let measure_layout = pangocairo::functions::create_layout(&measure_cr);
+    measure_layout.context().set_round_glyph_positions(false);
+    measure_layout.set_font_description(Some(&font));
+
+    let bold = AttrList::new();
+    bold.insert(AttrInt::new_weight(Weight::Bold));
+    measure_layout.set_attributes(Some(&bold));
+    measure_layout.set_alignment(pangocairo::pango::Alignment::Center);
+    measure_layout.set_text(label);
+    let (label_w, label_h) = measure_layout.pixel_size();
+    drop(measure_cr);
+
+    let label_offset: i32 = to_physical_precise_round(scale, LABEL_OFFSET);
+
+    // Compute total surface size: arrow + gap + label
+    let total_w;
+    let total_h;
+    let arrow_x;
+    let arrow_y;
+    let label_x;
+    let label_y;
+
+    match direction {
+        ArrowDir::Left | ArrowDir::Right => {
+            total_w = size + label_offset + label_w;
+            total_h = size.max(label_h);
+            arrow_y = (total_h - size) / 2;
+            label_y = (total_h - label_h) / 2;
+            if matches!(direction, ArrowDir::Left) {
+                arrow_x = 0;
+                label_x = size + label_offset;
+            } else {
+                label_x = 0;
+                arrow_x = label_w + label_offset;
+            }
+        }
+        ArrowDir::Up | ArrowDir::Down => {
+            total_w = size.max(label_w);
+            total_h = size + label_offset + label_h;
+            arrow_x = (total_w - size) / 2;
+            label_x = (total_w - label_w) / 2;
+            if matches!(direction, ArrowDir::Up) {
+                arrow_y = 0;
+                label_y = size + label_offset;
+            } else {
+                label_y = 0;
+                arrow_y = label_h + label_offset;
+            }
+        }
+    }
+
+    let surface = ImageSurface::create(cairo::Format::ARgb32, total_w, total_h)?;
+    let cr = cairo::Context::new(&surface)?;
+
+    // Draw rounded rectangle background behind the arrow.
+    let bg_radius = (size as f64) * 0.15;
+    let pi = std::f64::consts::PI;
+
+    let bx = arrow_x as f64;
+    let by = arrow_y as f64;
+    let bw = size as f64;
+    let bh = size as f64;
+
+    cr.new_path();
+    cr.arc(
+        bx + bg_radius,
+        by + bg_radius,
+        bg_radius,
+        pi,
+        1.5 * pi,
+    );
+    cr.arc(
+        bx + bw - bg_radius,
+        by + bg_radius,
+        bg_radius,
+        1.5 * pi,
+        2. * pi,
+    );
+    cr.arc(
+        bx + bw - bg_radius,
+        by + bh - bg_radius,
+        bg_radius,
+        0.,
+        0.5 * pi,
+    );
+    cr.arc(
+        bx + bg_radius,
+        by + bh - bg_radius,
+        bg_radius,
+        0.5 * pi,
+        pi,
+    );
+    cr.close_path();
+    cr.set_source_rgba(0.1, 0.1, 0.1, 0.9);
+    cr.fill()?;
+
+    // Draw arrow triangle using the theme color.
+    let margin = bw * 0.25;
+
+    draw_arrow_triangle(&cr, bx, by, bw, margin, direction);
+    cr.set_source_rgba(r, g, b, a);
+    cr.fill()?;
+
+    // Draw border on the arrow triangle.
+    draw_arrow_triangle(&cr, bx, by, bw, margin, direction);
+    let lighter = |c: f64| (c + (1. - c) * 0.3).min(1.);
+    cr.set_source_rgba(lighter(r), lighter(g), lighter(b), a);
+    cr.set_line_width(1.5 * scale);
+    cr.stroke()?;
+
+    // Draw label text.
+    cr.move_to(label_x.into(), label_y.into());
+    cr.set_source_rgba(0.9, 0.9, 0.9, 0.95);
+    let layout = pangocairo::functions::create_layout(&cr);
+    layout.context().set_round_glyph_positions(false);
+    layout.set_font_description(Some(&font));
+    layout.set_attributes(Some(&bold));
+    layout.set_alignment(pangocairo::pango::Alignment::Center);
+    layout.set_text(label);
+    pangocairo::functions::show_layout(&cr, &layout);
+
+    drop(cr);
+
+    let data = surface.take_data().unwrap();
+    let buffer = TextureBuffer::from_memory(
+        renderer,
+        &data,
+        Fourcc::Argb8888,
+        (total_w, total_h),
+        false,
+        scale,
+        Transform::Normal,
+        Vec::new(),
+    )?;
+
+    Ok(buffer)
+}
+
+fn draw_arrow_triangle(
+    cr: &cairo::Context,
+    bx: f64,
+    by: f64,
+    bw: f64,
+    margin: f64,
+    direction: ArrowDir,
+) {
+    cr.new_path();
+    match direction {
+        ArrowDir::Left => {
+            cr.move_to(bx + margin, by + bw / 2.);
+            cr.line_to(bx + bw - margin, by + margin);
+            cr.line_to(bx + bw - margin, by + bw - margin);
+        }
+        ArrowDir::Right => {
+            cr.move_to(bx + bw - margin, by + bw / 2.);
+            cr.line_to(bx + margin, by + margin);
+            cr.line_to(bx + margin, by + bw - margin);
+        }
+        ArrowDir::Up => {
+            cr.move_to(bx + bw / 2., by + margin);
+            cr.line_to(bx + bw - margin, by + bw - margin);
+            cr.line_to(bx + margin, by + bw - margin);
+        }
+        ArrowDir::Down => {
+            cr.move_to(bx + bw / 2., by + bw - margin);
+            cr.line_to(bx + bw - margin, by + margin);
+            cr.line_to(bx + margin, by + margin);
+        }
+    }
+    cr.close_path();
+}


### PR DESCRIPTION
## Summary

- Adds a new **spawn overlay UI** that shows themed directional arrows when spawning a window, letting the user choose where it appears relative to the focused window
- New config section `spawn-overlay { enable; }` (opt-in, off by default)
- New actions: `spawn-at-position` and `spawn-sh-at-position` for use in keybinds
- Left/Right places a new column; Up/Down stacks in the same column
- Arrow indicators use theme colors from `border` or `focus-ring` `active-color`
- Supports arrow keys and h/j/k/l for vim-style direction selection, Escape to cancel

### Example config

```kdl
spawn-overlay {
    enable
}

binds {
    Mod+Ctrl+Return { spawn-at-position "foot"; }
}
```

## Test plan

- [x] Tested nested niri session with overlay enabled
- [ ] Verify overlay renders correctly at different scales
- [ ] Verify all four directions place windows correctly
- [ ] Verify Escape cancels without spawning
- [ ] Verify feature is fully inert when `spawn-overlay` is not configured
- [ ] Verify config reload updates overlay theme colors