### PR TITLE
feat: layout-independent keybinds

### DIFF
--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -89,18 +89,18 @@ binds {
 
 Rules:
 
-- `layout-independent true` sets the default for all binds in the section.
-- Individual binds can override it with `layout-independent=true` or `layout-independent=false`.
+- `layout-independent true` sets the default only for binds declared in the same `binds {}` block.
+- Individual binds in that block can override it with `layout-independent=true` or `layout-independent=false`.
 - `xkb {}` uses the same fields as `input.keyboard.xkb`.
-- Layout-independent binds resolve against the declared reference keymap from `binds.xkb`.
+- Layout-independent binds resolve against the declared reference keymap from the same `binds.xkb` block.
 - If `binds.xkb.file` is set, that file is used as the reference keymap directly.
-- Otherwise, the bind `xkb {}` must describe exactly one reference layout.
+- Otherwise, that `xkb {}` block must describe exactly one reference layout.
 - The symbolic key in a layout-independent bind must resolve to a unique physical key in the reference keymap.
 - Extra modifiers that are needed to type that symbol in the reference keymap, such as `Shift` or `ISO_Level3_Shift`, also become part of the bind.
 - For example, if `/` is on the same physical key as `7` in the reference keymap, then `Mod+Slash` will match `Mod+Shift+7`, not plain `Mod+7`.
 - If the symbol is missing from the reference keymap, or ambiguous there, config loading fails.
-- If multiple config files contribute `binds {}` sections, the section-level `layout-independent`
-  and `xkb {}` values follow the normal merge rules: the last `binds {}` section wins.
+- If multiple config files contribute `binds {}` sections, `layout-independent` and `xkb {}` do not
+  carry across block boundaries. They only apply to binds declared in the same block.
 - If two layout-independent binds resolve to the same physical key combination, config loading
   fails.
 - If a layout-independent bind and a normal keysym bind would both match the same key event, the

--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -95,12 +95,14 @@ Rules:
 - `xkb {}` uses the same fields as `input.keyboard.xkb`.
 - Layout-independent binds resolve against the reference keymap declared by the same `binds.xkb` block.
 - If `binds.xkb.file` is set, that file is used as the reference keymap directly.
+- With `binds.xkb.file`, matching checks every physical key in the compiled keymap from that file, and for each key uses the first group/layout and level that produces the requested symbol.
 - Otherwise, that `xkb {}` block must describe exactly one reference layout.
 - Normal binds do not keep any `xkb` association and continue to match by keysym as before.
-- The symbolic key in a layout-independent bind must resolve to a unique physical key in the reference keymap.
+- The symbolic key in a layout-independent bind must resolve to at least one physical key in the reference keymap.
 - Extra modifiers that are needed to type that symbol in the reference keymap, such as `Shift` or `ISO_Level3_Shift`, also become part of the bind.
 - For example, if `/` is on the same physical key as `7` in the reference keymap, then `Mod+Slash` will match `Mod+Shift+7`, not plain `Mod+7`.
-- If the symbol is missing from the reference keymap, or ambiguous there, config loading fails.
+- If the symbol appears on multiple physical keys in the reference keymap, the bind will match all of them.
+- If the symbol is missing from the reference keymap, config loading fails.
 - If multiple config files contribute `binds {}` sections, `layout-independent` and `xkb {}` do not
   carry across block boundaries. They only apply to binds declared in the same block.
 - If two layout-independent binds resolve to the same physical key combination, config loading

--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -62,6 +62,51 @@ For this reason, most of the default keys use the `Mod` modifier.
 > When resolving latin keys, niri will search for the *first* configured XKB layout that has the latin key.
 > So for example with US QWERTY and RU layouts configured, US QWERTY will be used for latin binds.
 
+### Layout-Independent Binds
+
+<sup>Since: 25.11</sup>
+
+You can make binds match by physical key instead of by the currently produced symbol.
+This is useful if you want a bind like `Mod+/` to keep working even when the active layout puts `.`
+or some non-latin symbol on that key.
+
+Layout-independent binds still use the normal symbolic syntax in the config, but they are resolved
+against a reference XKB keymap declared in the `binds` section.
+
+```kdl
+binds {
+    layout-independent true
+
+    xkb {
+        layout "us"
+    }
+
+    Mod+T { spawn "alacritty"; }
+    Mod+Slash { show-hotkey-overlay; }
+    Mod+Q layout-independent=false { close-window; }
+}
+```
+
+Rules:
+
+- `layout-independent true` sets the default for all binds in the section.
+- Individual binds can override it with `layout-independent=true` or `layout-independent=false`.
+- `xkb {}` uses the same fields as `input.keyboard.xkb`.
+- Layout-independent binds resolve against the declared reference keymap from `binds.xkb`.
+- If `binds.xkb.file` is set, that file is used as the reference keymap directly.
+- Otherwise, the bind `xkb {}` must describe exactly one reference layout.
+- The symbolic key in a layout-independent bind must resolve to a unique physical key in the reference keymap.
+- Extra modifiers that are needed to type that symbol in the reference keymap, such as `Shift` or `ISO_Level3_Shift`, also become part of the bind.
+- For example, if `/` is on the same physical key as `7` in the reference keymap, then `Mod+Slash` will match `Mod+Shift+7`, not plain `Mod+7`.
+- If the symbol is missing from the reference keymap, or ambiguous there, config loading fails.
+- If multiple config files contribute `binds {}` sections, the section-level `layout-independent`
+  and `xkb {}` values follow the normal merge rules: the last `binds {}` section wins.
+- If two layout-independent binds resolve to the same physical key combination, config loading
+  fails.
+- If a layout-independent bind and a normal keysym bind would both match the same key event, the
+  layout-independent bind takes precedence.
+- Normal binds continue to match by keysym as before.
+
 <sup>Since: 0.1.8</sup> Binds will repeat by default (i.e. holding down a bind will make it trigger repeatedly).
 You can disable that for specific binds with `repeat=false`:
 

--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -71,7 +71,7 @@ This is useful if you want a bind like `Mod+/` to keep working even when the act
 or some non-latin symbol on that key.
 
 Layout-independent binds still use the normal symbolic syntax in the config, but they are resolved
-against a reference XKB keymap declared in the `binds` section.
+against a reference XKB keymap declared in the same `binds {}` block.
 
 ```kdl
 binds {
@@ -91,10 +91,12 @@ Rules:
 
 - `layout-independent true` sets the default only for binds declared in the same `binds {}` block.
 - Individual binds in that block can override it with `layout-independent=true` or `layout-independent=false`.
+- After parsing, a bind is layout-independent if and only if it resolved to using that block's `xkb {}`.
 - `xkb {}` uses the same fields as `input.keyboard.xkb`.
-- Layout-independent binds resolve against the declared reference keymap from the same `binds.xkb` block.
+- Layout-independent binds resolve against the reference keymap declared by the same `binds.xkb` block.
 - If `binds.xkb.file` is set, that file is used as the reference keymap directly.
 - Otherwise, that `xkb {}` block must describe exactly one reference layout.
+- Normal binds do not keep any `xkb` association and continue to match by keysym as before.
 - The symbolic key in a layout-independent bind must resolve to a unique physical key in the reference keymap.
 - Extra modifiers that are needed to type that symbol in the reference keymap, such as `Shift` or `ISO_Level3_Shift`, also become part of the bind.
 - For example, if `/` is on the same physical key as `7` in the reference keymap, then `Mod+Slash` will match `Mod+Shift+7`, not plain `Mod+7`.
@@ -105,7 +107,6 @@ Rules:
   fails.
 - If a layout-independent bind and a normal keysym bind would both match the same key event, the
   layout-independent bind takes precedence.
-- Normal binds continue to match by keysym as before.
 
 <sup>Since: 0.1.8</sup> Binds will repeat by default (i.e. holding down a bind will make it trigger repeatedly).
 You can disable that for specific binds with `repeat=false`:

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -13,10 +13,22 @@ use smithay::input::keyboard::xkb::{keysym_from_name, KEYSYM_CASE_INSENSITIVE, K
 use smithay::input::keyboard::Keysym;
 
 use crate::recent_windows::{MruDirection, MruFilter, MruScope};
-use crate::utils::{expect_only_children, MergeWith};
+use crate::utils::{Flag, MergeWith};
+use crate::Xkb;
 
 #[derive(Debug, Default, PartialEq)]
-pub struct Binds(pub Vec<Bind>);
+pub struct Binds {
+    pub binds: Vec<Bind>,
+    pub layout_independent: bool,
+    pub xkb: Option<Xkb>,
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct BindsPart {
+    pub binds: Vec<Bind>,
+    pub layout_independent: Option<bool>,
+    pub xkb: Option<Xkb>,
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Bind {
@@ -27,6 +39,7 @@ pub struct Bind {
     pub allow_when_locked: bool,
     pub allow_inhibiting: bool,
     pub hotkey_overlay_title: Option<Option<String>>,
+    pub layout_independent: Option<bool>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -759,7 +772,116 @@ impl<S: knuffel::traits::ErrorSpan> knuffel::DecodeScalar<S> for WorkspaceRefere
     }
 }
 
-impl<S> knuffel::Decode<S> for Binds
+impl MergeWith<BindsPart> for Binds {
+    fn merge_with(&mut self, part: &BindsPart) {
+        self.binds
+            .retain(|bind| !part.binds.iter().any(|new| new.key == bind.key));
+        self.binds.extend(part.binds.iter().cloned());
+
+        if let Some(layout_independent) = part.layout_independent {
+            self.layout_independent = layout_independent;
+        }
+        if let Some(xkb) = &part.xkb {
+            self.xkb = Some(xkb.clone());
+        }
+    }
+}
+
+fn validate_layout_independent_xkb<S>(
+    xkb: &Xkb,
+    node: &knuffel::ast::SpannedNode<S>,
+    ctx: &mut knuffel::decode::Context<S>,
+) where
+    S: knuffel::traits::ErrorSpan,
+{
+    if xkb.file.is_some() {
+        return;
+    }
+
+    if xkb
+        .layout
+        .split(',')
+        .find(|part| !part.trim().is_empty())
+        .is_none()
+    {
+        ctx.emit_error(DecodeError::conversion(
+            node,
+            "binds xkb must specify either a file or exactly one layout",
+        ));
+    }
+
+    let has_multiple_layouts = xkb
+        .layout
+        .split(',')
+        .filter(|part| !part.trim().is_empty())
+        .nth(1)
+        .is_some();
+    if has_multiple_layouts {
+        ctx.emit_error(DecodeError::conversion(
+            node,
+            "binds xkb layout must contain exactly one layout, but multiple were found",
+        ));
+    }
+
+    let has_multiple_variants = xkb
+        .variant
+        .split(',')
+        .filter(|part| !part.trim().is_empty())
+        .nth(1)
+        .is_some();
+    if has_multiple_variants {
+        ctx.emit_error(DecodeError::conversion(
+            node,
+            "binds xkb variant must contain exactly one variant",
+        ));
+    }
+}
+
+fn effective_layout_independent(binds: &Binds, bind: &Bind) -> bool {
+    bind.layout_independent.unwrap_or(binds.layout_independent)
+}
+
+fn validate_layout_independent_trigger<S>(
+    bind: &Bind,
+    layout_independent: bool,
+    node: &knuffel::ast::SpannedNode<S>,
+    ctx: &mut knuffel::decode::Context<S>,
+) where
+    S: knuffel::traits::ErrorSpan,
+{
+    if layout_independent && !matches!(bind.key.trigger, Trigger::Keysym(_)) {
+        ctx.emit_error(DecodeError::conversion(
+            node,
+            "layout-independent=true can only be used with keysym binds",
+        ));
+    }
+}
+
+pub fn validate_final_binds_config<S>(
+    binds: &Binds,
+    node: &knuffel::ast::SpannedNode<S>,
+    ctx: &mut knuffel::decode::Context<S>,
+) where
+    S: knuffel::traits::ErrorSpan,
+{
+    let has_layout_independent = binds
+        .binds
+        .iter()
+        .any(|bind| effective_layout_independent(binds, bind));
+
+    if let Some(xkb) = &binds.xkb {
+        validate_layout_independent_xkb(xkb, node, ctx);
+    }
+
+    if has_layout_independent && binds.xkb.is_none() {
+        ctx.emit_error(DecodeError::missing(
+            node,
+            "binds.xkb is required when any bind is layout-independent",
+        ));
+    }
+}
+
+impl<S> knuffel::Decode<S> for BindsPart
 where
     S: knuffel::traits::ErrorSpan,
 {
@@ -767,57 +889,126 @@ where
         node: &knuffel::ast::SpannedNode<S>,
         ctx: &mut knuffel::decode::Context<S>,
     ) -> Result<Self, DecodeError<S>> {
-        expect_only_children(node, ctx);
+        if let Some(type_name) = &node.type_name {
+            ctx.emit_error(DecodeError::unexpected(
+                type_name,
+                "type name",
+                "no type name expected for this node",
+            ));
+        }
+
+        for val in node.arguments.iter() {
+            ctx.emit_error(DecodeError::unexpected(
+                &val.literal,
+                "argument",
+                "no arguments expected for this node",
+            ));
+        }
+
+        for name in node.properties.keys() {
+            ctx.emit_error(DecodeError::unexpected(
+                name,
+                "property",
+                "no properties expected for this node",
+            ));
+        }
 
         let mut seen_keys = HashSet::new();
+        let mut saw_layout_independent = false;
+        let mut saw_xkb = false;
 
         let mut binds = Vec::new();
+        let mut bind_nodes = Vec::new();
+        let mut layout_independent = None;
+        let mut xkb = None;
 
         for child in node.children() {
-            match Bind::decode_node(child, ctx) {
-                Err(e) => {
-                    ctx.emit_error(e);
-                }
-                Ok(bind) => {
-                    if seen_keys.insert(bind.key) {
-                        binds.push(bind);
-                    } else {
-                        // ideally, this error should point to the previous instance of this keybind
-                        //
-                        // i (sodiboo) have tried to implement this in various ways:
-                        // miette!(), #[derive(Diagnostic)]
-                        // DecodeError::Custom, DecodeError::Conversion
-                        // nothing seems to work, and i suspect it's not possible.
-                        //
-                        // DecodeError is fairly restrictive.
-                        // even DecodeError::Custom just wraps a std::error::Error
-                        // and this erases all rich information from miette. (why???)
-                        //
-                        // why does knuffel do this?
-                        // from what i can tell, it doesn't even use DecodeError for much.
-                        // it only ever converts them to a Report anyways!
-                        // https://github.com/tailhook/knuffel/blob/c44c6b0c0f31ea6d1174d5d2ed41064922ea44ca/src/wrappers.rs#L55-L58
-                        //
-                        // besides like, allowing downstream users (such as us!)
-                        // to match on parse failure, i don't understand why
-                        // it doesn't just use a generic error type
-                        //
-                        // even the matching isn't consistent,
-                        // because errors can also be omitted as ctx.emit_error.
-                        // why does *that one* especially, require a DecodeError?
-                        //
-                        // anyways if you can make it format nicely, definitely do fix this
+            match child.node_name.as_ref() {
+                "layout-independent" => {
+                    if saw_layout_independent {
                         ctx.emit_error(DecodeError::unexpected(
                             &child.node_name,
-                            "keybind",
-                            "duplicate keybind",
+                            "node",
+                            "duplicate node `layout-independent`, single node expected",
                         ));
+                        continue;
                     }
+                    let value = Flag::decode_node(child, ctx)?.0;
+                    saw_layout_independent = true;
+                    layout_independent = Some(value);
                 }
+                "xkb" => {
+                    if saw_xkb {
+                        ctx.emit_error(DecodeError::unexpected(
+                            &child.node_name,
+                            "node",
+                            "duplicate node `xkb`, single node expected",
+                        ));
+                        continue;
+                    }
+                    let value = Xkb::decode_node(child, ctx)?;
+                    validate_layout_independent_xkb(&value, child, ctx);
+                    saw_xkb = true;
+                    xkb = Some(value);
+                }
+                _ => match Bind::decode_node(child, ctx) {
+                    Err(e) => {
+                        ctx.emit_error(e);
+                    }
+                    Ok(bind) => {
+                        if seen_keys.insert(bind.key) {
+                            bind_nodes.push(child);
+                            binds.push(bind);
+                        } else {
+                            // ideally, this error should point to the previous instance of this
+                            // keybind
+                            //
+                            // i (sodiboo) have tried to implement this in various ways:
+                            // miette!(), #[derive(Diagnostic)]
+                            // DecodeError::Custom, DecodeError::Conversion
+                            // nothing seems to work, and i suspect it's not possible.
+                            //
+                            // DecodeError is fairly restrictive.
+                            // even DecodeError::Custom just wraps a std::error::Error
+                            // and this erases all rich information from miette. (why???)
+                            //
+                            // why does knuffel do this?
+                            // from what i can tell, it doesn't even use DecodeError for much.
+                            // it only ever converts them to a Report anyways!
+                            // https://github.com/tailhook/knuffel/blob/c44c6b0c0f31ea6d1174d5d2ed41064922ea44ca/src/wrappers.rs#L55-L58
+                            //
+                            // besides like, allowing downstream users (such as us!)
+                            // to match on parse failure, i don't understand why
+                            // it doesn't just use a generic error type
+                            //
+                            // even the matching isn't consistent,
+                            // because errors can also be omitted as ctx.emit_error.
+                            // why does *that one* especially, require a DecodeError?
+                            //
+                            // anyways if you can make it format nicely, definitely do fix this
+                            ctx.emit_error(DecodeError::unexpected(
+                                &child.node_name,
+                                "keybind",
+                                "duplicate keybind",
+                            ));
+                        }
+                    }
+                },
             }
         }
 
-        Ok(Self(binds))
+        for (bind, bind_node) in binds.iter().zip(bind_nodes) {
+            let effective_layout_independent = bind
+                .layout_independent
+                .unwrap_or(layout_independent.unwrap_or(false));
+            validate_layout_independent_trigger(bind, effective_layout_independent, bind_node, ctx);
+        }
+
+        Ok(Self {
+            binds,
+            layout_independent,
+            xkb,
+        })
     }
 }
 
@@ -856,6 +1047,7 @@ where
         let mut allow_when_locked_node = None;
         let mut allow_inhibiting = true;
         let mut hotkey_overlay_title = None;
+        let mut layout_independent = None;
         for (name, val) in &node.properties {
             match &***name {
                 "repeat" => {
@@ -875,6 +1067,9 @@ where
                 }
                 "hotkey-overlay-title" => {
                     hotkey_overlay_title = Some(knuffel::traits::DecodeScalar::decode(val, ctx)?);
+                }
+                "layout-independent" => {
+                    layout_independent = Some(knuffel::traits::DecodeScalar::decode(val, ctx)?);
                 }
                 name_str => {
                     ctx.emit_error(DecodeError::unexpected(
@@ -899,6 +1094,7 @@ where
             allow_when_locked: false,
             allow_inhibiting: true,
             hotkey_overlay_title: None,
+            layout_independent: None,
         };
 
         if let Some(child) = children.next() {
@@ -935,6 +1131,7 @@ where
                         allow_when_locked,
                         allow_inhibiting,
                         hotkey_overlay_title,
+                        layout_independent,
                     })
                 }
                 Err(e) => {

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use bitflags::bitflags;
 use knuffel::errors::DecodeError;
+use knuffel::Decode;
 use miette::miette;
 use niri_ipc::{
     ColumnDisplay, LayoutSwitchTarget, PositionChange, SizeChange, WorkspaceReferenceArg,
@@ -35,7 +36,8 @@ pub struct Bind {
     pub allow_when_locked: bool,
     pub allow_inhibiting: bool,
     pub hotkey_overlay_title: Option<Option<String>>,
-    pub layout_independent: Option<bool>,
+    // When present, this bind is matched layout-independently using this reference keymap.
+    // When absent, this bind is matched by keysym as usual.
     pub xkb: Option<Xkb>,
 }
 
@@ -829,13 +831,13 @@ fn validate_layout_independent_xkb<S>(
 
 fn validate_layout_independent_trigger<S>(
     bind: &Bind,
-    layout_independent: bool,
+    enabled: bool,
     node: &knuffel::ast::SpannedNode<S>,
     ctx: &mut knuffel::decode::Context<S>,
 ) where
     S: knuffel::traits::ErrorSpan,
 {
-    if layout_independent && !matches!(bind.key.trigger, Trigger::Keysym(_)) {
+    if enabled && !matches!(bind.key.trigger, Trigger::Keysym(_)) {
         ctx.emit_error(DecodeError::conversion(
             node,
             "layout-independent=true can only be used with keysym binds",
@@ -878,8 +880,11 @@ where
         let mut saw_layout_independent = false;
         let mut saw_xkb = false;
 
+        // `layout-independent` is resolved entirely within a single binds block.
+        // It does not persist on the final `Bind`; instead, `bind.xkb = Some(...)`
+        // means layout-independent matching is enabled for that bind.
         let mut binds = Vec::new();
-        let mut layout_independent = None;
+        let mut block_layout_independent = None;
         let mut xkb = None;
 
         for child in node.children() {
@@ -895,7 +900,7 @@ where
                     }
                     let value = Flag::decode_node(child, ctx)?.0;
                     saw_layout_independent = true;
-                    layout_independent = Some(value);
+                    block_layout_independent = Some(value);
                 }
                 "xkb" => {
                     if saw_xkb {
@@ -911,13 +916,13 @@ where
                     saw_xkb = true;
                     xkb = Some(value);
                 }
-                _ => match Bind::decode_node(child, ctx) {
+                _ => match decode_bind_node(child, ctx) {
                     Err(e) => {
                         ctx.emit_error(e);
                     }
-                    Ok(bind) => {
+                    Ok((bind, bind_layout_independent_override)) => {
                         if seen_keys.insert(bind.key) {
-                            binds.push((child, bind));
+                            binds.push((child, bind, bind_layout_independent_override));
                         } else {
                             // ideally, this error should point to the previous instance of this
                             // keybind
@@ -958,19 +963,15 @@ where
 
         let binds = binds
             .into_iter()
-            .map(|(child, mut bind)| {
-                let bind_layout_independent = bind
-                    .layout_independent
-                    .unwrap_or(layout_independent.unwrap_or(false));
+            .map(|(child, mut bind, bind_layout_independent_override)| {
+                let bind_layout_independent = bind_layout_independent_override
+                    .unwrap_or(block_layout_independent.unwrap_or(false));
                 validate_layout_independent_trigger(
                     &bind,
                     bind_layout_independent,
                     child,
                     ctx,
                 );
-                if bind.layout_independent.is_some() || layout_independent.is_some() {
-                    bind.layout_independent = Some(bind_layout_independent);
-                }
                 if bind_layout_independent {
                     if xkb.is_none() {
                         ctx.emit_error(DecodeError::missing(
@@ -990,119 +991,118 @@ where
     }
 }
 
-impl<S> knuffel::Decode<S> for Bind
+fn decode_bind_node<S>(
+    node: &knuffel::ast::SpannedNode<S>,
+    ctx: &mut knuffel::decode::Context<S>,
+) -> Result<(Bind, Option<bool>), DecodeError<S>>
 where
     S: knuffel::traits::ErrorSpan,
 {
-    fn decode_node(
-        node: &knuffel::ast::SpannedNode<S>,
-        ctx: &mut knuffel::decode::Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
-        if let Some(type_name) = &node.type_name {
-            ctx.emit_error(DecodeError::unexpected(
-                type_name,
-                "type name",
-                "no type name expected for this node",
-            ));
-        }
+    if let Some(type_name) = &node.type_name {
+        ctx.emit_error(DecodeError::unexpected(
+            type_name,
+            "type name",
+            "no type name expected for this node",
+        ));
+    }
 
-        for val in node.arguments.iter() {
-            ctx.emit_error(DecodeError::unexpected(
-                &val.literal,
-                "argument",
-                "no arguments expected for this node",
-            ));
-        }
+    for val in node.arguments.iter() {
+        ctx.emit_error(DecodeError::unexpected(
+            &val.literal,
+            "argument",
+            "no arguments expected for this node",
+        ));
+    }
 
-        let key = node
-            .node_name
-            .parse::<Key>()
-            .map_err(|e| DecodeError::conversion(&node.node_name, e.wrap_err("invalid keybind")))?;
+    let key = node
+        .node_name
+        .parse::<Key>()
+        .map_err(|e| DecodeError::conversion(&node.node_name, e.wrap_err("invalid keybind")))?;
 
-        let mut repeat = true;
-        let mut cooldown = None;
-        let mut allow_when_locked = false;
-        let mut allow_when_locked_node = None;
-        let mut allow_inhibiting = true;
-        let mut hotkey_overlay_title = None;
-        let mut layout_independent = None;
-        for (name, val) in &node.properties {
-            match &***name {
-                "repeat" => {
-                    repeat = knuffel::traits::DecodeScalar::decode(val, ctx)?;
-                }
-                "cooldown-ms" => {
-                    cooldown = Some(Duration::from_millis(
-                        knuffel::traits::DecodeScalar::decode(val, ctx)?,
-                    ));
-                }
-                "allow-when-locked" => {
-                    allow_when_locked = knuffel::traits::DecodeScalar::decode(val, ctx)?;
-                    allow_when_locked_node = Some(name);
-                }
-                "allow-inhibiting" => {
-                    allow_inhibiting = knuffel::traits::DecodeScalar::decode(val, ctx)?;
-                }
-                "hotkey-overlay-title" => {
-                    hotkey_overlay_title = Some(knuffel::traits::DecodeScalar::decode(val, ctx)?);
-                }
-                "layout-independent" => {
-                    layout_independent = Some(knuffel::traits::DecodeScalar::decode(val, ctx)?);
-                }
-                name_str => {
-                    ctx.emit_error(DecodeError::unexpected(
-                        name,
-                        "property",
-                        format!("unexpected property `{}`", name_str.escape_default()),
-                    ));
-                }
+    let mut repeat = true;
+    let mut cooldown = None;
+    let mut allow_when_locked = false;
+    let mut allow_when_locked_node = None;
+    let mut allow_inhibiting = true;
+    let mut hotkey_overlay_title = None;
+    let mut layout_independent = None;
+    for (name, val) in &node.properties {
+        match &***name {
+            "repeat" => {
+                repeat = knuffel::traits::DecodeScalar::decode(val, ctx)?;
             }
-        }
-
-        let mut children = node.children();
-
-        // If the action is invalid but the key is fine, we still want to return something.
-        // That way, the parent can handle the existence of duplicate keybinds,
-        // even if their contents are not valid.
-        let dummy = Self {
-            key,
-            action: Action::Spawn(vec![]),
-            repeat: true,
-            cooldown: None,
-            allow_when_locked: false,
-            allow_inhibiting: true,
-            hotkey_overlay_title: None,
-            layout_independent: None,
-            xkb: None, // Populated by BindsPart post-processing.
-        };
-
-        if let Some(child) = children.next() {
-            for unwanted_child in children {
-                ctx.emit_error(DecodeError::unexpected(
-                    unwanted_child,
-                    "node",
-                    "only one action is allowed per keybind",
+            "cooldown-ms" => {
+                cooldown = Some(Duration::from_millis(
+                    knuffel::traits::DecodeScalar::decode(val, ctx)?,
                 ));
             }
-            match Action::decode_node(child, ctx) {
-                Ok(action) => {
-                    if !matches!(action, Action::Spawn(_) | Action::SpawnSh(_)) {
-                        if let Some(node) = allow_when_locked_node {
-                            ctx.emit_error(DecodeError::unexpected(
-                                node,
-                                "property",
-                                "allow-when-locked can only be set on spawn binds",
-                            ));
-                        }
-                    }
+            "allow-when-locked" => {
+                allow_when_locked = knuffel::traits::DecodeScalar::decode(val, ctx)?;
+                allow_when_locked_node = Some(name);
+            }
+            "allow-inhibiting" => {
+                allow_inhibiting = knuffel::traits::DecodeScalar::decode(val, ctx)?;
+            }
+            "hotkey-overlay-title" => {
+                hotkey_overlay_title = Some(knuffel::traits::DecodeScalar::decode(val, ctx)?);
+            }
+            "layout-independent" => {
+                layout_independent = Some(knuffel::traits::DecodeScalar::decode(val, ctx)?);
+            }
+            name_str => {
+                ctx.emit_error(DecodeError::unexpected(
+                    name,
+                    "property",
+                    format!("unexpected property `{}`", name_str.escape_default()),
+                ));
+            }
+        }
+    }
 
-                    // The toggle-inhibit action must always be uninhibitable.
-                    // Otherwise, it would be impossible to trigger it.
-                    if matches!(action, Action::ToggleKeyboardShortcutsInhibit) {
-                        allow_inhibiting = false;
-                    }
+    let mut children = node.children();
 
-                    Ok(Self {
+    // If the action is invalid but the key is fine, we still want to return something.
+    // That way, the parent can handle the existence of duplicate keybinds,
+    // even if their contents are not valid.
+    let dummy = Bind {
+        key,
+        action: Action::Spawn(vec![]),
+        repeat: true,
+        cooldown: None,
+        allow_when_locked: false,
+        allow_inhibiting: true,
+        hotkey_overlay_title: None,
+        xkb: None, // Populated by BindsPart post-processing.
+    };
+
+    if let Some(child) = children.next() {
+        for unwanted_child in children {
+            ctx.emit_error(DecodeError::unexpected(
+                unwanted_child,
+                "node",
+                "only one action is allowed per keybind",
+            ));
+        }
+        match Action::decode_node(child, ctx) {
+            Ok(action) => {
+                if !matches!(action, Action::Spawn(_) | Action::SpawnSh(_)) {
+                    if let Some(node) = allow_when_locked_node {
+                        ctx.emit_error(DecodeError::unexpected(
+                            node,
+                            "property",
+                            "allow-when-locked can only be set on spawn binds",
+                        ));
+                    }
+                }
+
+                // The toggle-inhibit action must always be uninhibitable.
+                // Otherwise, it would be impossible to trigger it.
+                if matches!(action, Action::ToggleKeyboardShortcutsInhibit) {
+                    allow_inhibiting = false;
+                }
+
+                Ok((
+                    Bind {
                         key,
                         action,
                         repeat,
@@ -1110,22 +1110,22 @@ where
                         allow_when_locked,
                         allow_inhibiting,
                         hotkey_overlay_title,
-                        layout_independent,
                         xkb: None, // Populated by BindsPart post-processing.
-                    })
-                }
-                Err(e) => {
-                    ctx.emit_error(e);
-                    Ok(dummy)
-                }
+                    },
+                    layout_independent,
+                ))
             }
-        } else {
-            ctx.emit_error(DecodeError::missing(
-                node,
-                "expected an action for this keybind",
-            ));
-            Ok(dummy)
+            Err(e) => {
+                ctx.emit_error(e);
+                Ok((dummy, layout_independent))
+            }
         }
+    } else {
+        ctx.emit_error(DecodeError::missing(
+            node,
+            "expected an action for this keybind",
+        ));
+        Ok((dummy, layout_independent))
     }
 }
 

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -19,15 +19,11 @@ use crate::Xkb;
 #[derive(Debug, Default, PartialEq)]
 pub struct Binds {
     pub binds: Vec<Bind>,
-    pub layout_independent: bool,
-    pub xkb: Option<Xkb>,
 }
 
 #[derive(Debug, Default, PartialEq)]
 pub struct BindsPart {
     pub binds: Vec<Bind>,
-    pub layout_independent: Option<bool>,
-    pub xkb: Option<Xkb>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -40,6 +36,7 @@ pub struct Bind {
     pub allow_inhibiting: bool,
     pub hotkey_overlay_title: Option<Option<String>>,
     pub layout_independent: Option<bool>,
+    pub xkb: Option<Xkb>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -777,13 +774,6 @@ impl MergeWith<BindsPart> for Binds {
         self.binds
             .retain(|bind| !part.binds.iter().any(|new| new.key == bind.key));
         self.binds.extend(part.binds.iter().cloned());
-
-        if let Some(layout_independent) = part.layout_independent {
-            self.layout_independent = layout_independent;
-        }
-        if let Some(xkb) = &part.xkb {
-            self.xkb = Some(xkb.clone());
-        }
     }
 }
 
@@ -837,10 +827,6 @@ fn validate_layout_independent_xkb<S>(
     }
 }
 
-fn effective_layout_independent(binds: &Binds, bind: &Bind) -> bool {
-    bind.layout_independent.unwrap_or(binds.layout_independent)
-}
-
 fn validate_layout_independent_trigger<S>(
     bind: &Bind,
     layout_independent: bool,
@@ -856,31 +842,6 @@ fn validate_layout_independent_trigger<S>(
         ));
     }
 }
-
-pub fn validate_final_binds_config<S>(
-    binds: &Binds,
-    node: &knuffel::ast::SpannedNode<S>,
-    ctx: &mut knuffel::decode::Context<S>,
-) where
-    S: knuffel::traits::ErrorSpan,
-{
-    let has_layout_independent = binds
-        .binds
-        .iter()
-        .any(|bind| effective_layout_independent(binds, bind));
-
-    if let Some(xkb) = &binds.xkb {
-        validate_layout_independent_xkb(xkb, node, ctx);
-    }
-
-    if has_layout_independent && binds.xkb.is_none() {
-        ctx.emit_error(DecodeError::missing(
-            node,
-            "binds.xkb is required when any bind is layout-independent",
-        ));
-    }
-}
-
 impl<S> knuffel::Decode<S> for BindsPart
 where
     S: knuffel::traits::ErrorSpan,
@@ -918,7 +879,6 @@ where
         let mut saw_xkb = false;
 
         let mut binds = Vec::new();
-        let mut bind_nodes = Vec::new();
         let mut layout_independent = None;
         let mut xkb = None;
 
@@ -957,8 +917,7 @@ where
                     }
                     Ok(bind) => {
                         if seen_keys.insert(bind.key) {
-                            bind_nodes.push(child);
-                            binds.push(bind);
+                            binds.push((child, bind));
                         } else {
                             // ideally, this error should point to the previous instance of this
                             // keybind
@@ -997,18 +956,37 @@ where
             }
         }
 
-        for (bind, bind_node) in binds.iter().zip(bind_nodes) {
-            let effective_layout_independent = bind
-                .layout_independent
-                .unwrap_or(layout_independent.unwrap_or(false));
-            validate_layout_independent_trigger(bind, effective_layout_independent, bind_node, ctx);
-        }
+        let binds = binds
+            .into_iter()
+            .map(|(child, mut bind)| {
+                let bind_layout_independent = bind
+                    .layout_independent
+                    .unwrap_or(layout_independent.unwrap_or(false));
+                validate_layout_independent_trigger(
+                    &bind,
+                    bind_layout_independent,
+                    child,
+                    ctx,
+                );
+                if bind.layout_independent.is_some() || layout_independent.is_some() {
+                    bind.layout_independent = Some(bind_layout_independent);
+                }
+                if bind_layout_independent {
+                    if xkb.is_none() {
+                        ctx.emit_error(DecodeError::missing(
+                            child,
+                            "binds.xkb is required when any bind in this binds block is layout-independent",
+                        ));
+                    } else {
+                        bind.xkb = xkb.clone();
+                    }
+                }
 
-        Ok(Self {
-            binds,
-            layout_independent,
-            xkb,
-        })
+                bind
+            })
+            .collect();
+
+        Ok(Self { binds })
     }
 }
 
@@ -1095,6 +1073,7 @@ where
             allow_inhibiting: true,
             hotkey_overlay_title: None,
             layout_independent: None,
+            xkb: None, // Populated by BindsPart post-processing.
         };
 
         if let Some(child) = children.next() {
@@ -1132,6 +1111,7 @@ where
                         allow_inhibiting,
                         hotkey_overlay_title,
                         layout_independent,
+                        xkb: None, // Populated by BindsPart post-processing.
                     })
                 }
                 Err(e) => {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1919,7 +1919,6 @@ mod tests {
                                 "Inhibit",
                             ),
                         ),
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -1937,7 +1936,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: false,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -1959,7 +1957,6 @@ mod tests {
                         allow_when_locked: true,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -1979,7 +1976,6 @@ mod tests {
                         hotkey_overlay_title: Some(
                             None,
                         ),
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -1997,7 +1993,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2017,7 +2012,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2035,7 +2029,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2055,7 +2048,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2075,7 +2067,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2093,7 +2084,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2115,7 +2105,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2137,7 +2126,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2157,7 +2145,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: false,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2175,7 +2162,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2195,7 +2181,6 @@ mod tests {
                         allow_when_locked: true,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                 ],
@@ -2321,7 +2306,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2345,7 +2329,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                     Bind {
@@ -2371,7 +2354,6 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
-                        layout_independent: None,
                         xkb: None,
                     },
                 ],
@@ -2399,7 +2381,6 @@ mod tests {
         );
 
         assert_eq!(parsed.binds.binds.len(), 2);
-        assert_eq!(parsed.binds.binds[0].layout_independent, Some(true));
         assert_eq!(
             parsed.binds.binds[0].xkb,
             Some(Xkb {
@@ -2408,7 +2389,6 @@ mod tests {
                 ..Default::default()
             })
         );
-        assert_eq!(parsed.binds.binds[1].layout_independent, Some(false));
         assert_eq!(parsed.binds.binds[1].xkb, None);
     }
 
@@ -2430,7 +2410,6 @@ mod tests {
         );
 
         assert_eq!(parsed.binds.binds.len(), 1);
-        assert_eq!(parsed.binds.binds[0].layout_independent, Some(true));
         assert_eq!(
             parsed.binds.binds[0].xkb,
             Some(Xkb {
@@ -2520,7 +2499,6 @@ mod tests {
 
         let parsed = Config::load(&main).config.unwrap();
         assert_eq!(parsed.binds.binds[0].xkb, None);
-        assert_eq!(parsed.binds.binds[0].layout_independent, None);
     }
 
     #[test]
@@ -2540,7 +2518,6 @@ mod tests {
         .unwrap();
 
         let parsed = Config::load(&main).config.unwrap();
-        assert_eq!(parsed.binds.binds[0].layout_independent, Some(false));
         assert_eq!(parsed.binds.binds[0].xkb, None);
     }
 
@@ -2560,7 +2537,6 @@ mod tests {
             "#,
         );
 
-        assert_eq!(parsed.binds.binds[0].layout_independent, Some(true));
         assert_eq!(
             parsed.binds.binds[0].xkb,
             Some(Xkb {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -213,17 +213,8 @@ where
 
                 // Single-part sections.
                 "binds" => {
-                    let part = Binds::decode_node(node, ctx)?;
-
-                    // We replace conflicting binds, rather than error, to support the use-case
-                    // where you import some preconfigured-dots.kdl, then override some binds with
-                    // your own.
-                    let mut config = config.borrow_mut();
-                    let binds = &mut config.binds.0;
-                    // Remove existing binds matching any new bind.
-                    binds.retain(|bind| !part.0.iter().any(|new| new.key == bind.key));
-                    // Add all new binds.
-                    binds.extend(part.0);
+                    let part = BindsPart::decode_node(node, ctx)?;
+                    config.borrow_mut().binds.merge_with(&part);
                 }
                 "environment" => {
                     let part = Environment::decode_node(node, ctx)?;
@@ -437,6 +428,18 @@ where
             }
         }
 
+        if recursion == 0 {
+            let config_ref = config.borrow();
+            if let Some(node) = nodes
+                .iter()
+                .rev()
+                .find(|node| node.node_name.as_ref() == "binds")
+                .or_else(|| nodes.last())
+            {
+                validate_final_binds_config(&config_ref.binds, node, ctx);
+            }
+        }
+
         Ok(Self)
     }
 }
@@ -613,10 +616,36 @@ impl ConfigPath {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use insta::{assert_debug_snapshot, assert_snapshot};
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    struct TestTempDir(PathBuf);
+
+    impl TestTempDir {
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestTempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn test_tempdir() -> TestTempDir {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+        let suffix = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let path = std::env::temp_dir().join(format!("niri-config-test-{pid}-{suffix}"));
+        fs::create_dir_all(&path).unwrap();
+        TestTempDir(path)
+    }
 
     #[test]
     fn can_create_default_config() {
@@ -837,7 +866,7 @@ mod tests {
                 window-open { off; }
 
                 window-close {
-                    curve "cubic-bezier" 0.05 0.7 0.1 1  
+                    curve "cubic-bezier" 0.05 0.7 0.1 1
                 }
 
                 recent-windows-close {
@@ -1881,8 +1910,8 @@ mod tests {
                     baba_is_float: None,
                 },
             ],
-            binds: Binds(
-                [
+            binds: Binds {
+                binds: [
                     Bind {
                         key: Key {
                             trigger: Keysym(
@@ -1902,6 +1931,7 @@ mod tests {
                                 "Inhibit",
                             ),
                         ),
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -1918,6 +1948,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: false,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -1938,6 +1969,7 @@ mod tests {
                         allow_when_locked: true,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -1956,6 +1988,7 @@ mod tests {
                         hotkey_overlay_title: Some(
                             None,
                         ),
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -1972,6 +2005,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -1990,6 +2024,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -2006,6 +2041,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -2024,6 +2060,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -2042,6 +2079,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -2058,6 +2096,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -2078,6 +2117,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -2098,6 +2138,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -2116,6 +2157,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: false,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -2132,6 +2174,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -2150,9 +2193,12 @@ mod tests {
                         allow_when_locked: true,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                 ],
-            ),
+                layout_independent: false,
+                xkb: None,
+            },
             switch_events: SwitchBinds {
                 lid_open: None,
                 lid_close: None,
@@ -2274,6 +2320,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -2296,6 +2343,7 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                     Bind {
                         key: Key {
@@ -2320,11 +2368,206 @@ mod tests {
                         allow_when_locked: false,
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
+                        layout_independent: None,
                     },
                 ],
             },
         }
         "#);
+    }
+
+    #[test]
+    fn parse_layout_independent_binds() {
+        let parsed = do_parse(
+            r#"
+            binds {
+                layout-independent
+
+                xkb {
+                    layout "us"
+                    variant "colemak"
+                }
+
+                Mod+T { close-window; }
+                Mod+Q layout-independent=false { close-window; }
+            }
+            "#,
+        );
+
+        assert!(parsed.binds.layout_independent);
+        assert_eq!(
+            parsed.binds.xkb,
+            Some(Xkb {
+                layout: String::from("us"),
+                variant: String::from("colemak"),
+                ..Default::default()
+            })
+        );
+        assert_eq!(parsed.binds.binds.len(), 2);
+        assert_eq!(parsed.binds.binds[0].layout_independent, None);
+        assert_eq!(parsed.binds.binds[1].layout_independent, Some(false));
+    }
+
+    #[test]
+    fn layout_independent_binds_can_split_xkb_and_default_across_includes() {
+        let dir = test_tempdir();
+        let main = dir.path().join("config.kdl");
+        let part1 = dir.path().join("binds-1.kdl");
+        let part2 = dir.path().join("binds-2.kdl");
+
+        fs::write(&main, "include \"binds-1.kdl\"\ninclude \"binds-2.kdl\"\n").unwrap();
+        fs::write(
+            &part1,
+            r#"
+            binds {
+                xkb {
+                    layout "us"
+                }
+
+                Mod+T { close-window; }
+            }
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            &part2,
+            r#"
+            binds {
+                layout-independent
+            }
+            "#,
+        )
+        .unwrap();
+
+        let parsed = Config::load(&main).config.unwrap();
+        assert!(parsed.binds.layout_independent);
+        assert_eq!(
+            parsed.binds.xkb.as_ref().map(|xkb| xkb.layout.as_str()),
+            Some("us")
+        );
+    }
+
+    #[test]
+    fn layout_independent_binds_require_xkb_after_merge() {
+        let dir = test_tempdir();
+        let main = dir.path().join("config.kdl");
+        let part = dir.path().join("binds.kdl");
+
+        fs::write(&main, "include \"binds.kdl\"\n").unwrap();
+        fs::write(
+            &part,
+            r#"
+            binds {
+                layout-independent
+                Mod+T { close-window; }
+            }
+            "#,
+        )
+        .unwrap();
+
+        let err = format!("{:?}", Config::load(&main).config.unwrap_err());
+        assert!(err.contains("binds.xkb is required when any bind is layout-independent"));
+    }
+
+    #[test]
+    fn binds_xkb_without_layout_independent_is_allowed_after_merge() {
+        let dir = test_tempdir();
+        let main = dir.path().join("config.kdl");
+
+        fs::write(
+            &main,
+            r#"
+            binds {
+                xkb {
+                    layout "us"
+                }
+
+                Mod+T { close-window; }
+            }
+            "#,
+        )
+        .unwrap();
+
+        let parsed = Config::load(&main).config.unwrap();
+        assert_eq!(
+            parsed.binds.xkb,
+            Some(Xkb {
+                layout: String::from("us"),
+                ..Default::default()
+            })
+        );
+        assert!(!parsed.binds.layout_independent);
+    }
+
+    #[test]
+    fn bind_level_false_override_disables_xkb_requirement() {
+        let dir = test_tempdir();
+        let main = dir.path().join("config.kdl");
+
+        fs::write(
+            &main,
+            r#"
+            binds {
+                layout-independent true
+                Mod+T layout-independent=false { close-window; }
+            }
+            "#,
+        )
+        .unwrap();
+
+        let parsed = Config::load(&main).config.unwrap();
+        assert!(parsed.binds.layout_independent);
+        assert_eq!(parsed.binds.binds[0].layout_independent, Some(false));
+        assert_eq!(parsed.binds.xkb, None);
+    }
+
+    #[test]
+    fn layout_independent_binds_accept_xkb_file_without_single_layout() {
+        let parsed = do_parse(
+            r#"
+            binds {
+                layout-independent
+
+                xkb {
+                    file "/tmp/layout.xkb"
+                }
+
+                Mod+T { close-window; }
+            }
+            "#,
+        );
+
+        assert!(parsed.binds.layout_independent);
+        assert_eq!(
+            parsed.binds.xkb,
+            Some(Xkb {
+                file: Some(String::from("/tmp/layout.xkb")),
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn layout_independent_non_keysym_binds_emit_an_error() {
+        let err = format!(
+            "{:?}",
+            Config::parse_mem(
+                r#"
+                binds {
+                    layout-independent
+
+                    xkb {
+                        layout "us"
+                    }
+
+                    Mod+WheelScrollDown { focus-workspace-down; }
+                }
+                "#,
+            )
+            .unwrap_err()
+        );
+
+        assert!(err.contains("layout-independent=true can only be used with keysym binds"));
     }
 
     fn diff_lines(expected: &str, actual: &str) -> String {
@@ -2371,7 +2614,7 @@ mod tests {
         // Some notable omissions: the default config has some window rules, and an empty config
         // will not have any binds. Clear them out so they don't spam the diff.
         default_config.window_rules.clear();
-        default_config.binds.0.clear();
+        default_config.binds.binds.clear();
 
         assert_snapshot!(
             diff_lines(

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -428,18 +428,6 @@ where
             }
         }
 
-        if recursion == 0 {
-            let config_ref = config.borrow();
-            if let Some(node) = nodes
-                .iter()
-                .rev()
-                .find(|node| node.node_name.as_ref() == "binds")
-                .or_else(|| nodes.last())
-            {
-                validate_final_binds_config(&config_ref.binds, node, ctx);
-            }
-        }
-
         Ok(Self)
     }
 }
@@ -1932,6 +1920,7 @@ mod tests {
                             ),
                         ),
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -1949,6 +1938,7 @@ mod tests {
                         allow_inhibiting: false,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -1970,6 +1960,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -1989,6 +1980,7 @@ mod tests {
                             None,
                         ),
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2006,6 +1998,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2025,6 +2018,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2042,6 +2036,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2061,6 +2056,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2080,6 +2076,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2097,6 +2094,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2118,6 +2116,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2139,6 +2138,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2158,6 +2158,7 @@ mod tests {
                         allow_inhibiting: false,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2175,6 +2176,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2194,10 +2196,9 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                 ],
-                layout_independent: false,
-                xkb: None,
             },
             switch_events: SwitchBinds {
                 lid_open: None,
@@ -2321,6 +2322,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2344,6 +2346,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                     Bind {
                         key: Key {
@@ -2369,6 +2372,7 @@ mod tests {
                         allow_inhibiting: true,
                         hotkey_overlay_title: None,
                         layout_independent: None,
+                        xkb: None,
                     },
                 ],
             },
@@ -2394,22 +2398,51 @@ mod tests {
             "#,
         );
 
-        assert!(parsed.binds.layout_independent);
+        assert_eq!(parsed.binds.binds.len(), 2);
+        assert_eq!(parsed.binds.binds[0].layout_independent, Some(true));
         assert_eq!(
-            parsed.binds.xkb,
+            parsed.binds.binds[0].xkb,
             Some(Xkb {
                 layout: String::from("us"),
                 variant: String::from("colemak"),
                 ..Default::default()
             })
         );
-        assert_eq!(parsed.binds.binds.len(), 2);
-        assert_eq!(parsed.binds.binds[0].layout_independent, None);
         assert_eq!(parsed.binds.binds[1].layout_independent, Some(false));
+        assert_eq!(parsed.binds.binds[1].xkb, None);
     }
 
     #[test]
-    fn layout_independent_binds_can_split_xkb_and_default_across_includes() {
+    fn parse_layout_independent_binds_is_order_independent_within_block() {
+        let parsed = do_parse(
+            r#"
+            binds {
+                Mod+T { close-window; }
+
+                xkb {
+                    layout "us"
+                    variant "colemak"
+                }
+
+                layout-independent true
+            }
+            "#,
+        );
+
+        assert_eq!(parsed.binds.binds.len(), 1);
+        assert_eq!(parsed.binds.binds[0].layout_independent, Some(true));
+        assert_eq!(
+            parsed.binds.binds[0].xkb,
+            Some(Xkb {
+                layout: String::from("us"),
+                variant: String::from("colemak"),
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn layout_independent_settings_do_not_apply_across_binds_blocks() {
         let dir = test_tempdir();
         let main = dir.path().join("config.kdl");
         let part1 = dir.path().join("binds-1.kdl");
@@ -2424,7 +2457,7 @@ mod tests {
                     layout "us"
                 }
 
-                Mod+T { close-window; }
+                Mod+T layout-independent=true { close-window; }
             }
             "#,
         )
@@ -2434,17 +2467,14 @@ mod tests {
             r#"
             binds {
                 layout-independent
+                Mod+Q { close-window; }
             }
             "#,
         )
         .unwrap();
 
-        let parsed = Config::load(&main).config.unwrap();
-        assert!(parsed.binds.layout_independent);
-        assert_eq!(
-            parsed.binds.xkb.as_ref().map(|xkb| xkb.layout.as_str()),
-            Some("us")
-        );
+        let err = format!("{:?}", Config::load(&main).config.unwrap_err());
+        assert!(err.contains("binds.xkb is required"));
     }
 
     #[test]
@@ -2466,7 +2496,7 @@ mod tests {
         .unwrap();
 
         let err = format!("{:?}", Config::load(&main).config.unwrap_err());
-        assert!(err.contains("binds.xkb is required when any bind is layout-independent"));
+        assert!(err.contains("binds.xkb is required"));
     }
 
     #[test]
@@ -2489,14 +2519,8 @@ mod tests {
         .unwrap();
 
         let parsed = Config::load(&main).config.unwrap();
-        assert_eq!(
-            parsed.binds.xkb,
-            Some(Xkb {
-                layout: String::from("us"),
-                ..Default::default()
-            })
-        );
-        assert!(!parsed.binds.layout_independent);
+        assert_eq!(parsed.binds.binds[0].xkb, None);
+        assert_eq!(parsed.binds.binds[0].layout_independent, None);
     }
 
     #[test]
@@ -2516,9 +2540,8 @@ mod tests {
         .unwrap();
 
         let parsed = Config::load(&main).config.unwrap();
-        assert!(parsed.binds.layout_independent);
         assert_eq!(parsed.binds.binds[0].layout_independent, Some(false));
-        assert_eq!(parsed.binds.xkb, None);
+        assert_eq!(parsed.binds.binds[0].xkb, None);
     }
 
     #[test]
@@ -2537,9 +2560,9 @@ mod tests {
             "#,
         );
 
-        assert!(parsed.binds.layout_independent);
+        assert_eq!(parsed.binds.binds[0].layout_independent, Some(true));
         assert_eq!(
-            parsed.binds.xkb,
+            parsed.binds.binds[0].xkb,
             Some(Xkb {
                 file: Some(String::from("/tmp/layout.xkb")),
                 ..Default::default()

--- a/niri-config/src/recent_windows.rs
+++ b/niri-config/src/recent_windows.rs
@@ -154,6 +154,7 @@ impl From<MruBind> for Bind {
             allow_when_locked: false,
             allow_inhibiting: x.allow_inhibiting,
             hotkey_overlay_title: x.hotkey_overlay_title,
+            layout_independent: None,
         }
     }
 }

--- a/niri-config/src/recent_windows.rs
+++ b/niri-config/src/recent_windows.rs
@@ -154,7 +154,6 @@ impl From<MruBind> for Bind {
             allow_when_locked: false,
             allow_inhibiting: x.allow_inhibiting,
             hotkey_overlay_title: x.hotkey_overlay_title,
-            layout_independent: None,
             xkb: None,
         }
     }

--- a/niri-config/src/recent_windows.rs
+++ b/niri-config/src/recent_windows.rs
@@ -155,6 +155,7 @@ impl From<MruBind> for Bind {
             allow_inhibiting: x.allow_inhibiting,
             hotkey_overlay_title: x.hotkey_overlay_title,
             layout_independent: None,
+            xkb: None,
         }
     }
 }

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -356,6 +356,16 @@ binds {
     //
     // Most actions that you can bind here can also be invoked programmatically with
     // `niri msg action do-something`.
+    //
+    // You can also make keyboard binds layout-independent by enabling:
+    //
+    // layout-independent true
+    // xkb {
+    //     layout "us"
+    // }
+    //
+    // This keeps binds like Mod+Slash matching the same physical key even after
+    // switching to another keyboard layout.
 
     // Mod-Shift-/, which is usually the same as Mod-?,
     // shows a list of important hotkeys.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::cmp::min;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -105,6 +106,113 @@ pub enum CompiledTrigger {
     TouchpadScrollUp,
     TouchpadScrollLeft,
     TouchpadScrollRight,
+}
+
+struct ModifierNameEntry {
+    modifier: Option<Modifiers>,
+    display_name: Option<&'static str>,
+    xkb_names: &'static [&'static str],
+}
+
+fn modifier_name_entries() -> &'static [ModifierNameEntry] {
+    &[
+        ModifierNameEntry {
+            modifier: Some(Modifiers::COMPOSITOR),
+            display_name: Some("Compositor"),
+            xkb_names: &[],
+        },
+        ModifierNameEntry {
+            modifier: Some(Modifiers::SUPER),
+            display_name: Some("Super"),
+            xkb_names: &[xkb::MOD_NAME_LOGO, "Logo", "Super", "Meta", "Win"],
+        },
+        ModifierNameEntry {
+            modifier: Some(Modifiers::CTRL),
+            display_name: Some("Ctrl"),
+            xkb_names: &[xkb::MOD_NAME_CTRL, "Ctrl"],
+        },
+        ModifierNameEntry {
+            modifier: Some(Modifiers::SHIFT),
+            display_name: Some("Shift"),
+            xkb_names: &[xkb::MOD_NAME_SHIFT],
+        },
+        ModifierNameEntry {
+            modifier: Some(Modifiers::ALT),
+            display_name: Some("Alt"),
+            xkb_names: &[xkb::MOD_NAME_ALT, "Alt"],
+        },
+        ModifierNameEntry {
+            modifier: Some(Modifiers::ISO_LEVEL3_SHIFT),
+            display_name: Some("ISO_Level3_Shift"),
+            xkb_names: &[
+                xkb::MOD_NAME_ISO_LEVEL3_SHIFT,
+                "ISO_Level3_Shift",
+                "LevelThree",
+                "AltGr",
+            ],
+        },
+        ModifierNameEntry {
+            modifier: Some(Modifiers::ISO_LEVEL5_SHIFT),
+            display_name: Some("ISO_Level5_Shift"),
+            xkb_names: &[xkb::MOD_NAME_MOD3, "ISO_Level5_Shift", "LevelFive"],
+        },
+        ModifierNameEntry {
+            modifier: None,
+            display_name: None,
+            xkb_names: &[xkb::MOD_NAME_CAPS, "Caps", "CapsLock"],
+        },
+        ModifierNameEntry {
+            modifier: None,
+            display_name: None,
+            xkb_names: &[xkb::MOD_NAME_NUM, "Num", "NumLock"],
+        },
+    ]
+}
+
+impl fmt::Display for CompiledTrigger {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Keysym(keysym) => f.write_str(&xkb::keysym_get_name(*keysym)),
+            Self::PhysicalKey(keycode) => write!(f, "keycode {}", keycode.raw()),
+            Self::MouseLeft => f.write_str("Mouse Left"),
+            Self::MouseRight => f.write_str("Mouse Right"),
+            Self::MouseMiddle => f.write_str("Mouse Middle"),
+            Self::MouseBack => f.write_str("Mouse Back"),
+            Self::MouseForward => f.write_str("Mouse Forward"),
+            Self::WheelScrollDown => f.write_str("Wheel Scroll Down"),
+            Self::WheelScrollUp => f.write_str("Wheel Scroll Up"),
+            Self::WheelScrollLeft => f.write_str("Wheel Scroll Left"),
+            Self::WheelScrollRight => f.write_str("Wheel Scroll Right"),
+            Self::TouchpadScrollDown => f.write_str("Touchpad Scroll Down"),
+            Self::TouchpadScrollUp => f.write_str("Touchpad Scroll Up"),
+            Self::TouchpadScrollLeft => f.write_str("Touchpad Scroll Left"),
+            Self::TouchpadScrollRight => f.write_str("Touchpad Scroll Right"),
+        }
+    }
+}
+
+impl fmt::Display for CompiledKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut wrote_modifier = false;
+        for entry in modifier_name_entries() {
+            let (Some(modifier), Some(name)) = (entry.modifier, entry.display_name) else {
+                continue;
+            };
+
+            if !self.modifiers.contains(modifier) {
+                continue;
+            }
+
+            write!(f, "{name}+")?;
+            wrote_modifier = true;
+        }
+
+        if !wrote_modifier {
+            return write!(f, "{}", self.trigger);
+        }
+
+        write!(f, "{}", self.trigger)
+    }
 }
 
 impl From<Trigger> for CompiledTrigger {
@@ -4611,10 +4719,6 @@ fn configured_bind_matches(
     bind_modifiers == modifiers
 }
 
-fn effective_layout_independent(binds: &Binds, bind: &ConfigBind) -> bool {
-    bind.layout_independent.unwrap_or(binds.layout_independent)
-}
-
 fn load_bind_keymap_from_file(path: &str) -> anyhow::Result<xkb::Keymap> {
     let path = PathBuf::from(path);
     let path = match expand_home(&path).context("failed to expand `~` in binds.xkb.file")? {
@@ -4654,50 +4758,13 @@ fn load_bind_keymap(xkb_config: &niri_config::Xkb) -> anyhow::Result<xkb::Keymap
 }
 
 fn modifier_from_xkb_name(name: &str) -> Option<Option<Modifiers>> {
-    canonical_modifier_from_xkb_name(name).or_else(|| modifier_from_xkb_alias(name))
-}
-
-fn canonical_modifier_from_xkb_name(name: &str) -> Option<Option<Modifiers>> {
-    [
-        (xkb::MOD_NAME_CTRL, Some(Modifiers::CTRL)),
-        (xkb::MOD_NAME_ALT, Some(Modifiers::ALT)),
-        (xkb::MOD_NAME_SHIFT, Some(Modifiers::SHIFT)),
-        (xkb::MOD_NAME_LOGO, Some(Modifiers::SUPER)),
-        (
-            xkb::MOD_NAME_ISO_LEVEL3_SHIFT,
-            Some(Modifiers::ISO_LEVEL3_SHIFT),
-        ),
-        (xkb::MOD_NAME_MOD3, Some(Modifiers::ISO_LEVEL5_SHIFT)),
-        (xkb::MOD_NAME_CAPS, None),
-        (xkb::MOD_NAME_NUM, None),
-    ]
-    .into_iter()
-    .find_map(|(canonical_name, modifier)| {
-        name.eq_ignore_ascii_case(canonical_name)
-            .then_some(modifier)
+    modifier_name_entries().iter().find_map(|entry| {
+        entry
+            .xkb_names
+            .iter()
+            .any(|candidate| name.eq_ignore_ascii_case(candidate))
+            .then_some(entry.modifier)
     })
-}
-
-fn modifier_from_xkb_alias(name: &str) -> Option<Option<Modifiers>> {
-    [
-        ("Ctrl", Some(Modifiers::CTRL)),
-        ("Alt", Some(Modifiers::ALT)),
-        ("Logo", Some(Modifiers::SUPER)),
-        ("Super", Some(Modifiers::SUPER)),
-        ("Meta", Some(Modifiers::SUPER)),
-        ("Win", Some(Modifiers::SUPER)),
-        ("ISO_Level3_Shift", Some(Modifiers::ISO_LEVEL3_SHIFT)),
-        ("LevelThree", Some(Modifiers::ISO_LEVEL3_SHIFT)),
-        ("AltGr", Some(Modifiers::ISO_LEVEL3_SHIFT)),
-        ("ISO_Level5_Shift", Some(Modifiers::ISO_LEVEL5_SHIFT)),
-        ("LevelFive", Some(Modifiers::ISO_LEVEL5_SHIFT)),
-        ("Caps", None),
-        ("CapsLock", None),
-        ("Num", None),
-        ("NumLock", None),
-    ]
-    .into_iter()
-    .find_map(|(alias, modifier)| name.eq_ignore_ascii_case(alias).then_some(modifier))
 }
 
 fn modifiers_from_xkb_mask(
@@ -4820,7 +4887,7 @@ pub fn compile_binds(binds: &Binds) -> anyhow::Result<Vec<CompiledBind>> {
     let needs_layout_independent = binds
         .binds
         .iter()
-        .any(|bind| effective_layout_independent(binds, bind));
+        .any(|bind| bind.layout_independent.unwrap_or(false));
 
     if !needs_layout_independent {
         return Ok(binds
@@ -4831,36 +4898,57 @@ pub fn compile_binds(binds: &Binds) -> anyhow::Result<Vec<CompiledBind>> {
             .collect());
     }
 
-    let xkb_config = binds
-        .xkb
-        .as_ref()
-        .context("layout-independent binds requested, but binds.xkb is missing")?;
-    let keymap = load_bind_keymap(xkb_config)?;
+    let mut keymaps: Vec<(niri_config::Xkb, xkb::Keymap)> = Vec::new();
     let mut errors = Vec::new();
 
     let compiled: Vec<_> = binds
         .binds
         .iter()
-        .cloned()
-        .map(|bind| {
-            let is_layout_independent = effective_layout_independent(binds, &bind);
-            let mut bind = CompiledBind::from(bind);
+        .map(|source_bind| {
+            let mut bind = CompiledBind::from(source_bind.clone());
 
-            if !is_layout_independent {
+            if !source_bind.layout_independent.unwrap_or(false) {
                 return bind;
             }
+
+            let Some(xkb_config) = source_bind.xkb.as_ref() else {
+                errors.push(format!(
+                    "failed to compile layout-independent bind {}: binds.xkb is missing",
+                    bind.key
+                ));
+                return bind;
+            };
+
+            let keymap =
+                if let Some((_, keymap)) = keymaps.iter().find(|(xkb, _)| xkb == xkb_config) {
+                    keymap
+                } else {
+                    match load_bind_keymap(xkb_config) {
+                        Ok(keymap) => {
+                            keymaps.push((xkb_config.clone(), keymap));
+                            &keymaps.last().unwrap().1
+                        }
+                        Err(err) => {
+                            errors.push(format!(
+                                "failed to compile layout-independent bind {}: {err:#}",
+                                bind.key
+                            ));
+                            return bind;
+                        }
+                    }
+                };
 
             let CompiledTrigger::Keysym(keysym) = bind.key.trigger else {
                 return bind;
             };
 
-            match resolve_bind_key(&keymap, keysym) {
+            match resolve_bind_key(keymap, keysym) {
                 Ok(key) => {
                     bind.key.trigger = key.trigger;
                     bind.key.modifiers |= key.modifiers;
                 }
                 Err(err) => errors.push(format!(
-                    "failed to compile layout-independent bind {:?}: {err:#}",
+                    "failed to compile layout-independent bind {}: {err:#}",
                     bind.key
                 )),
             }
@@ -4889,7 +4977,7 @@ fn duplicate_compiled_bind_errors(binds: &[CompiledBind]) -> Vec<String> {
             }
             Entry::Occupied(entry) => {
                 errors.push(format!(
-                    "duplicate compiled keybind after layout-independent resolution: key={:?}, first_action={:?}, duplicate_action={:?}",
+                    "duplicate compiled keybind after layout-independent resolution: key={}, first_action={:?}, duplicate_action={:?}",
                     bind.key,
                     entry.get().action,
                     bind.action,
@@ -5510,12 +5598,7 @@ mod tests {
     use crate::animation::Clock;
 
     fn test_binds(binds: Vec<SourceBind>) -> Vec<CompiledBind> {
-        compile_binds(&Binds {
-            binds,
-            layout_independent: false,
-            xkb: None,
-        })
-        .unwrap()
+        compile_binds(&Binds { binds }).unwrap()
     }
 
     struct TestTempDir(PathBuf);
@@ -5558,6 +5641,7 @@ mod tests {
             allow_inhibiting: true,
             hotkey_overlay_title: None,
             layout_independent: None,
+            xkb: None,
         }]);
 
         let comp_mod = ModKey::Super;
@@ -5792,6 +5876,7 @@ mod tests {
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
                 layout_independent: None,
+                xkb: None,
             },
             SourceBind {
                 key: Key {
@@ -5805,6 +5890,7 @@ mod tests {
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
                 layout_independent: None,
+                xkb: None,
             },
             SourceBind {
                 key: Key {
@@ -5818,6 +5904,7 @@ mod tests {
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
                 layout_independent: None,
+                xkb: None,
             },
             SourceBind {
                 key: Key {
@@ -5831,6 +5918,7 @@ mod tests {
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
                 layout_independent: None,
+                xkb: None,
             },
             SourceBind {
                 key: Key {
@@ -5844,6 +5932,7 @@ mod tests {
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
                 layout_independent: None,
+                xkb: None,
             },
         ]);
 
@@ -6010,16 +6099,15 @@ mod tests {
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
                 layout_independent: Some(true),
+                xkb: Some(niri_config::Xkb {
+                    layout: String::from("us"),
+                    ..Default::default()
+                }),
             }],
-            layout_independent: false,
-            xkb: Some(niri_config::Xkb {
-                layout: String::from("us"),
-                ..Default::default()
-            }),
         };
 
         let compiled = compile_binds(&binds).unwrap();
-        let keymap = load_bind_keymap(binds.xkb.as_ref().unwrap()).unwrap();
+        let keymap = load_bind_keymap(binds.binds[0].xkb.as_ref().unwrap()).unwrap();
         let keycode = match resolve_bind_key(&keymap, Keysym::slash).unwrap().trigger {
             CompiledTrigger::PhysicalKey(keycode) => keycode,
             _ => unreachable!(),
@@ -6062,16 +6150,15 @@ mod tests {
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
                 layout_independent: Some(true),
+                xkb: Some(niri_config::Xkb {
+                    layout: String::from("us"),
+                    ..Default::default()
+                }),
             }],
-            layout_independent: false,
-            xkb: Some(niri_config::Xkb {
-                layout: String::from("us"),
-                ..Default::default()
-            }),
         };
 
         let compiled = compile_binds(&binds).unwrap();
-        let keymap = load_bind_keymap(binds.xkb.as_ref().unwrap()).unwrap();
+        let keymap = load_bind_keymap(binds.binds[0].xkb.as_ref().unwrap()).unwrap();
         let exclam = match resolve_bind_key(&keymap, Keysym::exclam).unwrap().trigger {
             CompiledTrigger::PhysicalKey(keycode) => keycode,
             _ => unreachable!(),
@@ -6138,6 +6225,10 @@ mod tests {
                     allow_inhibiting: true,
                     hotkey_overlay_title: None,
                     layout_independent: Some(true),
+                    xkb: Some(niri_config::Xkb {
+                        layout: String::from("us"),
+                        ..Default::default()
+                    }),
                 },
                 SourceBind {
                     key: Key {
@@ -6151,17 +6242,13 @@ mod tests {
                     allow_inhibiting: true,
                     hotkey_overlay_title: None,
                     layout_independent: Some(false),
+                    xkb: None,
                 },
             ],
-            layout_independent: false,
-            xkb: Some(niri_config::Xkb {
-                layout: String::from("us"),
-                ..Default::default()
-            }),
         };
 
         let compiled = compile_binds(&binds).unwrap();
-        let keymap = load_bind_keymap(binds.xkb.as_ref().unwrap()).unwrap();
+        let keymap = load_bind_keymap(binds.binds[0].xkb.as_ref().unwrap()).unwrap();
         let slash_keycode = match resolve_bind_key(&keymap, Keysym::slash).unwrap().trigger {
             CompiledTrigger::PhysicalKey(keycode) => keycode,
             _ => unreachable!(),
@@ -6220,16 +6307,15 @@ mod tests {
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
                 layout_independent: Some(true),
+                xkb: Some(niri_config::Xkb {
+                    layout: String::from("us"),
+                    ..Default::default()
+                }),
             }],
-            layout_independent: false,
-            xkb: Some(niri_config::Xkb {
-                layout: String::from("us"),
-                ..Default::default()
-            }),
         };
 
         let compiled = compile_binds(&binds).unwrap();
-        let keymap = load_bind_keymap(binds.xkb.as_ref().unwrap()).unwrap();
+        let keymap = load_bind_keymap(binds.binds[0].xkb.as_ref().unwrap()).unwrap();
         let keycode = match resolve_bind_key(&keymap, Keysym::slash).unwrap().trigger {
             CompiledTrigger::PhysicalKey(keycode) => keycode,
             _ => unreachable!(),
@@ -6268,6 +6354,10 @@ mod tests {
                     allow_inhibiting: true,
                     hotkey_overlay_title: None,
                     layout_independent: Some(true),
+                    xkb: Some(niri_config::Xkb {
+                        layout: String::from("us"),
+                        ..Default::default()
+                    }),
                 },
                 SourceBind {
                     key: Key {
@@ -6281,18 +6371,17 @@ mod tests {
                     allow_inhibiting: true,
                     hotkey_overlay_title: None,
                     layout_independent: Some(true),
+                    xkb: Some(niri_config::Xkb {
+                        layout: String::from("us"),
+                        ..Default::default()
+                    }),
                 },
             ],
-            layout_independent: false,
-            xkb: Some(niri_config::Xkb {
-                layout: String::from("us"),
-                ..Default::default()
-            }),
         };
 
         let err = compile_binds(&binds).unwrap_err().to_string();
         assert!(err.contains("duplicate compiled keybind after layout-independent resolution"));
-        assert!(err.contains("PhysicalKey"));
+        assert!(err.contains("keycode "));
     }
 
     #[test]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3122,6 +3122,7 @@ impl State {
                                 allow_when_locked: false,
                                 allow_inhibiting: false,
                                 hotkey_overlay_title: None,
+                                layout_independent: None,
                             });
                             let bind_right = Some(Bind {
                                 key: Key {
@@ -3134,6 +3135,7 @@ impl State {
                                 allow_when_locked: false,
                                 allow_inhibiting: false,
                                 hotkey_overlay_title: None,
+                                layout_independent: None,
                             });
                             (bind_left, bind_right)
                         } else {
@@ -3183,6 +3185,7 @@ impl State {
                             allow_when_locked: false,
                             allow_inhibiting: false,
                             hotkey_overlay_title: None,
+                            layout_independent: None,
                         });
                         let bind_down = Some(Bind {
                             key: Key {
@@ -3195,6 +3198,7 @@ impl State {
                             allow_when_locked: false,
                             allow_inhibiting: false,
                             hotkey_overlay_title: None,
+                            layout_independent: None,
                         });
                         (bind_up, bind_down)
                     } else if should_handle_in_overview && modifiers == Modifiers::SHIFT {
@@ -3209,6 +3213,7 @@ impl State {
                             allow_when_locked: false,
                             allow_inhibiting: false,
                             hotkey_overlay_title: None,
+                            layout_independent: None,
                         });
                         let bind_down = Some(Bind {
                             key: Key {
@@ -3221,6 +3226,7 @@ impl State {
                             allow_when_locked: false,
                             allow_inhibiting: false,
                             hotkey_overlay_title: None,
+                            layout_independent: None,
                         });
                         (bind_up, bind_down)
                     } else {
@@ -4359,6 +4365,7 @@ fn should_intercept_key<'a>(
                     // inhibited.
                     allow_inhibiting: false,
                     hotkey_overlay_title: None,
+                    layout_independent: None,
                 });
             }
         }
@@ -4418,13 +4425,12 @@ fn find_bind<'a>(
             repeat: true,
             cooldown: None,
             allow_when_locked: false,
-            // In a worst-case scenario, the user has no way to unlock the compositor and a
-            // misbehaving client has a keyboard shortcuts inhibitor, "jailing" the user.
-            // The user must always be able to change VTs to recover from such a situation.
+            // Hardcoded binds never honor shortcuts inhibition.
             // It also makes no sense to inhibit the default power key handling.
             // Hardcoded binds must never be inhibited.
             allow_inhibiting: false,
             hotkey_overlay_title: None,
+            layout_independent: None,
         });
     }
 
@@ -4634,16 +4640,12 @@ fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Bind> {
         return None;
     }
 
-    let mut repeat = true;
-    let action = match raw {
-        Keysym::Escape | Keysym::Return => {
-            repeat = false;
-            Action::ToggleOverview
-        }
-        Keysym::Left => Action::FocusColumnLeft,
-        Keysym::Right => Action::FocusColumnRight,
-        Keysym::Up => Action::FocusWindowOrWorkspaceUp,
-        Keysym::Down => Action::FocusWindowOrWorkspaceDown,
+    let (action, repeat) = match raw {
+        Keysym::Escape | Keysym::Return => (Action::ToggleOverview, false),
+        Keysym::Left => (Action::FocusColumnLeft, true),
+        Keysym::Right => (Action::FocusColumnRight, true),
+        Keysym::Up => (Action::FocusWindowOrWorkspaceUp, true),
+        Keysym::Down => (Action::FocusWindowOrWorkspaceDown, true),
         _ => {
             return None;
         }
@@ -4660,6 +4662,7 @@ fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Bind> {
         allow_when_locked: false,
         allow_inhibiting: false,
         hotkey_overlay_title: None,
+        layout_independent: None,
     })
 }
 
@@ -4951,7 +4954,7 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
 
 pub fn mods_with_binds(mod_key: ModKey, binds: &Binds, triggers: &[Trigger]) -> HashSet<Modifiers> {
     let mut rv = HashSet::new();
-    for bind in &binds.0 {
+    for bind in &binds.binds {
         if !triggers.contains(&bind.key.trigger) {
             continue;
         }
@@ -5042,7 +5045,7 @@ fn make_binds_iter<'a>(
     mods: Modifiers,
 ) -> impl Iterator<Item = &'a Bind> + Clone {
     // Figure out the binds to use depending on whether the MRU is enabled and/or open.
-    let general_binds = (!mru.is_open()).then_some(config.binds.0.iter());
+    let general_binds = (!mru.is_open()).then_some(config.binds.binds.iter());
     let general_binds = general_binds.into_iter().flatten();
 
     let mru_binds =
@@ -5066,18 +5069,23 @@ mod tests {
     #[test]
     fn bindings_suppress_keys() {
         let close_keysym = Keysym::q;
-        let bindings = Binds(vec![Bind {
-            key: Key {
-                trigger: Trigger::Keysym(close_keysym),
-                modifiers: Modifiers::COMPOSITOR | Modifiers::CTRL,
-            },
-            action: Action::CloseWindow,
-            repeat: true,
-            cooldown: None,
-            allow_when_locked: false,
-            allow_inhibiting: true,
-            hotkey_overlay_title: None,
-        }]);
+        let bindings = Binds {
+            binds: vec![Bind {
+                key: Key {
+                    trigger: Trigger::Keysym(close_keysym),
+                    modifiers: Modifiers::COMPOSITOR | Modifiers::CTRL,
+                },
+                action: Action::CloseWindow,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+                hotkey_overlay_title: None,
+                layout_independent: None,
+            }],
+            layout_independent: false,
+            xkb: None,
+        };
 
         let comp_mod = ModKey::Super;
         let mut suppressed_keys = HashSet::new();
@@ -5093,7 +5101,7 @@ mod tests {
         let close_key_event = |suppr: &mut HashSet<Keycode>, mods: ModifiersState, pressed| {
             should_intercept_key(
                 suppr,
-                &bindings.0,
+                &bindings.binds,
                 comp_mod,
                 close_key_code,
                 close_keysym,
@@ -5110,7 +5118,7 @@ mod tests {
         let none_key_event = |suppr: &mut HashSet<Keycode>, mods: ModifiersState, pressed| {
             should_intercept_key(
                 suppr,
-                &bindings.0,
+                &bindings.binds,
                 comp_mod,
                 Keycode::from(Keysym::l.raw() + 8),
                 Keysym::l,
@@ -5251,72 +5259,81 @@ mod tests {
 
     #[test]
     fn comp_mod_handling() {
-        let bindings = Binds(vec![
-            Bind {
-                key: Key {
-                    trigger: Trigger::Keysym(Keysym::q),
-                    modifiers: Modifiers::COMPOSITOR,
+        let bindings = Binds {
+            binds: vec![
+                Bind {
+                    key: Key {
+                        trigger: Trigger::Keysym(Keysym::q),
+                        modifiers: Modifiers::COMPOSITOR,
+                    },
+                    action: Action::CloseWindow,
+                    repeat: true,
+                    cooldown: None,
+                    allow_when_locked: false,
+                    allow_inhibiting: true,
+                    hotkey_overlay_title: None,
+                    layout_independent: None,
                 },
-                action: Action::CloseWindow,
-                repeat: true,
-                cooldown: None,
-                allow_when_locked: false,
-                allow_inhibiting: true,
-                hotkey_overlay_title: None,
-            },
-            Bind {
-                key: Key {
-                    trigger: Trigger::Keysym(Keysym::h),
-                    modifiers: Modifiers::SUPER,
+                Bind {
+                    key: Key {
+                        trigger: Trigger::Keysym(Keysym::h),
+                        modifiers: Modifiers::SUPER,
+                    },
+                    action: Action::CloseWindow,
+                    repeat: true,
+                    cooldown: None,
+                    allow_when_locked: false,
+                    allow_inhibiting: true,
+                    hotkey_overlay_title: None,
+                    layout_independent: None,
                 },
-                action: Action::FocusColumnLeft,
-                repeat: true,
-                cooldown: None,
-                allow_when_locked: false,
-                allow_inhibiting: true,
-                hotkey_overlay_title: None,
-            },
-            Bind {
-                key: Key {
-                    trigger: Trigger::Keysym(Keysym::j),
-                    modifiers: Modifiers::empty(),
+                Bind {
+                    key: Key {
+                        trigger: Trigger::Keysym(Keysym::j),
+                        modifiers: Modifiers::empty(),
+                    },
+                    action: Action::CloseWindow,
+                    repeat: true,
+                    cooldown: None,
+                    allow_when_locked: false,
+                    allow_inhibiting: true,
+                    hotkey_overlay_title: None,
+                    layout_independent: None,
                 },
-                action: Action::FocusWindowDown,
-                repeat: true,
-                cooldown: None,
-                allow_when_locked: false,
-                allow_inhibiting: true,
-                hotkey_overlay_title: None,
-            },
-            Bind {
-                key: Key {
-                    trigger: Trigger::Keysym(Keysym::k),
-                    modifiers: Modifiers::COMPOSITOR | Modifiers::SUPER,
+                Bind {
+                    key: Key {
+                        trigger: Trigger::Keysym(Keysym::k),
+                        modifiers: Modifiers::COMPOSITOR | Modifiers::SUPER,
+                    },
+                    action: Action::CloseWindow,
+                    repeat: true,
+                    cooldown: None,
+                    allow_when_locked: false,
+                    allow_inhibiting: true,
+                    hotkey_overlay_title: None,
+                    layout_independent: None,
                 },
-                action: Action::FocusWindowUp,
-                repeat: true,
-                cooldown: None,
-                allow_when_locked: false,
-                allow_inhibiting: true,
-                hotkey_overlay_title: None,
-            },
-            Bind {
-                key: Key {
-                    trigger: Trigger::Keysym(Keysym::l),
-                    modifiers: Modifiers::SUPER | Modifiers::ALT,
+                Bind {
+                    key: Key {
+                        trigger: Trigger::Keysym(Keysym::l),
+                        modifiers: Modifiers::SUPER | Modifiers::ALT,
+                    },
+                    action: Action::CloseWindow,
+                    repeat: true,
+                    cooldown: None,
+                    allow_when_locked: false,
+                    allow_inhibiting: true,
+                    hotkey_overlay_title: None,
+                    layout_independent: None,
                 },
-                action: Action::FocusColumnRight,
-                repeat: true,
-                cooldown: None,
-                allow_when_locked: false,
-                allow_inhibiting: true,
-                hotkey_overlay_title: None,
-            },
-        ]);
+            ],
+            layout_independent: false,
+            xkb: None,
+        };
 
         assert_eq!(
             find_configured_bind(
-                &bindings.0,
+                &bindings.binds,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::q),
                 ModifiersState {
@@ -5325,11 +5342,11 @@ mod tests {
                 }
             )
             .as_ref(),
-            Some(&bindings.0[0])
+            Some(&bindings.binds[0])
         );
         assert_eq!(
             find_configured_bind(
-                &bindings.0,
+                &bindings.binds,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::q),
                 ModifiersState::default(),
@@ -5339,7 +5356,7 @@ mod tests {
 
         assert_eq!(
             find_configured_bind(
-                &bindings.0,
+                &bindings.binds,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::h),
                 ModifiersState {
@@ -5348,11 +5365,11 @@ mod tests {
                 }
             )
             .as_ref(),
-            Some(&bindings.0[1])
+            Some(&bindings.binds[1])
         );
         assert_eq!(
             find_configured_bind(
-                &bindings.0,
+                &bindings.binds,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::h),
                 ModifiersState::default(),
@@ -5362,7 +5379,7 @@ mod tests {
 
         assert_eq!(
             find_configured_bind(
-                &bindings.0,
+                &bindings.binds,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::j),
                 ModifiersState {
@@ -5374,18 +5391,18 @@ mod tests {
         );
         assert_eq!(
             find_configured_bind(
-                &bindings.0,
+                &bindings.binds,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::j),
                 ModifiersState::default(),
             )
             .as_ref(),
-            Some(&bindings.0[2])
+            Some(&bindings.binds[2])
         );
 
         assert_eq!(
             find_configured_bind(
-                &bindings.0,
+                &bindings.binds,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::k),
                 ModifiersState {
@@ -5394,11 +5411,11 @@ mod tests {
                 }
             )
             .as_ref(),
-            Some(&bindings.0[3])
+            Some(&bindings.binds[3])
         );
         assert_eq!(
             find_configured_bind(
-                &bindings.0,
+                &bindings.binds,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::k),
                 ModifiersState::default(),
@@ -5408,7 +5425,7 @@ mod tests {
 
         assert_eq!(
             find_configured_bind(
-                &bindings.0,
+                &bindings.binds,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::l),
                 ModifiersState {
@@ -5418,11 +5435,11 @@ mod tests {
                 }
             )
             .as_ref(),
-            Some(&bindings.0[4])
+            Some(&bindings.binds[4])
         );
         assert_eq!(
             find_configured_bind(
-                &bindings.0,
+                &bindings.binds,
                 ModKey::Super,
                 Trigger::Keysym(Keysym::l),
                 ModifiersState {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4807,7 +4807,10 @@ fn modifiers_from_xkb_mask(
     }
 }
 
-fn resolve_bind_key(keymap: &xkb::Keymap, keysym: Keysym) -> anyhow::Result<CompiledKey> {
+fn resolve_bind_physical_keys(
+    keymap: &xkb::Keymap,
+    keysym: Keysym,
+) -> anyhow::Result<Vec<CompiledKey>> {
     let mut matching_keys = Vec::new();
     let mut masks = [xkb::ModMask::default(); 32];
     let mut unsupported_modifiers = Vec::new();
@@ -4868,18 +4871,7 @@ fn resolve_bind_key(keymap: &xkb::Keymap, keysym: Keysym) -> anyhow::Result<Comp
                 )
             }
         }
-        [key] => Ok(*key),
-        _ => {
-            let keys = matching_keys
-                .iter()
-                .map(|key| format!("{key:?}"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            anyhow::bail!(
-                "keysym {} is ambiguous in the reference binds.xkb keymap; matching keys: {keys}",
-                xkb::keysym_get_name(keysym)
-            );
-        }
+        _ => Ok(matching_keys),
     }
 }
 
@@ -4898,61 +4890,58 @@ pub fn compile_binds(binds: &Binds) -> anyhow::Result<Vec<CompiledBind>> {
     let mut keymaps: Vec<(niri_config::Xkb, xkb::Keymap)> = Vec::new();
     let mut errors = Vec::new();
 
-    let compiled: Vec<_> = binds
-        .binds
-        .iter()
-        .map(|source_bind| {
-            let mut bind = CompiledBind::from(source_bind.clone());
+    let mut compiled = Vec::new();
 
-            if source_bind.xkb.is_none() {
-                return bind;
+    for source_bind in &binds.binds {
+        let bind = CompiledBind::from(source_bind.clone());
+
+        if source_bind.xkb.is_none() {
+            compiled.push(bind);
+            continue;
+        }
+
+        let xkb_config = source_bind.xkb.as_ref().unwrap();
+
+        let keymap = if let Some((_, keymap)) = keymaps.iter().find(|(xkb, _)| xkb == xkb_config) {
+            keymap
+        } else {
+            match load_bind_keymap(xkb_config) {
+                Ok(keymap) => {
+                    keymaps.push((xkb_config.clone(), keymap));
+                    &keymaps.last().unwrap().1
+                }
+                Err(err) => {
+                    errors.push(format!(
+                        "failed to compile layout-independent bind {}: {err:#}",
+                        bind.key
+                    ));
+                    continue;
+                }
             }
+        };
 
-            let Some(xkb_config) = source_bind.xkb.as_ref() else {
-                errors.push(format!(
-                    "failed to compile layout-independent bind {}: binds.xkb is missing",
-                    bind.key
-                ));
-                return bind;
-            };
+        let CompiledTrigger::Keysym(keysym) = bind.key.trigger else {
+            compiled.push(bind);
+            continue;
+        };
 
-            let keymap =
-                if let Some((_, keymap)) = keymaps.iter().find(|(xkb, _)| xkb == xkb_config) {
-                    keymap
-                } else {
-                    match load_bind_keymap(xkb_config) {
-                        Ok(keymap) => {
-                            keymaps.push((xkb_config.clone(), keymap));
-                            &keymaps.last().unwrap().1
-                        }
-                        Err(err) => {
-                            errors.push(format!(
-                                "failed to compile layout-independent bind {}: {err:#}",
-                                bind.key
-                            ));
-                            return bind;
-                        }
-                    }
-                };
-
-            let CompiledTrigger::Keysym(keysym) = bind.key.trigger else {
-                return bind;
-            };
-
-            match resolve_bind_key(keymap, keysym) {
-                Ok(key) => {
+        match resolve_bind_physical_keys(keymap, keysym) {
+            Ok(keys) => {
+                // Ambiguous symbols intentionally expand to every physical key that produces them
+                // in the reference keymap. We reject only if the expanded bindings collide later.
+                for key in keys {
+                    let mut bind = bind.clone();
                     bind.key.trigger = key.trigger;
                     bind.key.modifiers |= key.modifiers;
+                    compiled.push(bind);
                 }
-                Err(err) => errors.push(format!(
-                    "failed to compile layout-independent bind {}: {err:#}",
-                    bind.key
-                )),
             }
-
-            bind
-        })
-        .collect();
+            Err(err) => errors.push(format!(
+                "failed to compile layout-independent bind {}: {err:#}",
+                bind.key
+            )),
+        }
+    }
 
     errors.extend(duplicate_compiled_bind_errors(&compiled));
 
@@ -6098,7 +6087,7 @@ mod tests {
 
         let compiled = compile_binds(&binds).unwrap();
         let keymap = load_bind_keymap(binds.binds[0].xkb.as_ref().unwrap()).unwrap();
-        let keycode = match resolve_bind_key(&keymap, Keysym::slash).unwrap().trigger {
+        let keycode = match resolve_bind_physical_keys(&keymap, Keysym::slash).unwrap()[0].trigger {
             CompiledTrigger::PhysicalKey(keycode) => keycode,
             _ => unreachable!(),
         };
@@ -6148,11 +6137,11 @@ mod tests {
 
         let compiled = compile_binds(&binds).unwrap();
         let keymap = load_bind_keymap(binds.binds[0].xkb.as_ref().unwrap()).unwrap();
-        let exclam = match resolve_bind_key(&keymap, Keysym::exclam).unwrap().trigger {
+        let exclam = match resolve_bind_physical_keys(&keymap, Keysym::exclam).unwrap()[0].trigger {
             CompiledTrigger::PhysicalKey(keycode) => keycode,
             _ => unreachable!(),
         };
-        let one = match resolve_bind_key(&keymap, Keysym::_1).unwrap().trigger {
+        let one = match resolve_bind_physical_keys(&keymap, Keysym::_1).unwrap()[0].trigger {
             CompiledTrigger::PhysicalKey(keycode) => keycode,
             _ => unreachable!(),
         };
@@ -6236,11 +6225,12 @@ mod tests {
 
         let compiled = compile_binds(&binds).unwrap();
         let keymap = load_bind_keymap(binds.binds[0].xkb.as_ref().unwrap()).unwrap();
-        let slash_keycode = match resolve_bind_key(&keymap, Keysym::slash).unwrap().trigger {
-            CompiledTrigger::PhysicalKey(keycode) => keycode,
-            _ => unreachable!(),
-        };
-        let q_keycode = match resolve_bind_key(&keymap, Keysym::q).unwrap().trigger {
+        let slash_keycode =
+            match resolve_bind_physical_keys(&keymap, Keysym::slash).unwrap()[0].trigger {
+                CompiledTrigger::PhysicalKey(keycode) => keycode,
+                _ => unreachable!(),
+            };
+        let q_keycode = match resolve_bind_physical_keys(&keymap, Keysym::q).unwrap()[0].trigger {
             CompiledTrigger::PhysicalKey(keycode) => keycode,
             _ => unreachable!(),
         };
@@ -6302,7 +6292,7 @@ mod tests {
 
         let compiled = compile_binds(&binds).unwrap();
         let keymap = load_bind_keymap(binds.binds[0].xkb.as_ref().unwrap()).unwrap();
-        let keycode = match resolve_bind_key(&keymap, Keysym::slash).unwrap().trigger {
+        let keycode = match resolve_bind_physical_keys(&keymap, Keysym::slash).unwrap()[0].trigger {
             CompiledTrigger::PhysicalKey(keycode) => keycode,
             _ => unreachable!(),
         };
@@ -6369,7 +6359,7 @@ mod tests {
     }
 
     #[test]
-    fn config_with_ambiguous_reference_keymap_file_fails_bind_compilation() {
+    fn ambiguous_reference_keymap_file_expands_bind_to_multiple_physical_keys() {
         let dir = test_tempdir();
         let config_path = dir.path().join("config.kdl");
         let keymap_path = dir.path().join("ambiguous.xkb");
@@ -6411,7 +6401,64 @@ mod tests {
         .unwrap();
 
         let config = Config::load(&config_path).config.unwrap();
+        let keymap = load_bind_keymap_from_file(keymap_path.to_str().unwrap()).unwrap();
+        let keys = resolve_bind_physical_keys(&keymap, Keysym::exclam).unwrap();
+        let compiled = compile_binds(&config.binds).unwrap();
+
+        assert_eq!(keys.len(), 2);
+        assert_eq!(compiled.len(), keys.len());
+        for (bind, key) in compiled.iter().zip(keys) {
+            assert_eq!(bind.action, Action::CloseWindow);
+            assert_eq!(bind.key.trigger, key.trigger);
+            assert_eq!(bind.key.modifiers, Modifiers::COMPOSITOR | key.modifiers);
+        }
+    }
+
+    #[test]
+    fn ambiguous_reference_keymap_file_still_fails_on_expanded_collisions() {
+        let dir = test_tempdir();
+        let config_path = dir.path().join("config.kdl");
+        let keymap_path = dir.path().join("ambiguous.xkb");
+
+        let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let keymap =
+            xkb::Keymap::new_from_names(&context, "", "", "us", "", None, xkb::COMPILE_NO_FLAGS)
+                .unwrap();
+        let keymap = keymap
+            .get_as_string(xkb::KEYMAP_FORMAT_TEXT_V1)
+            .lines()
+            .map(|line| {
+                if line.contains("key <AE02>") {
+                    "\tkey <AE02>               {\t[               2,          exclam ] };"
+                        .to_owned()
+                } else {
+                    line.to_owned()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&keymap_path, keymap).unwrap();
+
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+                binds {{
+                    xkb {{
+                        file "{}"
+                    }}
+
+                    Mod+exclam layout-independent=true {{ close-window; }}
+                    Mod+Shift+1 layout-independent=true {{ quit; }}
+                }}
+                "#,
+                keymap_path.display()
+            ),
+        )
+        .unwrap();
+
+        let config = Config::load(&config_path).config.unwrap();
         let err = compile_binds(&config.binds).unwrap_err().to_string();
-        assert!(err.contains("keysym exclam is ambiguous in the reference binds.xkb keymap"));
+        assert!(err.contains("duplicate compiled keybind after layout-independent resolution"));
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,9 +1,11 @@
 use std::any::Any;
 use std::cmp::min;
 use std::collections::hash_map::Entry;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::time::Duration;
 
+use anyhow::Context as _;
 use calloop::timer::{TimeoutAction, Timer};
 use input::event::gesture::GestureEventCoordinates as _;
 use niri_config::{
@@ -21,7 +23,7 @@ use smithay::backend::input::{
 };
 use smithay::backend::libinput::LibinputInputBackend;
 use smithay::input::dnd::DnDGrab;
-use smithay::input::keyboard::{keysyms, FilterResult, Keysym, Layout, ModifiersState};
+use smithay::input::keyboard::{keysyms, xkb, FilterResult, Keysym, Layout, ModifiersState};
 use smithay::input::pointer::{
     AxisFrame, ButtonEvent, CursorIcon, CursorImageStatus, Focus, GestureHoldBeginEvent,
     GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent,
@@ -52,7 +54,7 @@ use crate::niri::{CastTarget, PointerVisibility, State};
 use crate::ui::mru::{WindowMru, WindowMruUi};
 use crate::ui::screenshot_ui::ScreenshotUi;
 use crate::utils::spawning::{spawn, spawn_sh};
-use crate::utils::{center, get_monotonic_time, CastSessionId, ResizeEdge};
+use crate::utils::{center, expand_home, get_monotonic_time, CastSessionId, ResizeEdge};
 
 pub mod backend_ext;
 pub mod move_grab;
@@ -4528,13 +4530,17 @@ fn find_bind(
             repeat: true,
             cooldown: None,
             allow_when_locked: false,
-            // Hardcoded binds never honor shortcuts inhibition.
+            // In a worst-case scenario, the user has no way to unlock the compositor and a
+            // misbehaving client has a keyboard shortcuts inhibitor, "jailing" the user.
+            // The user must always be able to change VTs to recover from such a situation.
             // It also makes no sense to inhibit the default power key handling.
             // Hardcoded binds must never be inhibited.
             allow_inhibiting: false,
         });
     }
 
+    // Layout-independent binds compile to physical keys and intentionally win over symbol-based
+    // binds when both would match the same event.
     let modifiers = configured_bind_modifiers(mod_key, mods);
     let physical_trigger = CompiledTrigger::PhysicalKey(key_code);
     let keysym_trigger = raw.map(CompiledTrigger::Keysym);
@@ -4603,6 +4609,296 @@ fn configured_bind_matches(
     }
 
     bind_modifiers == modifiers
+}
+
+fn effective_layout_independent(binds: &Binds, bind: &ConfigBind) -> bool {
+    bind.layout_independent.unwrap_or(binds.layout_independent)
+}
+
+fn load_bind_keymap_from_file(path: &str) -> anyhow::Result<xkb::Keymap> {
+    let path = PathBuf::from(path);
+    let path = match expand_home(&path).context("failed to expand `~` in binds.xkb.file")? {
+        Some(path) => path,
+        None => path,
+    };
+
+    let keymap = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read binds.xkb.file at {path:?}"))?;
+
+    let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+    xkb::Keymap::new_from_string(
+        &context,
+        keymap,
+        xkb::KEYMAP_FORMAT_TEXT_V1,
+        xkb::COMPILE_NO_FLAGS,
+    )
+    .with_context(|| format!("failed to compile binds.xkb keymap from file {path:?}"))
+}
+
+fn load_bind_keymap(xkb_config: &niri_config::Xkb) -> anyhow::Result<xkb::Keymap> {
+    if let Some(path) = &xkb_config.file {
+        return load_bind_keymap_from_file(path);
+    }
+
+    let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+    xkb::Keymap::new_from_names(
+        &context,
+        &xkb_config.rules,
+        &xkb_config.model,
+        &xkb_config.layout,
+        &xkb_config.variant,
+        xkb_config.options.clone(),
+        xkb::COMPILE_NO_FLAGS,
+    )
+    .context("failed to compile binds.xkb keymap from rules/model/layout/variant/options")
+}
+
+fn modifier_from_xkb_name(name: &str) -> Option<Option<Modifiers>> {
+    canonical_modifier_from_xkb_name(name).or_else(|| modifier_from_xkb_alias(name))
+}
+
+fn canonical_modifier_from_xkb_name(name: &str) -> Option<Option<Modifiers>> {
+    [
+        (xkb::MOD_NAME_CTRL, Some(Modifiers::CTRL)),
+        (xkb::MOD_NAME_ALT, Some(Modifiers::ALT)),
+        (xkb::MOD_NAME_SHIFT, Some(Modifiers::SHIFT)),
+        (xkb::MOD_NAME_LOGO, Some(Modifiers::SUPER)),
+        (
+            xkb::MOD_NAME_ISO_LEVEL3_SHIFT,
+            Some(Modifiers::ISO_LEVEL3_SHIFT),
+        ),
+        (xkb::MOD_NAME_MOD3, Some(Modifiers::ISO_LEVEL5_SHIFT)),
+        (xkb::MOD_NAME_CAPS, None),
+        (xkb::MOD_NAME_NUM, None),
+    ]
+    .into_iter()
+    .find_map(|(canonical_name, modifier)| {
+        name.eq_ignore_ascii_case(canonical_name)
+            .then_some(modifier)
+    })
+}
+
+fn modifier_from_xkb_alias(name: &str) -> Option<Option<Modifiers>> {
+    [
+        ("Ctrl", Some(Modifiers::CTRL)),
+        ("Alt", Some(Modifiers::ALT)),
+        ("Logo", Some(Modifiers::SUPER)),
+        ("Super", Some(Modifiers::SUPER)),
+        ("Meta", Some(Modifiers::SUPER)),
+        ("Win", Some(Modifiers::SUPER)),
+        ("ISO_Level3_Shift", Some(Modifiers::ISO_LEVEL3_SHIFT)),
+        ("LevelThree", Some(Modifiers::ISO_LEVEL3_SHIFT)),
+        ("AltGr", Some(Modifiers::ISO_LEVEL3_SHIFT)),
+        ("ISO_Level5_Shift", Some(Modifiers::ISO_LEVEL5_SHIFT)),
+        ("LevelFive", Some(Modifiers::ISO_LEVEL5_SHIFT)),
+        ("Caps", None),
+        ("CapsLock", None),
+        ("Num", None),
+        ("NumLock", None),
+    ]
+    .into_iter()
+    .find_map(|(alias, modifier)| name.eq_ignore_ascii_case(alias).then_some(modifier))
+}
+
+fn modifiers_from_xkb_mask(
+    keymap: &xkb::Keymap,
+    mask: xkb::ModMask,
+) -> Result<Modifiers, Vec<String>> {
+    let mut modifiers = Modifiers::empty();
+    let mut unsupported = Vec::new();
+    let mut known_mask = 0;
+
+    for mod_index in 0..keymap.num_mods() {
+        let Some(bit) = 1u32.checked_shl(mod_index) else {
+            continue;
+        };
+
+        if mask & bit == 0 {
+            continue;
+        }
+
+        known_mask |= bit;
+
+        let name = keymap.mod_get_name(mod_index);
+        match modifier_from_xkb_name(name) {
+            Some(Some(modifier)) => modifiers |= modifier,
+            Some(None) => (),
+            None => unsupported.push(name.to_owned()),
+        }
+    }
+
+    if mask & !known_mask != 0 {
+        unsupported.push(String::from("<unknown>"));
+    }
+
+    if unsupported.is_empty() {
+        Ok(modifiers)
+    } else {
+        unsupported.sort();
+        unsupported.dedup();
+        Err(unsupported)
+    }
+}
+
+fn resolve_bind_key(keymap: &xkb::Keymap, keysym: Keysym) -> anyhow::Result<CompiledKey> {
+    let mut matching_keys = Vec::new();
+    let mut masks = [xkb::ModMask::default(); 32];
+    let mut unsupported_modifiers = Vec::new();
+
+    for raw in keymap.min_keycode().raw()..=keymap.max_keycode().raw() {
+        let keycode = Keycode::from(raw);
+
+        'layouts: for layout in 0..keymap.num_layouts_for_key(keycode) {
+            for level in 0..keymap.num_levels_for_key(keycode, layout) {
+                let syms = keymap.key_get_syms_by_level(keycode, layout, level);
+                if !syms.contains(&keysym) {
+                    continue;
+                }
+
+                let num_masks = keymap.key_get_mods_for_level(keycode, layout, level, &mut masks);
+                let masks = if num_masks == 0 {
+                    &[0]
+                } else {
+                    &masks[..num_masks]
+                };
+
+                for mask in masks {
+                    match modifiers_from_xkb_mask(keymap, *mask) {
+                        Ok(modifiers) => matching_keys.push(CompiledKey {
+                            trigger: CompiledTrigger::PhysicalKey(keycode),
+                            modifiers,
+                        }),
+                        Err(names) => unsupported_modifiers.extend(names),
+                    }
+                }
+
+                break 'layouts;
+            }
+        }
+    }
+
+    matching_keys.sort_by_key(|key| match key.trigger {
+        CompiledTrigger::PhysicalKey(keycode) => (keycode.raw(), key.modifiers.bits()),
+        _ => unreachable!(),
+    });
+    matching_keys.dedup();
+
+    match matching_keys.as_slice() {
+        [] => {
+            unsupported_modifiers.sort();
+            unsupported_modifiers.dedup();
+
+            if unsupported_modifiers.is_empty() {
+                anyhow::bail!(
+                    "keysym {} does not exist in the reference binds.xkb keymap",
+                    xkb::keysym_get_name(keysym)
+                )
+            } else {
+                anyhow::bail!(
+                    "keysym {} in the reference binds.xkb keymap requires unsupported modifiers: {}",
+                    xkb::keysym_get_name(keysym),
+                    unsupported_modifiers.join(", ")
+                )
+            }
+        }
+        [key] => Ok(*key),
+        _ => {
+            let keys = matching_keys
+                .iter()
+                .map(|key| format!("{key:?}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "keysym {} is ambiguous in the reference binds.xkb keymap; matching keys: {keys}",
+                xkb::keysym_get_name(keysym)
+            );
+        }
+    }
+}
+
+pub fn compile_binds(binds: &Binds) -> anyhow::Result<Vec<CompiledBind>> {
+    let needs_layout_independent = binds
+        .binds
+        .iter()
+        .any(|bind| effective_layout_independent(binds, bind));
+
+    if !needs_layout_independent {
+        return Ok(binds
+            .binds
+            .iter()
+            .cloned()
+            .map(CompiledBind::from)
+            .collect());
+    }
+
+    let xkb_config = binds
+        .xkb
+        .as_ref()
+        .context("layout-independent binds requested, but binds.xkb is missing")?;
+    let keymap = load_bind_keymap(xkb_config)?;
+    let mut errors = Vec::new();
+
+    let compiled: Vec<_> = binds
+        .binds
+        .iter()
+        .cloned()
+        .map(|bind| {
+            let is_layout_independent = effective_layout_independent(binds, &bind);
+            let mut bind = CompiledBind::from(bind);
+
+            if !is_layout_independent {
+                return bind;
+            }
+
+            let CompiledTrigger::Keysym(keysym) = bind.key.trigger else {
+                return bind;
+            };
+
+            match resolve_bind_key(&keymap, keysym) {
+                Ok(key) => {
+                    bind.key.trigger = key.trigger;
+                    bind.key.modifiers |= key.modifiers;
+                }
+                Err(err) => errors.push(format!(
+                    "failed to compile layout-independent bind {:?}: {err:#}",
+                    bind.key
+                )),
+            }
+
+            bind
+        })
+        .collect();
+
+    errors.extend(duplicate_compiled_bind_errors(&compiled));
+
+    if !errors.is_empty() {
+        anyhow::bail!(errors.join("\n"));
+    }
+
+    Ok(compiled)
+}
+
+fn duplicate_compiled_bind_errors(binds: &[CompiledBind]) -> Vec<String> {
+    let mut seen: HashMap<CompiledKey, &CompiledBind> = HashMap::new();
+    let mut errors = Vec::new();
+
+    for bind in binds {
+        match seen.entry(bind.key) {
+            Entry::Vacant(entry) => {
+                entry.insert(bind);
+            }
+            Entry::Occupied(entry) => {
+                errors.push(format!(
+                    "duplicate compiled keybind after layout-independent resolution: key={:?}, first_action={:?}, duplicate_action={:?}",
+                    bind.key,
+                    entry.get().action,
+                    bind.action,
+                ));
+            }
+        }
+    }
+
+    errors
 }
 
 fn find_configured_switch_action(
@@ -4773,12 +5069,16 @@ fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Compiled
         return None;
     }
 
-    let (action, repeat) = match raw {
-        Keysym::Escape | Keysym::Return => (Action::ToggleOverview, false),
-        Keysym::Left => (Action::FocusColumnLeft, true),
-        Keysym::Right => (Action::FocusColumnRight, true),
-        Keysym::Up => (Action::FocusWindowOrWorkspaceUp, true),
-        Keysym::Down => (Action::FocusWindowOrWorkspaceDown, true),
+    let mut repeat = true;
+    let action = match raw {
+        Keysym::Escape | Keysym::Return => {
+            repeat = false;
+            Action::ToggleOverview
+        }
+        Keysym::Left => Action::FocusColumnLeft,
+        Keysym::Right => Action::FocusColumnRight,
+        Keysym::Up => Action::FocusWindowOrWorkspaceUp,
+        Keysym::Down => Action::FocusWindowOrWorkspaceDown,
         _ => {
             return None;
         }
@@ -5200,6 +5500,9 @@ fn make_binds_iter<'a>(
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use niri_config::Bind as SourceBind;
 
@@ -5207,7 +5510,37 @@ mod tests {
     use crate::animation::Clock;
 
     fn test_binds(binds: Vec<SourceBind>) -> Vec<CompiledBind> {
-        binds.into_iter().map(CompiledBind::from).collect()
+        compile_binds(&Binds {
+            binds,
+            layout_independent: false,
+            xkb: None,
+        })
+        .unwrap()
+    }
+
+    struct TestTempDir(PathBuf);
+
+    impl TestTempDir {
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestTempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn test_tempdir() -> TestTempDir {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+        let suffix = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let path =
+            std::env::temp_dir().join(format!("niri-layout-independent-binds-{pid}-{suffix}"));
+        fs::create_dir_all(&path).unwrap();
+        TestTempDir(path)
     }
 
     #[test]
@@ -5231,17 +5564,14 @@ mod tests {
         let mut suppressed_keys = HashSet::new();
 
         let screenshot_ui = ScreenshotUi::new(Clock::default(), Default::default());
-
+        let disable_power_key_handling = false;
         let is_inhibiting_shortcuts = Cell::new(false);
 
         // The key_code we pick is arbitrary, the only thing
         // that matters is that they are different between cases.
 
         let close_key_code = Keycode::from(close_keysym.raw() + 8u32);
-        let close_key_event = |suppr: &mut HashSet<Keycode>,
-                               mods: ModifiersState,
-                               pressed,
-                               is_inhibiting_shortcuts| {
+        let close_key_event = |suppr: &mut HashSet<Keycode>, mods: ModifiersState, pressed| {
             should_intercept_key(
                 suppr,
                 bindings.iter().cloned(),
@@ -5252,16 +5582,13 @@ mod tests {
                 pressed,
                 mods,
                 &screenshot_ui,
-                false,
-                is_inhibiting_shortcuts,
+                disable_power_key_handling,
+                is_inhibiting_shortcuts.get(),
             )
         };
 
         // Key event with the code which can't trigger any action.
-        let none_key_event = |suppr: &mut HashSet<Keycode>,
-                              mods: ModifiersState,
-                              pressed,
-                              is_inhibiting_shortcuts| {
+        let none_key_event = |suppr: &mut HashSet<Keycode>, mods: ModifiersState, pressed| {
             should_intercept_key(
                 suppr,
                 bindings.iter().cloned(),
@@ -5272,8 +5599,8 @@ mod tests {
                 pressed,
                 mods,
                 &screenshot_ui,
-                false,
-                is_inhibiting_shortcuts,
+                disable_power_key_handling,
+                is_inhibiting_shortcuts.get(),
             )
         };
 
@@ -5285,7 +5612,7 @@ mod tests {
 
         // Action press/release.
 
-        let filter = close_key_event(&mut suppressed_keys, mods, true, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, true);
         assert!(matches!(
             filter,
             FilterResult::Intercept(Some(CompiledBind {
@@ -5295,31 +5622,31 @@ mod tests {
         ));
         assert!(suppressed_keys.contains(&close_key_code));
 
-        let filter = close_key_event(&mut suppressed_keys, mods, false, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Intercept(None)));
         assert!(suppressed_keys.is_empty());
 
         // Remove mod to make it for a binding.
 
         mods.shift = true;
-        let filter = close_key_event(&mut suppressed_keys, mods, true, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, true);
         assert!(matches!(filter, FilterResult::Forward));
 
         mods.shift = false;
-        let filter = close_key_event(&mut suppressed_keys, mods, false, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Forward));
 
         // Just none press/release.
 
-        let filter = none_key_event(&mut suppressed_keys, mods, true, false);
+        let filter = none_key_event(&mut suppressed_keys, mods, true);
         assert!(matches!(filter, FilterResult::Forward));
 
-        let filter = none_key_event(&mut suppressed_keys, mods, false, false);
+        let filter = none_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Forward));
 
         // Press action, press arbitrary, release action, release arbitrary.
 
-        let filter = close_key_event(&mut suppressed_keys, mods, true, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, true);
         assert!(matches!(
             filter,
             FilterResult::Intercept(Some(CompiledBind {
@@ -5328,18 +5655,18 @@ mod tests {
             }))
         ));
 
-        let filter = none_key_event(&mut suppressed_keys, mods, true, false);
+        let filter = none_key_event(&mut suppressed_keys, mods, true);
         assert!(matches!(filter, FilterResult::Forward));
 
-        let filter = close_key_event(&mut suppressed_keys, mods, false, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Intercept(None)));
 
-        let filter = none_key_event(&mut suppressed_keys, mods, false, false);
+        let filter = none_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Forward));
 
         // Trigger and remove all mods.
 
-        let filter = close_key_event(&mut suppressed_keys, mods, true, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, true);
         assert!(matches!(
             filter,
             FilterResult::Intercept(Some(CompiledBind {
@@ -5349,7 +5676,7 @@ mod tests {
         ));
 
         mods = Default::default();
-        let filter = close_key_event(&mut suppressed_keys, mods, false, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Intercept(None)));
 
         // Ensure that no keys are being suppressed.
@@ -5366,52 +5693,27 @@ mod tests {
             ..Default::default()
         };
 
-        let filter = close_key_event(
-            &mut suppressed_keys,
-            mods,
-            true,
-            is_inhibiting_shortcuts.get(),
-        );
+        let filter = close_key_event(&mut suppressed_keys, mods, true);
         assert!(matches!(filter, FilterResult::Forward));
         assert!(suppressed_keys.is_empty());
 
-        let filter = close_key_event(
-            &mut suppressed_keys,
-            mods,
-            false,
-            is_inhibiting_shortcuts.get(),
-        );
+        let filter = close_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Forward));
         assert!(suppressed_keys.is_empty());
 
         // Toggle it off after pressing the shortcut.
-        let filter = close_key_event(
-            &mut suppressed_keys,
-            mods,
-            true,
-            is_inhibiting_shortcuts.get(),
-        );
+        let filter = close_key_event(&mut suppressed_keys, mods, true);
         assert!(matches!(filter, FilterResult::Forward));
         assert!(suppressed_keys.is_empty());
 
         is_inhibiting_shortcuts.set(false);
 
-        let filter = close_key_event(
-            &mut suppressed_keys,
-            mods,
-            false,
-            is_inhibiting_shortcuts.get(),
-        );
+        let filter = close_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Forward));
         assert!(suppressed_keys.is_empty());
 
         // Toggle it on after pressing the shortcut.
-        let filter = close_key_event(
-            &mut suppressed_keys,
-            mods,
-            true,
-            is_inhibiting_shortcuts.get(),
-        );
+        let filter = close_key_event(&mut suppressed_keys, mods, true);
         assert!(matches!(
             filter,
             FilterResult::Intercept(Some(CompiledBind {
@@ -5423,12 +5725,7 @@ mod tests {
 
         is_inhibiting_shortcuts.set(true);
 
-        let filter = close_key_event(
-            &mut suppressed_keys,
-            mods,
-            false,
-            is_inhibiting_shortcuts.get(),
-        );
+        let filter = close_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Intercept(None)));
         assert!(suppressed_keys.is_empty());
     }
@@ -5501,7 +5798,7 @@ mod tests {
                     trigger: Trigger::Keysym(Keysym::h),
                     modifiers: Modifiers::SUPER,
                 },
-                action: Action::CloseWindow,
+                action: Action::FocusColumnLeft,
                 repeat: true,
                 cooldown: None,
                 allow_when_locked: false,
@@ -5514,7 +5811,7 @@ mod tests {
                     trigger: Trigger::Keysym(Keysym::j),
                     modifiers: Modifiers::empty(),
                 },
-                action: Action::CloseWindow,
+                action: Action::FocusWindowDown,
                 repeat: true,
                 cooldown: None,
                 allow_when_locked: false,
@@ -5527,7 +5824,7 @@ mod tests {
                     trigger: Trigger::Keysym(Keysym::k),
                     modifiers: Modifiers::COMPOSITOR | Modifiers::SUPER,
                 },
-                action: Action::CloseWindow,
+                action: Action::FocusWindowUp,
                 repeat: true,
                 cooldown: None,
                 allow_when_locked: false,
@@ -5540,7 +5837,7 @@ mod tests {
                     trigger: Trigger::Keysym(Keysym::l),
                     modifiers: Modifiers::SUPER | Modifiers::ALT,
                 },
-                action: Action::CloseWindow,
+                action: Action::FocusColumnRight,
                 repeat: true,
                 cooldown: None,
                 allow_when_locked: false,
@@ -5605,8 +5902,7 @@ mod tests {
                     logo: true,
                     ..Default::default()
                 }
-            )
-            .as_ref(),
+            ),
             None,
         );
         assert_eq!(
@@ -5665,9 +5961,384 @@ mod tests {
                 ModifiersState {
                     logo: true,
                     ..Default::default()
-                }
+                },
             ),
             None,
         );
+    }
+
+    #[test]
+    fn modifier_from_xkb_name_accepts_common_aliases() {
+        assert_eq!(
+            modifier_from_xkb_name("Control"),
+            Some(Some(Modifiers::CTRL))
+        );
+        assert_eq!(modifier_from_xkb_name("Alt"), Some(Some(Modifiers::ALT)));
+        assert_eq!(
+            modifier_from_xkb_name("Super"),
+            Some(Some(Modifiers::SUPER))
+        );
+        assert_eq!(
+            modifier_from_xkb_name("ISO_Level3_Shift"),
+            Some(Some(Modifiers::ISO_LEVEL3_SHIFT))
+        );
+        assert_eq!(
+            modifier_from_xkb_name("LevelFive"),
+            Some(Some(Modifiers::ISO_LEVEL5_SHIFT))
+        );
+        assert_eq!(modifier_from_xkb_name("CapsLock"), Some(None));
+        assert_eq!(modifier_from_xkb_name("NumLock"), Some(None));
+    }
+
+    #[test]
+    fn modifier_from_xkb_name_rejects_unknown_names() {
+        assert_eq!(modifier_from_xkb_name("Hyper"), None);
+    }
+
+    #[test]
+    fn compile_layout_independent_punctuation_bind_matches_physical_key() {
+        let binds = Binds {
+            binds: vec![SourceBind {
+                key: Key {
+                    trigger: Trigger::Keysym(Keysym::slash),
+                    modifiers: Modifiers::COMPOSITOR,
+                },
+                action: Action::CloseWindow,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+                hotkey_overlay_title: None,
+                layout_independent: Some(true),
+            }],
+            layout_independent: false,
+            xkb: Some(niri_config::Xkb {
+                layout: String::from("us"),
+                ..Default::default()
+            }),
+        };
+
+        let compiled = compile_binds(&binds).unwrap();
+        let keymap = load_bind_keymap(binds.xkb.as_ref().unwrap()).unwrap();
+        let keycode = match resolve_bind_key(&keymap, Keysym::slash).unwrap().trigger {
+            CompiledTrigger::PhysicalKey(keycode) => keycode,
+            _ => unreachable!(),
+        };
+
+        assert!(matches!(
+            compiled[0].key.trigger,
+            CompiledTrigger::PhysicalKey(compiled_keycode) if compiled_keycode == keycode
+        ));
+
+        let mut mods = ModifiersState::default();
+        mods.logo = true;
+
+        let bind = find_bind(
+            compiled.iter().cloned(),
+            ModKey::Super,
+            keycode,
+            Keysym::period,
+            Some(Keysym::period),
+            mods,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(bind.action, Action::CloseWindow);
+    }
+
+    #[test]
+    fn compile_layout_independent_shifted_symbol_uses_reference_key_level() {
+        let binds = Binds {
+            binds: vec![SourceBind {
+                key: Key {
+                    trigger: Trigger::Keysym(Keysym::exclam),
+                    modifiers: Modifiers::COMPOSITOR,
+                },
+                action: Action::CloseWindow,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+                hotkey_overlay_title: None,
+                layout_independent: Some(true),
+            }],
+            layout_independent: false,
+            xkb: Some(niri_config::Xkb {
+                layout: String::from("us"),
+                ..Default::default()
+            }),
+        };
+
+        let compiled = compile_binds(&binds).unwrap();
+        let keymap = load_bind_keymap(binds.xkb.as_ref().unwrap()).unwrap();
+        let exclam = match resolve_bind_key(&keymap, Keysym::exclam).unwrap().trigger {
+            CompiledTrigger::PhysicalKey(keycode) => keycode,
+            _ => unreachable!(),
+        };
+        let one = match resolve_bind_key(&keymap, Keysym::_1).unwrap().trigger {
+            CompiledTrigger::PhysicalKey(keycode) => keycode,
+            _ => unreachable!(),
+        };
+
+        assert_eq!(exclam, one);
+        assert!(matches!(
+            compiled[0].key.trigger,
+            CompiledTrigger::PhysicalKey(compiled_keycode) if compiled_keycode == exclam
+        ));
+        assert_eq!(
+            compiled[0].key.modifiers,
+            Modifiers::COMPOSITOR | Modifiers::SHIFT
+        );
+
+        let super_only = find_bind(
+            compiled.iter().cloned(),
+            ModKey::Super,
+            exclam,
+            Keysym::_1,
+            Some(Keysym::_1),
+            ModifiersState {
+                logo: true,
+                ..Default::default()
+            },
+            false,
+        );
+        assert_eq!(super_only, None);
+
+        let super_and_shift = find_bind(
+            compiled,
+            ModKey::Super,
+            exclam,
+            Keysym::exclam,
+            Some(Keysym::exclam),
+            ModifiersState {
+                logo: true,
+                shift: true,
+                ..Default::default()
+            },
+            false,
+        )
+        .unwrap();
+        assert_eq!(super_and_shift.action, Action::CloseWindow);
+    }
+
+    #[test]
+    fn mixed_layout_independent_and_keysym_binds_compile_and_match() {
+        let binds = Binds {
+            binds: vec![
+                SourceBind {
+                    key: Key {
+                        trigger: Trigger::Keysym(Keysym::slash),
+                        modifiers: Modifiers::COMPOSITOR,
+                    },
+                    action: Action::CloseWindow,
+                    repeat: true,
+                    cooldown: None,
+                    allow_when_locked: false,
+                    allow_inhibiting: true,
+                    hotkey_overlay_title: None,
+                    layout_independent: Some(true),
+                },
+                SourceBind {
+                    key: Key {
+                        trigger: Trigger::Keysym(Keysym::q),
+                        modifiers: Modifiers::COMPOSITOR,
+                    },
+                    action: Action::ToggleOverview,
+                    repeat: true,
+                    cooldown: None,
+                    allow_when_locked: false,
+                    allow_inhibiting: true,
+                    hotkey_overlay_title: None,
+                    layout_independent: Some(false),
+                },
+            ],
+            layout_independent: false,
+            xkb: Some(niri_config::Xkb {
+                layout: String::from("us"),
+                ..Default::default()
+            }),
+        };
+
+        let compiled = compile_binds(&binds).unwrap();
+        let keymap = load_bind_keymap(binds.xkb.as_ref().unwrap()).unwrap();
+        let slash_keycode = match resolve_bind_key(&keymap, Keysym::slash).unwrap().trigger {
+            CompiledTrigger::PhysicalKey(keycode) => keycode,
+            _ => unreachable!(),
+        };
+        let q_keycode = match resolve_bind_key(&keymap, Keysym::q).unwrap().trigger {
+            CompiledTrigger::PhysicalKey(keycode) => keycode,
+            _ => unreachable!(),
+        };
+
+        assert!(matches!(
+            compiled[0].key.trigger,
+            CompiledTrigger::PhysicalKey(compiled_keycode) if compiled_keycode == slash_keycode
+        ));
+        assert_eq!(compiled[1].key.trigger, CompiledTrigger::Keysym(Keysym::q));
+
+        let mut mods = ModifiersState::default();
+        mods.logo = true;
+
+        let slash_bind = find_bind(
+            compiled.iter().cloned(),
+            ModKey::Super,
+            slash_keycode,
+            Keysym::period,
+            Some(Keysym::period),
+            mods,
+            false,
+        )
+        .unwrap();
+        assert_eq!(slash_bind.action, Action::CloseWindow);
+
+        let q_bind = find_bind(
+            compiled.iter().cloned(),
+            ModKey::Super,
+            q_keycode,
+            Keysym::q,
+            Some(Keysym::q),
+            mods,
+            false,
+        )
+        .unwrap();
+        assert_eq!(q_bind.action, Action::ToggleOverview);
+    }
+
+    #[test]
+    fn physical_bind_matches_when_raw_keysym_is_missing() {
+        let binds = Binds {
+            binds: vec![SourceBind {
+                key: Key {
+                    trigger: Trigger::Keysym(Keysym::slash),
+                    modifiers: Modifiers::COMPOSITOR,
+                },
+                action: Action::CloseWindow,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+                hotkey_overlay_title: None,
+                layout_independent: Some(true),
+            }],
+            layout_independent: false,
+            xkb: Some(niri_config::Xkb {
+                layout: String::from("us"),
+                ..Default::default()
+            }),
+        };
+
+        let compiled = compile_binds(&binds).unwrap();
+        let keymap = load_bind_keymap(binds.xkb.as_ref().unwrap()).unwrap();
+        let keycode = match resolve_bind_key(&keymap, Keysym::slash).unwrap().trigger {
+            CompiledTrigger::PhysicalKey(keycode) => keycode,
+            _ => unreachable!(),
+        };
+
+        let bind = find_bind(
+            compiled,
+            ModKey::Super,
+            keycode,
+            Keysym::space,
+            None,
+            ModifiersState {
+                logo: true,
+                ..Default::default()
+            },
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(bind.action, Action::CloseWindow);
+    }
+
+    #[test]
+    fn compile_layout_independent_duplicate_binds_fail_after_resolution() {
+        let binds = Binds {
+            binds: vec![
+                SourceBind {
+                    key: Key {
+                        trigger: Trigger::Keysym(Keysym::_1),
+                        modifiers: Modifiers::COMPOSITOR | Modifiers::SHIFT,
+                    },
+                    action: Action::CloseWindow,
+                    repeat: true,
+                    cooldown: None,
+                    allow_when_locked: false,
+                    allow_inhibiting: true,
+                    hotkey_overlay_title: None,
+                    layout_independent: Some(true),
+                },
+                SourceBind {
+                    key: Key {
+                        trigger: Trigger::Keysym(Keysym::exclam),
+                        modifiers: Modifiers::COMPOSITOR,
+                    },
+                    action: Action::Quit(false),
+                    repeat: true,
+                    cooldown: None,
+                    allow_when_locked: false,
+                    allow_inhibiting: true,
+                    hotkey_overlay_title: None,
+                    layout_independent: Some(true),
+                },
+            ],
+            layout_independent: false,
+            xkb: Some(niri_config::Xkb {
+                layout: String::from("us"),
+                ..Default::default()
+            }),
+        };
+
+        let err = compile_binds(&binds).unwrap_err().to_string();
+        assert!(err.contains("duplicate compiled keybind after layout-independent resolution"));
+        assert!(err.contains("PhysicalKey"));
+    }
+
+    #[test]
+    fn config_with_ambiguous_reference_keymap_file_fails_bind_compilation() {
+        let dir = test_tempdir();
+        let config_path = dir.path().join("config.kdl");
+        let keymap_path = dir.path().join("ambiguous.xkb");
+
+        let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let keymap =
+            xkb::Keymap::new_from_names(&context, "", "", "us", "", None, xkb::COMPILE_NO_FLAGS)
+                .unwrap();
+        let keymap = keymap
+            .get_as_string(xkb::KEYMAP_FORMAT_TEXT_V1)
+            .lines()
+            .map(|line| {
+                if line.contains("key <AE02>") {
+                    "\tkey <AE02>               {\t[               2,          exclam ] };"
+                        .to_owned()
+                } else {
+                    line.to_owned()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&keymap_path, keymap).unwrap();
+
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+                binds {{
+                    xkb {{
+                        file "{}"
+                    }}
+
+                    Mod+exclam layout-independent=true {{ close-window; }}
+                }}
+                "#,
+                keymap_path.display()
+            ),
+        )
+        .unwrap();
+
+        let config = Config::load(&config_path).config.unwrap();
+        let err = compile_binds(&config.binds).unwrap_err().to_string();
+        assert!(err.contains("keysym exclam is ambiguous in the reference binds.xkb keymap"));
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 use calloop::timer::{TimeoutAction, Timer};
 use input::event::gesture::GestureEventCoordinates as _;
 use niri_config::{
-    Action, Bind, Binds, Config, Key, ModKey, Modifiers, MruDirection, SwitchBinds, Trigger,
+    Action, Bind as ConfigBind, Binds, Config, Key, ModKey, Modifiers, MruDirection, SwitchBinds,
+    Trigger,
 };
 use niri_ipc::LayoutSwitchTarget;
 use smithay::backend::input::{
@@ -68,6 +69,84 @@ pub mod touch_resize_grab;
 use backend_ext::{NiriInputBackend as InputBackend, NiriInputDevice as _};
 
 pub const DOUBLE_CLICK_TIME: Duration = Duration::from_millis(400);
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompiledBind {
+    pub key: CompiledKey,
+    pub action: Action,
+    pub repeat: bool,
+    pub cooldown: Option<Duration>,
+    pub allow_when_locked: bool,
+    pub allow_inhibiting: bool,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub struct CompiledKey {
+    pub trigger: CompiledTrigger,
+    pub modifiers: Modifiers,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum CompiledTrigger {
+    Keysym(Keysym),
+    PhysicalKey(Keycode),
+    MouseLeft,
+    MouseRight,
+    MouseMiddle,
+    MouseBack,
+    MouseForward,
+    WheelScrollDown,
+    WheelScrollUp,
+    WheelScrollLeft,
+    WheelScrollRight,
+    TouchpadScrollDown,
+    TouchpadScrollUp,
+    TouchpadScrollLeft,
+    TouchpadScrollRight,
+}
+
+impl From<Trigger> for CompiledTrigger {
+    fn from(value: Trigger) -> Self {
+        match value {
+            Trigger::Keysym(keysym) => Self::Keysym(keysym),
+            Trigger::MouseLeft => Self::MouseLeft,
+            Trigger::MouseRight => Self::MouseRight,
+            Trigger::MouseMiddle => Self::MouseMiddle,
+            Trigger::MouseBack => Self::MouseBack,
+            Trigger::MouseForward => Self::MouseForward,
+            Trigger::WheelScrollDown => Self::WheelScrollDown,
+            Trigger::WheelScrollUp => Self::WheelScrollUp,
+            Trigger::WheelScrollLeft => Self::WheelScrollLeft,
+            Trigger::WheelScrollRight => Self::WheelScrollRight,
+            Trigger::TouchpadScrollDown => Self::TouchpadScrollDown,
+            Trigger::TouchpadScrollUp => Self::TouchpadScrollUp,
+            Trigger::TouchpadScrollLeft => Self::TouchpadScrollLeft,
+            Trigger::TouchpadScrollRight => Self::TouchpadScrollRight,
+        }
+    }
+}
+
+impl From<Key> for CompiledKey {
+    fn from(value: Key) -> Self {
+        Self {
+            trigger: value.trigger.into(),
+            modifiers: value.modifiers,
+        }
+    }
+}
+
+impl From<ConfigBind> for CompiledBind {
+    fn from(value: ConfigBind) -> Self {
+        Self {
+            key: value.key.into(),
+            action: value.action,
+            repeat: value.repeat,
+            cooldown: value.cooldown,
+            allow_when_locked: value.allow_when_locked,
+            allow_inhibiting: value.allow_inhibiting,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TabletData {
@@ -509,8 +588,12 @@ impl State {
 
                 let res = {
                     let config = this.niri.config.borrow();
-                    let bindings =
-                        make_binds_iter(&config, &mut this.niri.window_mru_ui, modifiers);
+                    let bindings = make_binds_iter(
+                        &this.niri.compiled_binds,
+                        &config,
+                        &mut this.niri.window_mru_ui,
+                        modifiers,
+                    );
 
                     should_intercept_key(
                         &mut this.niri.suppressed_keys,
@@ -557,7 +640,7 @@ impl State {
         self.start_key_repeat(bind);
     }
 
-    fn start_key_repeat(&mut self, bind: Bind) {
+    fn start_key_repeat(&mut self, bind: CompiledBind) {
         if !bind.repeat {
             return;
         }
@@ -613,7 +696,7 @@ impl State {
         self.niri.queue_redraw_all();
     }
 
-    pub fn handle_bind(&mut self, bind: Bind) {
+    pub fn handle_bind(&mut self, bind: CompiledBind) {
         let Some(cooldown) = bind.cooldown else {
             self.do_action(bind.action, bind.allow_when_locked);
             return;
@@ -2787,9 +2870,13 @@ impl State {
                 }
                 .and_then(|trigger| {
                     let config = self.niri.config.borrow();
-                    let bindings =
-                        make_binds_iter(&config, &mut self.niri.window_mru_ui, modifiers);
-                    find_configured_bind(bindings, mod_key, trigger, mods)
+                    let bindings = make_binds_iter(
+                        &self.niri.compiled_binds,
+                        &config,
+                        &mut self.niri.window_mru_ui,
+                        modifiers,
+                    );
+                    find_configured_bind(bindings, mod_key, trigger.into(), mods)
                 }) {
                     self.niri.suppressed_buttons.insert(button_code);
                     self.handle_bind(bind.clone());
@@ -3111,9 +3198,9 @@ impl State {
                 if ticks != 0 {
                     let (bind_left, bind_right) =
                         if should_handle_in_overview && modifiers.is_empty() {
-                            let bind_left = Some(Bind {
-                                key: Key {
-                                    trigger: Trigger::WheelScrollLeft,
+                            let bind_left = Some(CompiledBind {
+                                key: CompiledKey {
+                                    trigger: CompiledTrigger::WheelScrollLeft,
                                     modifiers: Modifiers::empty(),
                                 },
                                 action: Action::FocusColumnLeftUnderMouse,
@@ -3121,12 +3208,10 @@ impl State {
                                 cooldown: None,
                                 allow_when_locked: false,
                                 allow_inhibiting: false,
-                                hotkey_overlay_title: None,
-                                layout_independent: None,
                             });
-                            let bind_right = Some(Bind {
-                                key: Key {
-                                    trigger: Trigger::WheelScrollRight,
+                            let bind_right = Some(CompiledBind {
+                                key: CompiledKey {
+                                    trigger: CompiledTrigger::WheelScrollRight,
                                     modifiers: Modifiers::empty(),
                                 },
                                 action: Action::FocusColumnRightUnderMouse,
@@ -3134,24 +3219,26 @@ impl State {
                                 cooldown: None,
                                 allow_when_locked: false,
                                 allow_inhibiting: false,
-                                hotkey_overlay_title: None,
-                                layout_independent: None,
                             });
                             (bind_left, bind_right)
                         } else {
                             let config = self.niri.config.borrow();
-                            let bindings =
-                                make_binds_iter(&config, &mut self.niri.window_mru_ui, modifiers);
+                            let bindings = make_binds_iter(
+                                &self.niri.compiled_binds,
+                                &config,
+                                &mut self.niri.window_mru_ui,
+                                modifiers,
+                            );
                             let bind_left = find_configured_bind(
                                 bindings.clone(),
                                 mod_key,
-                                Trigger::WheelScrollLeft,
+                                CompiledTrigger::WheelScrollLeft,
                                 mods,
                             );
                             let bind_right = find_configured_bind(
                                 bindings,
                                 mod_key,
-                                Trigger::WheelScrollRight,
+                                CompiledTrigger::WheelScrollRight,
                                 mods,
                             );
                             (bind_left, bind_right)
@@ -3174,9 +3261,9 @@ impl State {
                 if ticks != 0 {
                     let (bind_up, bind_down) = if should_handle_in_overview && modifiers.is_empty()
                     {
-                        let bind_up = Some(Bind {
-                            key: Key {
-                                trigger: Trigger::WheelScrollUp,
+                        let bind_up = Some(CompiledBind {
+                            key: CompiledKey {
+                                trigger: CompiledTrigger::WheelScrollUp,
                                 modifiers: Modifiers::empty(),
                             },
                             action: Action::FocusWorkspaceUpUnderMouse,
@@ -3184,12 +3271,10 @@ impl State {
                             cooldown: Some(Duration::from_millis(50)),
                             allow_when_locked: false,
                             allow_inhibiting: false,
-                            hotkey_overlay_title: None,
-                            layout_independent: None,
                         });
-                        let bind_down = Some(Bind {
-                            key: Key {
-                                trigger: Trigger::WheelScrollDown,
+                        let bind_down = Some(CompiledBind {
+                            key: CompiledKey {
+                                trigger: CompiledTrigger::WheelScrollDown,
                                 modifiers: Modifiers::empty(),
                             },
                             action: Action::FocusWorkspaceDownUnderMouse,
@@ -3197,14 +3282,12 @@ impl State {
                             cooldown: Some(Duration::from_millis(50)),
                             allow_when_locked: false,
                             allow_inhibiting: false,
-                            hotkey_overlay_title: None,
-                            layout_independent: None,
                         });
                         (bind_up, bind_down)
                     } else if should_handle_in_overview && modifiers == Modifiers::SHIFT {
-                        let bind_up = Some(Bind {
-                            key: Key {
-                                trigger: Trigger::WheelScrollUp,
+                        let bind_up = Some(CompiledBind {
+                            key: CompiledKey {
+                                trigger: CompiledTrigger::WheelScrollUp,
                                 modifiers: Modifiers::empty(),
                             },
                             action: Action::FocusColumnLeftUnderMouse,
@@ -3212,12 +3295,10 @@ impl State {
                             cooldown: Some(Duration::from_millis(50)),
                             allow_when_locked: false,
                             allow_inhibiting: false,
-                            hotkey_overlay_title: None,
-                            layout_independent: None,
                         });
-                        let bind_down = Some(Bind {
-                            key: Key {
-                                trigger: Trigger::WheelScrollDown,
+                        let bind_down = Some(CompiledBind {
+                            key: CompiledKey {
+                                trigger: CompiledTrigger::WheelScrollDown,
                                 modifiers: Modifiers::empty(),
                             },
                             action: Action::FocusColumnRightUnderMouse,
@@ -3225,22 +3306,28 @@ impl State {
                             cooldown: Some(Duration::from_millis(50)),
                             allow_when_locked: false,
                             allow_inhibiting: false,
-                            hotkey_overlay_title: None,
-                            layout_independent: None,
                         });
                         (bind_up, bind_down)
                     } else {
                         let config = self.niri.config.borrow();
-                        let bindings =
-                            make_binds_iter(&config, &mut self.niri.window_mru_ui, modifiers);
+                        let bindings = make_binds_iter(
+                            &self.niri.compiled_binds,
+                            &config,
+                            &mut self.niri.window_mru_ui,
+                            modifiers,
+                        );
                         let bind_up = find_configured_bind(
                             bindings.clone(),
                             mod_key,
-                            Trigger::WheelScrollUp,
+                            CompiledTrigger::WheelScrollUp,
                             mods,
                         );
-                        let bind_down =
-                            find_configured_bind(bindings, mod_key, Trigger::WheelScrollDown, mods);
+                        let bind_down = find_configured_bind(
+                            bindings,
+                            mod_key,
+                            CompiledTrigger::WheelScrollDown,
+                            mods,
+                        );
                         (bind_up, bind_down)
                     };
 
@@ -3376,16 +3463,24 @@ impl State {
                     .accumulate(horizontal);
                 if ticks != 0 {
                     let config = self.niri.config.borrow();
-                    let bindings =
-                        make_binds_iter(&config, &mut self.niri.window_mru_ui, modifiers);
+                    let bindings = make_binds_iter(
+                        &self.niri.compiled_binds,
+                        &config,
+                        &mut self.niri.window_mru_ui,
+                        modifiers,
+                    );
                     let bind_left = find_configured_bind(
                         bindings.clone(),
                         mod_key,
-                        Trigger::TouchpadScrollLeft,
+                        CompiledTrigger::TouchpadScrollLeft,
                         mods,
                     );
-                    let bind_right =
-                        find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollRight, mods);
+                    let bind_right = find_configured_bind(
+                        bindings,
+                        mod_key,
+                        CompiledTrigger::TouchpadScrollRight,
+                        mods,
+                    );
                     drop(config);
 
                     if let Some(right) = bind_right {
@@ -3406,16 +3501,24 @@ impl State {
                     .accumulate(vertical);
                 if ticks != 0 {
                     let config = self.niri.config.borrow();
-                    let bindings =
-                        make_binds_iter(&config, &mut self.niri.window_mru_ui, modifiers);
+                    let bindings = make_binds_iter(
+                        &self.niri.compiled_binds,
+                        &config,
+                        &mut self.niri.window_mru_ui,
+                        modifiers,
+                    );
                     let bind_up = find_configured_bind(
                         bindings.clone(),
                         mod_key,
-                        Trigger::TouchpadScrollUp,
+                        CompiledTrigger::TouchpadScrollUp,
                         mods,
                     );
-                    let bind_down =
-                        find_configured_bind(bindings, mod_key, Trigger::TouchpadScrollDown, mods);
+                    let bind_down = find_configured_bind(
+                        bindings,
+                        mod_key,
+                        CompiledTrigger::TouchpadScrollDown,
+                        mods,
+                    );
                     drop(config);
 
                     if let Some(down) = bind_down {
@@ -4308,9 +4411,9 @@ impl State {
 /// pressed keys as `suppressed`, thus preventing `releases` corresponding
 /// to them from being delivered.
 #[allow(clippy::too_many_arguments)]
-fn should_intercept_key<'a>(
+fn should_intercept_key(
     suppressed_keys: &mut HashSet<Keycode>,
-    bindings: impl IntoIterator<Item = &'a Bind>,
+    bindings: impl IntoIterator<Item = CompiledBind>,
     mod_key: ModKey,
     key_code: Keycode,
     modified: Keysym,
@@ -4320,7 +4423,7 @@ fn should_intercept_key<'a>(
     screenshot_ui: &ScreenshotUi,
     disable_power_key_handling: bool,
     is_inhibiting_shortcuts: bool,
-) -> FilterResult<Option<Bind>> {
+) -> FilterResult<Option<CompiledBind>> {
     // Actions are only triggered on presses, release of the key
     // shouldn't try to intercept anything unless we have marked
     // the key to suppress.
@@ -4331,6 +4434,7 @@ fn should_intercept_key<'a>(
     let mut final_bind = find_bind(
         bindings,
         mod_key,
+        key_code,
         modified,
         raw,
         mods,
@@ -4350,9 +4454,9 @@ fn should_intercept_key<'a>(
 
         if use_screenshot_ui_action {
             if let Some(raw) = raw {
-                final_bind = screenshot_ui.action(raw, mods).map(|action| Bind {
-                    key: Key {
-                        trigger: Trigger::Keysym(raw),
+                final_bind = screenshot_ui.action(raw, mods).map(|action| CompiledBind {
+                    key: CompiledKey {
+                        trigger: CompiledTrigger::Keysym(raw),
                         // Not entirely correct but it doesn't matter in how we currently use it.
                         modifiers: Modifiers::empty(),
                     },
@@ -4364,8 +4468,6 @@ fn should_intercept_key<'a>(
                     // But logically, nothing can inhibit its actions. Only opening it can be
                     // inhibited.
                     allow_inhibiting: false,
-                    hotkey_overlay_title: None,
-                    layout_independent: None,
                 });
             }
         }
@@ -4393,14 +4495,15 @@ fn should_intercept_key<'a>(
     }
 }
 
-fn find_bind<'a>(
-    bindings: impl IntoIterator<Item = &'a Bind>,
+fn find_bind(
+    bindings: impl IntoIterator<Item = CompiledBind>,
     mod_key: ModKey,
+    key_code: Keycode,
     modified: Keysym,
     raw: Option<Keysym>,
     mods: ModifiersState,
     disable_power_key_handling: bool,
-) -> Option<Bind> {
+) -> Option<CompiledBind> {
     use keysyms::*;
 
     // Handle hardcoded binds.
@@ -4415,10 +4518,10 @@ fn find_bind<'a>(
     };
 
     if let Some(action) = hardcoded_action {
-        return Some(Bind {
-            key: Key {
+        return Some(CompiledBind {
+            key: CompiledKey {
                 // Not entirely correct but it doesn't matter in how we currently use it.
-                trigger: Trigger::Keysym(modified),
+                trigger: CompiledTrigger::Keysym(modified),
                 modifiers: Modifiers::empty(),
             },
             action,
@@ -4429,47 +4532,77 @@ fn find_bind<'a>(
             // It also makes no sense to inhibit the default power key handling.
             // Hardcoded binds must never be inhibited.
             allow_inhibiting: false,
-            hotkey_overlay_title: None,
-            layout_independent: None,
         });
     }
 
-    let trigger = Trigger::Keysym(raw?);
-    find_configured_bind(bindings, mod_key, trigger, mods)
-}
-
-fn find_configured_bind<'a>(
-    bindings: impl IntoIterator<Item = &'a Bind>,
-    mod_key: ModKey,
-    trigger: Trigger,
-    mods: ModifiersState,
-) -> Option<Bind> {
-    // Handle configured binds.
-    let mut modifiers = modifiers_from_state(mods);
-
-    let mod_down = modifiers_from_state(mods).contains(mod_key.to_modifiers());
-    if mod_down {
-        modifiers |= Modifiers::COMPOSITOR;
-    }
+    let modifiers = configured_bind_modifiers(mod_key, mods);
+    let physical_trigger = CompiledTrigger::PhysicalKey(key_code);
+    let keysym_trigger = raw.map(CompiledTrigger::Keysym);
+    let mut keysym_bind = None;
 
     for bind in bindings {
-        if bind.key.trigger != trigger {
+        let trigger = bind.key.trigger;
+        if trigger != physical_trigger && Some(trigger) != keysym_trigger {
+            continue;
+        }
+        if !configured_bind_matches(&bind, mod_key, trigger, modifiers) {
             continue;
         }
 
-        let mut bind_modifiers = bind.key.modifiers;
-        if bind_modifiers.contains(Modifiers::COMPOSITOR) {
-            bind_modifiers |= mod_key.to_modifiers();
-        } else if bind_modifiers.contains(mod_key.to_modifiers()) {
-            bind_modifiers |= Modifiers::COMPOSITOR;
+        if trigger == physical_trigger {
+            return Some(bind);
         }
 
-        if bind_modifiers == modifiers {
-            return Some(bind.clone());
+        if keysym_bind.is_none() {
+            keysym_bind = Some(bind);
         }
     }
 
-    None
+    keysym_bind
+}
+
+fn find_configured_bind(
+    bindings: impl IntoIterator<Item = CompiledBind>,
+    mod_key: ModKey,
+    trigger: CompiledTrigger,
+    mods: ModifiersState,
+) -> Option<CompiledBind> {
+    // Handle configured binds.
+    let modifiers = configured_bind_modifiers(mod_key, mods);
+
+    bindings
+        .into_iter()
+        .find(|bind| configured_bind_matches(bind, mod_key, trigger, modifiers))
+}
+
+fn configured_bind_modifiers(mod_key: ModKey, mods: ModifiersState) -> Modifiers {
+    let mut modifiers = modifiers_from_state(mods);
+
+    if modifiers.contains(mod_key.to_modifiers()) {
+        modifiers |= Modifiers::COMPOSITOR;
+    }
+
+    modifiers
+}
+
+fn configured_bind_matches(
+    bind: &CompiledBind,
+    mod_key: ModKey,
+    trigger: CompiledTrigger,
+    modifiers: Modifiers,
+) -> bool {
+    if bind.key.trigger != trigger {
+        return false;
+    }
+
+    let mut bind_modifiers = bind.key.modifiers;
+    if bind_modifiers.contains(Modifiers::COMPOSITOR) {
+        bind_modifiers |= mod_key.to_modifiers();
+    } else if bind_modifiers.contains(mod_key.to_modifiers()) {
+        bind_modifiers |= Modifiers::COMPOSITOR;
+    }
+
+    bind_modifiers == modifiers
 }
 
 fn find_configured_switch_action(
@@ -4634,7 +4767,7 @@ fn allowed_during_screenshot(action: &Action) -> bool {
     )
 }
 
-fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Bind> {
+fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<CompiledBind> {
     let mods = modifiers_from_state(mods);
     if !mods.is_empty() {
         return None;
@@ -4651,9 +4784,9 @@ fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Bind> {
         }
     };
 
-    Some(Bind {
-        key: Key {
-            trigger: Trigger::Keysym(raw),
+    Some(CompiledBind {
+        key: CompiledKey {
+            trigger: CompiledTrigger::Keysym(raw),
             modifiers: Modifiers::empty(),
         },
         action,
@@ -4661,8 +4794,6 @@ fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Bind> {
         cooldown: None,
         allow_when_locked: false,
         allow_inhibiting: false,
-        hotkey_overlay_title: None,
-        layout_independent: None,
     })
 }
 
@@ -5040,19 +5171,26 @@ fn grab_allows_hot_corner(grab: &(dyn PointerGrab<State> + 'static)) -> bool {
 ///
 /// Includes dynamically populated bindings like the MRU UI.
 fn make_binds_iter<'a>(
+    general_binds: &'a [CompiledBind],
     config: &'a Config,
     mru: &'a mut WindowMruUi,
     mods: Modifiers,
-) -> impl Iterator<Item = &'a Bind> + Clone {
+) -> impl Iterator<Item = CompiledBind> + Clone + 'a {
     // Figure out the binds to use depending on whether the MRU is enabled and/or open.
-    let general_binds = (!mru.is_open()).then_some(config.binds.binds.iter());
+    let general_binds = (!mru.is_open()).then_some(general_binds.iter().cloned());
     let general_binds = general_binds.into_iter().flatten();
 
-    let mru_binds =
-        (config.recent_windows.on || mru.is_open()).then_some(config.recent_windows.binds.iter());
+    let mru_binds = (config.recent_windows.on || mru.is_open()).then_some(
+        config
+            .recent_windows
+            .binds
+            .iter()
+            .cloned()
+            .map(CompiledBind::from),
+    );
     let mru_binds = mru_binds.into_iter().flatten();
 
-    let mru_open_binds = mru.is_open().then(|| mru.opened_bindings(mods));
+    let mru_open_binds = mru.is_open().then(|| mru.opened_bindings(mods).cloned());
     let mru_open_binds = mru_open_binds.into_iter().flatten();
 
     // General binds take precedence over the MRU binds.
@@ -5063,45 +5201,50 @@ fn make_binds_iter<'a>(
 mod tests {
     use std::cell::Cell;
 
+    use niri_config::Bind as SourceBind;
+
     use super::*;
     use crate::animation::Clock;
+
+    fn test_binds(binds: Vec<SourceBind>) -> Vec<CompiledBind> {
+        binds.into_iter().map(CompiledBind::from).collect()
+    }
 
     #[test]
     fn bindings_suppress_keys() {
         let close_keysym = Keysym::q;
-        let bindings = Binds {
-            binds: vec![Bind {
-                key: Key {
-                    trigger: Trigger::Keysym(close_keysym),
-                    modifiers: Modifiers::COMPOSITOR | Modifiers::CTRL,
-                },
-                action: Action::CloseWindow,
-                repeat: true,
-                cooldown: None,
-                allow_when_locked: false,
-                allow_inhibiting: true,
-                hotkey_overlay_title: None,
-                layout_independent: None,
-            }],
-            layout_independent: false,
-            xkb: None,
-        };
+        let bindings = test_binds(vec![SourceBind {
+            key: Key {
+                trigger: Trigger::Keysym(close_keysym),
+                modifiers: Modifiers::COMPOSITOR | Modifiers::CTRL,
+            },
+            action: Action::CloseWindow,
+            repeat: true,
+            cooldown: None,
+            allow_when_locked: false,
+            allow_inhibiting: true,
+            hotkey_overlay_title: None,
+            layout_independent: None,
+        }]);
 
         let comp_mod = ModKey::Super;
         let mut suppressed_keys = HashSet::new();
 
         let screenshot_ui = ScreenshotUi::new(Clock::default(), Default::default());
-        let disable_power_key_handling = false;
+
         let is_inhibiting_shortcuts = Cell::new(false);
 
         // The key_code we pick is arbitrary, the only thing
         // that matters is that they are different between cases.
 
         let close_key_code = Keycode::from(close_keysym.raw() + 8u32);
-        let close_key_event = |suppr: &mut HashSet<Keycode>, mods: ModifiersState, pressed| {
+        let close_key_event = |suppr: &mut HashSet<Keycode>,
+                               mods: ModifiersState,
+                               pressed,
+                               is_inhibiting_shortcuts| {
             should_intercept_key(
                 suppr,
-                &bindings.binds,
+                bindings.iter().cloned(),
                 comp_mod,
                 close_key_code,
                 close_keysym,
@@ -5109,16 +5252,19 @@ mod tests {
                 pressed,
                 mods,
                 &screenshot_ui,
-                disable_power_key_handling,
-                is_inhibiting_shortcuts.get(),
+                false,
+                is_inhibiting_shortcuts,
             )
         };
 
         // Key event with the code which can't trigger any action.
-        let none_key_event = |suppr: &mut HashSet<Keycode>, mods: ModifiersState, pressed| {
+        let none_key_event = |suppr: &mut HashSet<Keycode>,
+                              mods: ModifiersState,
+                              pressed,
+                              is_inhibiting_shortcuts| {
             should_intercept_key(
                 suppr,
-                &bindings.binds,
+                bindings.iter().cloned(),
                 comp_mod,
                 Keycode::from(Keysym::l.raw() + 8),
                 Keysym::l,
@@ -5126,8 +5272,8 @@ mod tests {
                 pressed,
                 mods,
                 &screenshot_ui,
-                disable_power_key_handling,
-                is_inhibiting_shortcuts.get(),
+                false,
+                is_inhibiting_shortcuts,
             )
         };
 
@@ -5139,71 +5285,71 @@ mod tests {
 
         // Action press/release.
 
-        let filter = close_key_event(&mut suppressed_keys, mods, true);
+        let filter = close_key_event(&mut suppressed_keys, mods, true, false);
         assert!(matches!(
             filter,
-            FilterResult::Intercept(Some(Bind {
+            FilterResult::Intercept(Some(CompiledBind {
                 action: Action::CloseWindow,
                 ..
             }))
         ));
         assert!(suppressed_keys.contains(&close_key_code));
 
-        let filter = close_key_event(&mut suppressed_keys, mods, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, false, false);
         assert!(matches!(filter, FilterResult::Intercept(None)));
         assert!(suppressed_keys.is_empty());
 
         // Remove mod to make it for a binding.
 
         mods.shift = true;
-        let filter = close_key_event(&mut suppressed_keys, mods, true);
+        let filter = close_key_event(&mut suppressed_keys, mods, true, false);
         assert!(matches!(filter, FilterResult::Forward));
 
         mods.shift = false;
-        let filter = close_key_event(&mut suppressed_keys, mods, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, false, false);
         assert!(matches!(filter, FilterResult::Forward));
 
         // Just none press/release.
 
-        let filter = none_key_event(&mut suppressed_keys, mods, true);
+        let filter = none_key_event(&mut suppressed_keys, mods, true, false);
         assert!(matches!(filter, FilterResult::Forward));
 
-        let filter = none_key_event(&mut suppressed_keys, mods, false);
+        let filter = none_key_event(&mut suppressed_keys, mods, false, false);
         assert!(matches!(filter, FilterResult::Forward));
 
         // Press action, press arbitrary, release action, release arbitrary.
 
-        let filter = close_key_event(&mut suppressed_keys, mods, true);
+        let filter = close_key_event(&mut suppressed_keys, mods, true, false);
         assert!(matches!(
             filter,
-            FilterResult::Intercept(Some(Bind {
+            FilterResult::Intercept(Some(CompiledBind {
                 action: Action::CloseWindow,
                 ..
             }))
         ));
 
-        let filter = none_key_event(&mut suppressed_keys, mods, true);
+        let filter = none_key_event(&mut suppressed_keys, mods, true, false);
         assert!(matches!(filter, FilterResult::Forward));
 
-        let filter = close_key_event(&mut suppressed_keys, mods, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, false, false);
         assert!(matches!(filter, FilterResult::Intercept(None)));
 
-        let filter = none_key_event(&mut suppressed_keys, mods, false);
+        let filter = none_key_event(&mut suppressed_keys, mods, false, false);
         assert!(matches!(filter, FilterResult::Forward));
 
         // Trigger and remove all mods.
 
-        let filter = close_key_event(&mut suppressed_keys, mods, true);
+        let filter = close_key_event(&mut suppressed_keys, mods, true, false);
         assert!(matches!(
             filter,
-            FilterResult::Intercept(Some(Bind {
+            FilterResult::Intercept(Some(CompiledBind {
                 action: Action::CloseWindow,
                 ..
             }))
         ));
 
         mods = Default::default();
-        let filter = close_key_event(&mut suppressed_keys, mods, false);
+        let filter = close_key_event(&mut suppressed_keys, mods, false, false);
         assert!(matches!(filter, FilterResult::Intercept(None)));
 
         // Ensure that no keys are being suppressed.
@@ -5220,30 +5366,55 @@ mod tests {
             ..Default::default()
         };
 
-        let filter = close_key_event(&mut suppressed_keys, mods, true);
+        let filter = close_key_event(
+            &mut suppressed_keys,
+            mods,
+            true,
+            is_inhibiting_shortcuts.get(),
+        );
         assert!(matches!(filter, FilterResult::Forward));
         assert!(suppressed_keys.is_empty());
 
-        let filter = close_key_event(&mut suppressed_keys, mods, false);
+        let filter = close_key_event(
+            &mut suppressed_keys,
+            mods,
+            false,
+            is_inhibiting_shortcuts.get(),
+        );
         assert!(matches!(filter, FilterResult::Forward));
         assert!(suppressed_keys.is_empty());
 
         // Toggle it off after pressing the shortcut.
-        let filter = close_key_event(&mut suppressed_keys, mods, true);
+        let filter = close_key_event(
+            &mut suppressed_keys,
+            mods,
+            true,
+            is_inhibiting_shortcuts.get(),
+        );
         assert!(matches!(filter, FilterResult::Forward));
         assert!(suppressed_keys.is_empty());
 
         is_inhibiting_shortcuts.set(false);
 
-        let filter = close_key_event(&mut suppressed_keys, mods, false);
+        let filter = close_key_event(
+            &mut suppressed_keys,
+            mods,
+            false,
+            is_inhibiting_shortcuts.get(),
+        );
         assert!(matches!(filter, FilterResult::Forward));
         assert!(suppressed_keys.is_empty());
 
         // Toggle it on after pressing the shortcut.
-        let filter = close_key_event(&mut suppressed_keys, mods, true);
+        let filter = close_key_event(
+            &mut suppressed_keys,
+            mods,
+            true,
+            is_inhibiting_shortcuts.get(),
+        );
         assert!(matches!(
             filter,
-            FilterResult::Intercept(Some(Bind {
+            FilterResult::Intercept(Some(CompiledBind {
                 action: Action::CloseWindow,
                 ..
             }))
@@ -5252,103 +5423,151 @@ mod tests {
 
         is_inhibiting_shortcuts.set(true);
 
-        let filter = close_key_event(&mut suppressed_keys, mods, false);
+        let filter = close_key_event(
+            &mut suppressed_keys,
+            mods,
+            false,
+            is_inhibiting_shortcuts.get(),
+        );
         assert!(matches!(filter, FilterResult::Intercept(None)));
         assert!(suppressed_keys.is_empty());
     }
 
     #[test]
+    fn physical_binds_take_priority_over_keysym_binds() {
+        let key_code = Keycode::from(24u32);
+        let keysym = Keysym::q;
+        let bindings = vec![
+            CompiledBind {
+                key: CompiledKey {
+                    trigger: CompiledTrigger::Keysym(keysym),
+                    modifiers: Modifiers::COMPOSITOR,
+                },
+                action: Action::CloseWindow,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+            },
+            CompiledBind {
+                key: CompiledKey {
+                    trigger: CompiledTrigger::PhysicalKey(key_code),
+                    modifiers: Modifiers::COMPOSITOR,
+                },
+                action: Action::ToggleOverview,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+            },
+        ];
+
+        assert_eq!(
+            find_bind(
+                bindings.clone(),
+                ModKey::Super,
+                key_code,
+                keysym,
+                Some(keysym),
+                ModifiersState {
+                    logo: true,
+                    ..Default::default()
+                },
+                false,
+            )
+            .as_ref(),
+            Some(&bindings[1]),
+        );
+    }
+
+    #[test]
     fn comp_mod_handling() {
-        let bindings = Binds {
-            binds: vec![
-                Bind {
-                    key: Key {
-                        trigger: Trigger::Keysym(Keysym::q),
-                        modifiers: Modifiers::COMPOSITOR,
-                    },
-                    action: Action::CloseWindow,
-                    repeat: true,
-                    cooldown: None,
-                    allow_when_locked: false,
-                    allow_inhibiting: true,
-                    hotkey_overlay_title: None,
-                    layout_independent: None,
+        let bindings = test_binds(vec![
+            SourceBind {
+                key: Key {
+                    trigger: Trigger::Keysym(Keysym::q),
+                    modifiers: Modifiers::COMPOSITOR,
                 },
-                Bind {
-                    key: Key {
-                        trigger: Trigger::Keysym(Keysym::h),
-                        modifiers: Modifiers::SUPER,
-                    },
-                    action: Action::CloseWindow,
-                    repeat: true,
-                    cooldown: None,
-                    allow_when_locked: false,
-                    allow_inhibiting: true,
-                    hotkey_overlay_title: None,
-                    layout_independent: None,
+                action: Action::CloseWindow,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+                hotkey_overlay_title: None,
+                layout_independent: None,
+            },
+            SourceBind {
+                key: Key {
+                    trigger: Trigger::Keysym(Keysym::h),
+                    modifiers: Modifiers::SUPER,
                 },
-                Bind {
-                    key: Key {
-                        trigger: Trigger::Keysym(Keysym::j),
-                        modifiers: Modifiers::empty(),
-                    },
-                    action: Action::CloseWindow,
-                    repeat: true,
-                    cooldown: None,
-                    allow_when_locked: false,
-                    allow_inhibiting: true,
-                    hotkey_overlay_title: None,
-                    layout_independent: None,
+                action: Action::CloseWindow,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+                hotkey_overlay_title: None,
+                layout_independent: None,
+            },
+            SourceBind {
+                key: Key {
+                    trigger: Trigger::Keysym(Keysym::j),
+                    modifiers: Modifiers::empty(),
                 },
-                Bind {
-                    key: Key {
-                        trigger: Trigger::Keysym(Keysym::k),
-                        modifiers: Modifiers::COMPOSITOR | Modifiers::SUPER,
-                    },
-                    action: Action::CloseWindow,
-                    repeat: true,
-                    cooldown: None,
-                    allow_when_locked: false,
-                    allow_inhibiting: true,
-                    hotkey_overlay_title: None,
-                    layout_independent: None,
+                action: Action::CloseWindow,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+                hotkey_overlay_title: None,
+                layout_independent: None,
+            },
+            SourceBind {
+                key: Key {
+                    trigger: Trigger::Keysym(Keysym::k),
+                    modifiers: Modifiers::COMPOSITOR | Modifiers::SUPER,
                 },
-                Bind {
-                    key: Key {
-                        trigger: Trigger::Keysym(Keysym::l),
-                        modifiers: Modifiers::SUPER | Modifiers::ALT,
-                    },
-                    action: Action::CloseWindow,
-                    repeat: true,
-                    cooldown: None,
-                    allow_when_locked: false,
-                    allow_inhibiting: true,
-                    hotkey_overlay_title: None,
-                    layout_independent: None,
+                action: Action::CloseWindow,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+                hotkey_overlay_title: None,
+                layout_independent: None,
+            },
+            SourceBind {
+                key: Key {
+                    trigger: Trigger::Keysym(Keysym::l),
+                    modifiers: Modifiers::SUPER | Modifiers::ALT,
                 },
-            ],
-            layout_independent: false,
-            xkb: None,
-        };
+                action: Action::CloseWindow,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+                hotkey_overlay_title: None,
+                layout_independent: None,
+            },
+        ]);
 
         assert_eq!(
             find_configured_bind(
-                &bindings.binds,
+                bindings.iter().cloned(),
                 ModKey::Super,
-                Trigger::Keysym(Keysym::q),
+                Trigger::Keysym(Keysym::q).into(),
                 ModifiersState {
                     logo: true,
                     ..Default::default()
                 }
             )
             .as_ref(),
-            Some(&bindings.binds[0])
+            Some(&bindings[0])
         );
         assert_eq!(
             find_configured_bind(
-                &bindings.binds,
+                bindings.iter().cloned(),
                 ModKey::Super,
-                Trigger::Keysym(Keysym::q),
+                Trigger::Keysym(Keysym::q).into(),
                 ModifiersState::default(),
             ),
             None,
@@ -5356,22 +5575,22 @@ mod tests {
 
         assert_eq!(
             find_configured_bind(
-                &bindings.binds,
+                bindings.iter().cloned(),
                 ModKey::Super,
-                Trigger::Keysym(Keysym::h),
+                Trigger::Keysym(Keysym::h).into(),
                 ModifiersState {
                     logo: true,
                     ..Default::default()
                 }
             )
             .as_ref(),
-            Some(&bindings.binds[1])
+            Some(&bindings[1])
         );
         assert_eq!(
             find_configured_bind(
-                &bindings.binds,
+                bindings.iter().cloned(),
                 ModKey::Super,
-                Trigger::Keysym(Keysym::h),
+                Trigger::Keysym(Keysym::h).into(),
                 ModifiersState::default(),
             ),
             None,
@@ -5379,45 +5598,46 @@ mod tests {
 
         assert_eq!(
             find_configured_bind(
-                &bindings.binds,
+                bindings.iter().cloned(),
                 ModKey::Super,
-                Trigger::Keysym(Keysym::j),
-                ModifiersState {
-                    logo: true,
-                    ..Default::default()
-                }
-            ),
-            None,
-        );
-        assert_eq!(
-            find_configured_bind(
-                &bindings.binds,
-                ModKey::Super,
-                Trigger::Keysym(Keysym::j),
-                ModifiersState::default(),
-            )
-            .as_ref(),
-            Some(&bindings.binds[2])
-        );
-
-        assert_eq!(
-            find_configured_bind(
-                &bindings.binds,
-                ModKey::Super,
-                Trigger::Keysym(Keysym::k),
+                Trigger::Keysym(Keysym::j).into(),
                 ModifiersState {
                     logo: true,
                     ..Default::default()
                 }
             )
             .as_ref(),
-            Some(&bindings.binds[3])
+            None,
         );
         assert_eq!(
             find_configured_bind(
-                &bindings.binds,
+                bindings.iter().cloned(),
                 ModKey::Super,
-                Trigger::Keysym(Keysym::k),
+                Trigger::Keysym(Keysym::j).into(),
+                ModifiersState::default(),
+            )
+            .as_ref(),
+            Some(&bindings[2])
+        );
+
+        assert_eq!(
+            find_configured_bind(
+                bindings.iter().cloned(),
+                ModKey::Super,
+                Trigger::Keysym(Keysym::k).into(),
+                ModifiersState {
+                    logo: true,
+                    ..Default::default()
+                }
+            )
+            .as_ref(),
+            Some(&bindings[3])
+        );
+        assert_eq!(
+            find_configured_bind(
+                bindings.iter().cloned(),
+                ModKey::Super,
+                Trigger::Keysym(Keysym::k).into(),
                 ModifiersState::default(),
             ),
             None,
@@ -5425,9 +5645,9 @@ mod tests {
 
         assert_eq!(
             find_configured_bind(
-                &bindings.binds,
+                bindings.iter().cloned(),
                 ModKey::Super,
-                Trigger::Keysym(Keysym::l),
+                Trigger::Keysym(Keysym::l).into(),
                 ModifiersState {
                     logo: true,
                     alt: true,
@@ -5435,17 +5655,17 @@ mod tests {
                 }
             )
             .as_ref(),
-            Some(&bindings.binds[4])
+            Some(&bindings[4])
         );
         assert_eq!(
             find_configured_bind(
-                &bindings.binds,
+                bindings.iter().cloned(),
                 ModKey::Super,
-                Trigger::Keysym(Keysym::l),
+                Trigger::Keysym(Keysym::l).into(),
                 ModifiersState {
                     logo: true,
                     ..Default::default()
-                },
+                }
             ),
             None,
         );

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4884,10 +4884,7 @@ fn resolve_bind_key(keymap: &xkb::Keymap, keysym: Keysym) -> anyhow::Result<Comp
 }
 
 pub fn compile_binds(binds: &Binds) -> anyhow::Result<Vec<CompiledBind>> {
-    let needs_layout_independent = binds
-        .binds
-        .iter()
-        .any(|bind| bind.layout_independent.unwrap_or(false));
+    let needs_layout_independent = binds.binds.iter().any(|bind| bind.xkb.is_some());
 
     if !needs_layout_independent {
         return Ok(binds
@@ -4907,7 +4904,7 @@ pub fn compile_binds(binds: &Binds) -> anyhow::Result<Vec<CompiledBind>> {
         .map(|source_bind| {
             let mut bind = CompiledBind::from(source_bind.clone());
 
-            if !source_bind.layout_independent.unwrap_or(false) {
+            if source_bind.xkb.is_none() {
                 return bind;
             }
 
@@ -5640,7 +5637,6 @@ mod tests {
             allow_when_locked: false,
             allow_inhibiting: true,
             hotkey_overlay_title: None,
-            layout_independent: None,
             xkb: None,
         }]);
 
@@ -5875,7 +5871,6 @@ mod tests {
                 allow_when_locked: false,
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
-                layout_independent: None,
                 xkb: None,
             },
             SourceBind {
@@ -5889,7 +5884,6 @@ mod tests {
                 allow_when_locked: false,
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
-                layout_independent: None,
                 xkb: None,
             },
             SourceBind {
@@ -5903,7 +5897,6 @@ mod tests {
                 allow_when_locked: false,
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
-                layout_independent: None,
                 xkb: None,
             },
             SourceBind {
@@ -5917,7 +5910,6 @@ mod tests {
                 allow_when_locked: false,
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
-                layout_independent: None,
                 xkb: None,
             },
             SourceBind {
@@ -5931,7 +5923,6 @@ mod tests {
                 allow_when_locked: false,
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
-                layout_independent: None,
                 xkb: None,
             },
         ]);
@@ -6098,7 +6089,6 @@ mod tests {
                 allow_when_locked: false,
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
-                layout_independent: Some(true),
                 xkb: Some(niri_config::Xkb {
                     layout: String::from("us"),
                     ..Default::default()
@@ -6149,7 +6139,6 @@ mod tests {
                 allow_when_locked: false,
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
-                layout_independent: Some(true),
                 xkb: Some(niri_config::Xkb {
                     layout: String::from("us"),
                     ..Default::default()
@@ -6224,7 +6213,6 @@ mod tests {
                     allow_when_locked: false,
                     allow_inhibiting: true,
                     hotkey_overlay_title: None,
-                    layout_independent: Some(true),
                     xkb: Some(niri_config::Xkb {
                         layout: String::from("us"),
                         ..Default::default()
@@ -6241,7 +6229,6 @@ mod tests {
                     allow_when_locked: false,
                     allow_inhibiting: true,
                     hotkey_overlay_title: None,
-                    layout_independent: Some(false),
                     xkb: None,
                 },
             ],
@@ -6306,7 +6293,6 @@ mod tests {
                 allow_when_locked: false,
                 allow_inhibiting: true,
                 hotkey_overlay_title: None,
-                layout_independent: Some(true),
                 xkb: Some(niri_config::Xkb {
                     layout: String::from("us"),
                     ..Default::default()
@@ -6353,7 +6339,6 @@ mod tests {
                     allow_when_locked: false,
                     allow_inhibiting: true,
                     hotkey_overlay_title: None,
-                    layout_independent: Some(true),
                     xkb: Some(niri_config::Xkb {
                         layout: String::from("us"),
                         ..Default::default()
@@ -6370,7 +6355,6 @@ mod tests {
                     allow_when_locked: false,
                     allow_inhibiting: true,
                     hotkey_overlay_title: None,
-                    layout_independent: Some(true),
                     xkb: Some(niri_config::Xkb {
                         layout: String::from("us"),
                         ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use directories::ProjectDirs;
 use niri::cli::{Cli, CompletionShell, Sub};
 #[cfg(feature = "dbus")]
 use niri::dbus;
+use niri::input::compile_binds;
 use niri::ipc::client::handle_msg;
 use niri::niri::State;
 use niri::utils::spawning::{
@@ -101,7 +102,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Sub::Validate { config } => {
                 tracy_client::Client::start();
 
-                config_path(config).load().config?;
+                let config = config_path(config).load().config?;
+                compile_binds(&config.binds)?;
                 info!("config is valid");
                 return Ok(());
             }
@@ -148,11 +150,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config_path = config_path(cli.config);
     env::remove_var("NIRI_CONFIG");
     let (config_created_at, config_load_result) = config_path.load_or_create();
-    let config_errored = config_load_result.config.is_err();
+    let mut config_errored = config_load_result.config.is_err();
     let mut config = config_load_result.config.unwrap_or_else(|err| {
         warn!("{err:?}");
         Config::load_default()
     });
+    let compiled_binds = match compile_binds(&config.binds) {
+        Ok(compiled_binds) => compiled_binds,
+        Err(err) => {
+            warn!("error compiling layout-independent binds in startup config: {err:#}");
+            config_errored = true;
+            config = Config::load_default();
+            compile_binds(&config.binds)
+                .expect("default config layout-independent binds must compile")
+        }
+    };
     let config_includes = config_load_result.includes;
 
     let spawn_at_startup = mem::take(&mut config.spawn_at_startup);
@@ -175,6 +187,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut state = State::new(
         config,
+        compiled_binds,
         event_loop.handle(),
         event_loop.get_signal(),
         display,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use niri::cli::{Cli, CompletionShell, Sub};
 use niri::dbus;
 use niri::input::compile_binds;
 use niri::ipc::client::handle_msg;
-use niri::niri::State;
+use niri::niri::{SessionOptions, State};
 use niri::utils::spawning::{
     spawn, spawn_sh, store_and_increase_nofile_rlimit, CHILD_DISPLAY, CHILD_ENV,
     REMOVE_ENV_RUST_BACKTRACE, REMOVE_ENV_RUST_LIB_BACKTRACE,
@@ -192,8 +192,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         event_loop.get_signal(),
         display,
         false,
-        true,
-        cli.session,
+        SessionOptions {
+            create_wayland_socket: true,
+            is_session_instance: cli.session,
+        },
     )
     .unwrap();
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -129,7 +129,7 @@ use crate::input::pick_color_grab::PickColorGrab;
 use crate::input::scroll_swipe_gesture::ScrollSwipeGesture;
 use crate::input::scroll_tracker::ScrollTracker;
 use crate::input::{
-    apply_libinput_settings, mods_with_finger_scroll_binds, mods_with_mouse_binds,
+    apply_libinput_settings, compile_binds, mods_with_finger_scroll_binds, mods_with_mouse_binds,
     mods_with_wheel_binds, CompiledBind, CompiledKey, TabletData,
 };
 use crate::ipc::server::IpcServer;
@@ -695,6 +695,7 @@ pub struct State {
 impl State {
     pub fn new(
         config: Config,
+        compiled_binds: Vec<CompiledBind>,
         event_loop: LoopHandle<'static, State>,
         stop_signal: LoopSignal,
         display: Display<State>,
@@ -724,6 +725,7 @@ impl State {
 
         let mut niri = Niri::new(
             config.clone(),
+            compiled_binds,
             event_loop,
             stop_signal,
             display,
@@ -1418,11 +1420,44 @@ impl State {
             }
         };
 
+        let mut reload_xkb = None;
+        let mut libinput_config_changed = false;
+        let mut output_config_changed = false;
+        let mut preserved_output_config = None;
+        let mut window_rules_changed = false;
+        let mut layer_rules_changed = false;
+        let mut shaders_changed = false;
+        let mut cursor_inactivity_timeout_changed = false;
+        let mut recent_windows_changed = false;
+        let mut xwls_changed = false;
+        let binds_changed = {
+            let old_config = self.niri.config.borrow();
+            config.binds != old_config.binds
+        };
+        let compiled_binds = if binds_changed {
+            match compile_binds(&config.binds) {
+                Ok(compiled_binds) => Some(compiled_binds),
+                Err(err) => {
+                    warn!("error compiling layout-independent binds: {err:#}");
+                    self.niri.config_error_notification.show();
+                    self.niri.queue_redraw_all();
+
+                    #[cfg(feature = "dbus")]
+                    self.niri.a11y_announce_config_error();
+
+                    return;
+                }
+            }
+        } else {
+            None
+        };
+
         self.niri.config_error_notification.hide();
+        let mut old_config = self.niri.config.borrow_mut();
 
         // Find & orphan removed named workspaces.
         let mut removed_workspaces: Vec<String> = vec![];
-        for ws in &self.niri.config.borrow().workspaces {
+        for ws in &old_config.workspaces {
             if !config.workspaces.iter().any(|w| w.name == ws.name) {
                 removed_workspaces.push(ws.name.0.clone());
             }
@@ -1448,18 +1483,6 @@ impl State {
             .set_complete_instantly(config.animations.off);
 
         *CHILD_ENV.write().unwrap() = mem::take(&mut config.environment);
-
-        let mut reload_xkb = None;
-        let mut libinput_config_changed = false;
-        let mut output_config_changed = false;
-        let mut preserved_output_config = None;
-        let mut window_rules_changed = false;
-        let mut layer_rules_changed = false;
-        let mut shaders_changed = false;
-        let mut cursor_inactivity_timeout_changed = false;
-        let mut recent_windows_changed = false;
-        let mut xwls_changed = false;
-        let mut old_config = self.niri.config.borrow_mut();
 
         // Reload the cursor.
         if config.cursor != old_config.cursor {
@@ -1509,20 +1532,13 @@ impl State {
             preserved_output_config = Some(mem::take(&mut old_config.outputs));
         }
 
-        let binds_changed = config.binds != old_config.binds;
         let new_mod_key = self.backend.mod_key(&config);
         if new_mod_key != self.backend.mod_key(&old_config) || binds_changed {
             self.niri
                 .hotkey_overlay
                 .on_hotkey_config_updated(new_mod_key);
-            if binds_changed {
-                self.niri.compiled_binds = config
-                    .binds
-                    .binds
-                    .iter()
-                    .cloned()
-                    .map(CompiledBind::from)
-                    .collect();
+            if let Some(compiled_binds) = compiled_binds {
+                self.niri.compiled_binds = compiled_binds;
             }
             self.niri.mods_with_mouse_binds = mods_with_mouse_binds(new_mod_key, &config.binds);
             self.niri.mods_with_wheel_binds = mods_with_wheel_binds(new_mod_key, &config.binds);
@@ -2175,6 +2191,7 @@ impl State {
 impl Niri {
     pub fn new(
         config: Rc<RefCell<Config>>,
+        compiled_binds: Vec<CompiledBind>,
         event_loop: LoopHandle<'static, State>,
         stop_signal: LoopSignal,
         display: Display<State>,
@@ -2351,13 +2368,6 @@ impl Niri {
             CursorManager::new(&config_.cursor.xcursor_theme, config_.cursor.xcursor_size);
 
         let mod_key = backend.mod_key(&config.borrow());
-        let compiled_binds = config_
-            .binds
-            .binds
-            .iter()
-            .cloned()
-            .map(CompiledBind::from)
-            .collect::<Vec<_>>();
         let mods_with_mouse_binds = mods_with_mouse_binds(mod_key, &config_.binds);
         let mods_with_wheel_binds = mods_with_wheel_binds(mod_key, &config_.binds);
         let mods_with_finger_scroll_binds = mods_with_finger_scroll_binds(mod_key, &config_.binds);

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, ensure, Context};
 use calloop::futures::Scheduler;
 use niri_config::debug::PreviewRender;
 use niri_config::{
-    Config, FloatOrInt, Key, Modifiers, OutputName, TrackLayout, WarpMouseToFocusMode,
+    Config, FloatOrInt, Modifiers, OutputName, TrackLayout, WarpMouseToFocusMode,
     WorkspaceReference, Xkb,
 };
 use smithay::backend::allocator::Fourcc;
@@ -130,7 +130,7 @@ use crate::input::scroll_swipe_gesture::ScrollSwipeGesture;
 use crate::input::scroll_tracker::ScrollTracker;
 use crate::input::{
     apply_libinput_settings, mods_with_finger_scroll_binds, mods_with_mouse_binds,
-    mods_with_wheel_binds, TabletData,
+    mods_with_wheel_binds, CompiledBind, CompiledKey, TabletData,
 };
 use crate::ipc::server::IpcServer;
 use crate::layer::mapped::LayerSurfaceRenderElement;
@@ -320,7 +320,8 @@ pub struct Niri {
     pub suppressed_keys: HashSet<Keycode>,
     /// Button codes of the mouse buttons to suppress.
     pub suppressed_buttons: HashSet<u32>,
-    pub bind_cooldown_timers: HashMap<Key, RegistrationToken>,
+    pub compiled_binds: Vec<CompiledBind>,
+    pub bind_cooldown_timers: HashMap<CompiledKey, RegistrationToken>,
     pub bind_repeat_timer: Option<RegistrationToken>,
     pub keyboard_focus: KeyboardFocus,
     pub layer_shell_on_demand_focus: Option<LayerSurface>,
@@ -1514,6 +1515,15 @@ impl State {
             self.niri
                 .hotkey_overlay
                 .on_hotkey_config_updated(new_mod_key);
+            if binds_changed {
+                self.niri.compiled_binds = config
+                    .binds
+                    .binds
+                    .iter()
+                    .cloned()
+                    .map(CompiledBind::from)
+                    .collect();
+            }
             self.niri.mods_with_mouse_binds = mods_with_mouse_binds(new_mod_key, &config.binds);
             self.niri.mods_with_wheel_binds = mods_with_wheel_binds(new_mod_key, &config.binds);
             self.niri.mods_with_finger_scroll_binds =
@@ -1659,7 +1669,9 @@ impl State {
         }
 
         if binds_changed {
-            self.niri.window_mru_ui.update_binds();
+            self.niri
+                .window_mru_ui
+                .update_binds(&self.niri.compiled_binds);
         }
 
         if recent_windows_changed {
@@ -2339,12 +2351,19 @@ impl Niri {
             CursorManager::new(&config_.cursor.xcursor_theme, config_.cursor.xcursor_size);
 
         let mod_key = backend.mod_key(&config.borrow());
+        let compiled_binds = config_
+            .binds
+            .binds
+            .iter()
+            .cloned()
+            .map(CompiledBind::from)
+            .collect::<Vec<_>>();
         let mods_with_mouse_binds = mods_with_mouse_binds(mod_key, &config_.binds);
         let mods_with_wheel_binds = mods_with_wheel_binds(mod_key, &config_.binds);
         let mods_with_finger_scroll_binds = mods_with_finger_scroll_binds(mod_key, &config_.binds);
 
         let screenshot_ui = ScreenshotUi::new(animation_clock.clone(), config.clone());
-        let window_mru_ui = WindowMruUi::new(config.clone());
+        let window_mru_ui = WindowMruUi::new(config.clone(), &compiled_binds);
         let config_error_notification =
             ConfigErrorNotification::new(animation_clock.clone(), config.clone());
 
@@ -2488,6 +2507,7 @@ impl Niri {
             popup_grab: None,
             suppressed_keys: HashSet::new(),
             suppressed_buttons: HashSet::new(),
+            compiled_binds,
             bind_cooldown_timers: HashMap::new(),
             bind_repeat_timer: Option::default(),
             presentation_state,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -692,6 +692,12 @@ pub struct State {
     pub niri: Niri,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct SessionOptions {
+    pub create_wayland_socket: bool,
+    pub is_session_instance: bool,
+}
+
 impl State {
     pub fn new(
         config: Config,
@@ -700,8 +706,7 @@ impl State {
         stop_signal: LoopSignal,
         display: Display<State>,
         headless: bool,
-        create_wayland_socket: bool,
-        is_session_instance: bool,
+        session_options: SessionOptions,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let _span = tracy_client::span!("State::new");
 
@@ -730,8 +735,7 @@ impl State {
             stop_signal,
             display,
             &backend,
-            create_wayland_socket,
-            is_session_instance,
+            session_options,
         );
         backend.init(&mut niri);
 
@@ -2196,8 +2200,7 @@ impl Niri {
         stop_signal: LoopSignal,
         display: Display<State>,
         backend: &Backend,
-        create_wayland_socket: bool,
-        is_session_instance: bool,
+        session_options: SessionOptions,
     ) -> Self {
         let _span = tracy_client::span!("Niri::new");
 
@@ -2397,7 +2400,7 @@ impl Niri {
             )
             .unwrap();
 
-        let socket_name = create_wayland_socket.then(|| {
+        let socket_name = session_options.create_wayland_socket.then(|| {
             let socket_source = ListeningSocketSource::new_auto().unwrap();
             let socket_name = socket_source.socket_name().to_os_string();
             event_loop
@@ -2458,7 +2461,7 @@ impl Niri {
             stop_signal,
             socket_name,
             display_handle,
-            is_session_instance,
+            is_session_instance: session_options.is_session_instance,
             start_time: Instant::now(),
             is_at_startup: true,
             clock: animation_clock,

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -4,6 +4,7 @@ use calloop::EventLoop;
 use niri_config::Config;
 use smithay::reexports::wayland_server::Display;
 
+use crate::input::compile_binds;
 use crate::niri::State;
 
 pub struct Server {
@@ -16,8 +17,10 @@ impl Server {
         let event_loop = EventLoop::try_new().unwrap();
         let handle = event_loop.handle();
         let display = Display::new().unwrap();
+        let compiled_binds = compile_binds(&config.binds).unwrap();
         let state = State::new(
             config,
+            compiled_binds,
             handle.clone(),
             event_loop.get_signal(),
             display,

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -5,7 +5,7 @@ use niri_config::Config;
 use smithay::reexports::wayland_server::Display;
 
 use crate::input::compile_binds;
-use crate::niri::State;
+use crate::niri::{SessionOptions, State};
 
 pub struct Server {
     pub event_loop: EventLoop<'static, State>,
@@ -25,8 +25,10 @@ impl Server {
             event_loop.get_signal(),
             display,
             true,
-            false,
-            false,
+            SessionOptions {
+                create_wayland_socket: false,
+                is_session_instance: false,
+            },
         )
         .unwrap();
 

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -133,7 +133,7 @@ impl HotkeyOverlay {
         writeln!(&mut buf, "{TITLE}").unwrap();
 
         for action in actions {
-            let Some((key, action)) = format_bind(&config.binds.0, action) else {
+            let Some((key, action)) = format_bind(&config.binds.binds, action) else {
                 continue;
             };
 
@@ -195,7 +195,7 @@ fn format_bind(binds: &[Bind], action: &Action) -> Option<(Option<Key>, String)>
 }
 
 fn collect_actions(config: &Config) -> Vec<&Action> {
-    let binds = &config.binds.0;
+    let binds = &config.binds.binds;
 
     // Collect actions that we want to show.
     let mut actions = vec![&Action::ShowHotkeyOverlay];
@@ -323,7 +323,7 @@ fn render(
 
     let strings = collect_actions(config)
         .into_iter()
-        .filter_map(|action| format_bind(&config.binds.0, action))
+        .filter_map(|action| format_bind(&config.binds.binds, action))
         .map(|(key, action)| {
             let key = key.map(|key| key_name(false, mod_key, &key));
             let key = key.as_deref().unwrap_or("(not bound)");
@@ -615,7 +615,7 @@ mod tests {
     #[track_caller]
     fn check(config: &str, action: Action) -> String {
         let config = Config::parse_mem(config).unwrap();
-        if let Some((key, title)) = format_bind(&config.binds.0, &action) {
+        if let Some((key, title)) = format_bind(&config.binds.binds, &action) {
             let key = key.map(|key| key_name(false, ModKey::Super, &key));
             let key = key.as_deref().unwrap_or("(not bound)");
             format!(" {key} : {title}")

--- a/src/ui/mru.rs
+++ b/src/ui/mru.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use anyhow::ensure;
 use niri_config::{
-    Action, Bind, Color, Config, CornerRadius, GradientInterpolation, Key, Modifiers, MruDirection,
-    MruFilter, MruScope, Trigger,
+    Action, Color, Config, CornerRadius, GradientInterpolation, Modifiers, MruDirection, MruFilter,
+    MruScope,
 };
 use pango::FontDescription;
 use pangocairo::cairo::{self, ImageSurface};
@@ -24,6 +24,7 @@ use smithay::output::Output;
 use smithay::utils::{Logical, Point, Rectangle, Scale, Size, Transform};
 
 use crate::animation::{Animation, Clock};
+use crate::input::{CompiledBind, CompiledKey, CompiledTrigger};
 use crate::layout::focus_ring::{FocusRing, FocusRingRenderElement};
 use crate::layout::{Layout, LayoutElement as _, LayoutElementRenderElement};
 use crate::niri::Niri;
@@ -97,8 +98,8 @@ pub struct WindowMru {
 
 pub struct WindowMruUi {
     state: UiState,
-    preset_opened_binds: Vec<Bind>,
-    dynamic_opened_binds: Vec<Bind>,
+    preset_opened_binds: Vec<CompiledBind>,
+    dynamic_opened_binds: Vec<CompiledBind>,
     config: Rc<RefCell<Config>>,
 }
 
@@ -897,7 +898,7 @@ impl ViewPos {
 }
 
 impl WindowMruUi {
-    pub fn new(config: Rc<RefCell<Config>>) -> Self {
+    pub fn new(config: Rc<RefCell<Config>>, compiled_binds: &[CompiledBind]) -> Self {
         let mut rv = Self {
             state: UiState::Closed {
                 previous_scope: MruScope::default(),
@@ -906,12 +907,12 @@ impl WindowMruUi {
             dynamic_opened_binds: Vec::new(),
             config,
         };
-        rv.update_binds();
+        rv.update_binds(compiled_binds);
         rv
     }
 
-    pub fn update_binds(&mut self) {
-        self.dynamic_opened_binds = make_dynamic_opened_binds(&self.config.borrow());
+    pub fn update_binds(&mut self, compiled_binds: &[CompiledBind]) {
+        self.dynamic_opened_binds = make_dynamic_opened_binds(compiled_binds);
     }
 
     pub fn update_config(&mut self) {
@@ -1205,7 +1206,10 @@ impl WindowMruUi {
         }
     }
 
-    pub fn opened_bindings(&mut self, mods: Modifiers) -> impl Iterator<Item = &Bind> + Clone {
+    pub fn opened_bindings(
+        &mut self,
+        mods: Modifiers,
+    ) -> impl Iterator<Item = &CompiledBind> + Clone {
         // Fill modifiers with the current mods.
         for bind in &mut self.preset_opened_binds {
             bind.key.modifiers = mods;
@@ -1828,13 +1832,13 @@ fn render_panel(renderer: &mut GlesRenderer, scale: f64, text: &str) -> anyhow::
 }
 
 /// Returns key bindings available when the MRU UI is open.
-fn make_preset_opened_binds() -> Vec<Bind> {
+fn make_preset_opened_binds() -> Vec<CompiledBind> {
     let mut rv = Vec::new();
 
     let mut push = |trigger, action| {
-        rv.push(Bind {
-            key: Key {
-                trigger: Trigger::Keysym(trigger),
+        rv.push(CompiledBind {
+            key: CompiledKey {
+                trigger: CompiledTrigger::Keysym(trigger),
                 // The modifier is filled dynamically.
                 modifiers: Modifiers::empty(),
             },
@@ -1843,8 +1847,6 @@ fn make_preset_opened_binds() -> Vec<Bind> {
             cooldown: None,
             allow_when_locked: false,
             allow_inhibiting: false,
-            hotkey_overlay_title: None,
-            layout_independent: None,
         })
     };
 
@@ -1883,10 +1885,10 @@ fn make_preset_opened_binds() -> Vec<Bind> {
 /// Returns dynamic key bindings available when the MRU UI is open.
 ///
 /// These ones are generated based on the normal bindings.
-fn make_dynamic_opened_binds(config: &Config) -> Vec<Bind> {
-    let mut binds: HashMap<Trigger, Vec<Bind>> = HashMap::new();
+fn make_dynamic_opened_binds(general_binds: &[CompiledBind]) -> Vec<CompiledBind> {
+    let mut binds: HashMap<CompiledTrigger, Vec<CompiledBind>> = HashMap::new();
 
-    for bind in &config.binds.binds {
+    for bind in general_binds {
         let action = match &bind.action {
             Action::FocusColumnRight
             | Action::FocusColumnRightOrFirst
@@ -1911,10 +1913,13 @@ fn make_dynamic_opened_binds(config: &Config) -> Vec<Bind> {
             _ => continue,
         };
 
-        binds.entry(bind.key.trigger).or_default().push(Bind {
-            action,
-            ..bind.clone()
-        });
+        binds
+            .entry(bind.key.trigger)
+            .or_default()
+            .push(CompiledBind {
+                action,
+                ..bind.clone()
+            });
     }
 
     let mut rv = Vec::new();
@@ -1926,8 +1931,8 @@ fn make_dynamic_opened_binds(config: &Config) -> Vec<Bind> {
             .min_by_key(|bind| bind.key.modifiers.iter().count())
             .unwrap();
 
-        rv.push(Bind {
-            key: Key {
+        rv.push(CompiledBind {
+            key: CompiledKey {
                 trigger: bind.key.trigger,
                 // The modifier is filled dynamically.
                 modifiers: Modifiers::empty(),

--- a/src/ui/mru.rs
+++ b/src/ui/mru.rs
@@ -1844,6 +1844,7 @@ fn make_preset_opened_binds() -> Vec<Bind> {
             allow_when_locked: false,
             allow_inhibiting: false,
             hotkey_overlay_title: None,
+            layout_independent: None,
         })
     };
 
@@ -1885,7 +1886,7 @@ fn make_preset_opened_binds() -> Vec<Bind> {
 fn make_dynamic_opened_binds(config: &Config) -> Vec<Bind> {
     let mut binds: HashMap<Trigger, Vec<Bind>> = HashMap::new();
 
-    for bind in &config.binds.0 {
+    for bind in &config.binds.binds {
         let action = match &bind.action {
             Action::FocusColumnRight
             | Action::FocusColumnRightOrFirst

--- a/src/ui/mru/tests.rs
+++ b/src/ui/mru/tests.rs
@@ -4,27 +4,6 @@ use smithay::backend::input::Keycode;
 
 use super::*;
 
-#[test]
-fn dynamic_opened_binds_keep_compiled_triggers() {
-    let trigger = CompiledTrigger::PhysicalKey(Keycode::from(61u32));
-    let binds = vec![CompiledBind {
-        key: CompiledKey {
-            trigger,
-            modifiers: Modifiers::COMPOSITOR,
-        },
-        action: Action::CloseWindow,
-        repeat: true,
-        cooldown: None,
-        allow_when_locked: false,
-        allow_inhibiting: true,
-    }];
-
-    let opened = make_dynamic_opened_binds(&binds);
-    assert_eq!(opened.len(), 1);
-    assert_eq!(opened[0].key.trigger, trigger);
-    assert_eq!(opened[0].action, Action::MruCloseCurrentWindow);
-}
-
 fn create_thumbnail() -> Thumbnail {
     Thumbnail {
         id: MappedId::next(),
@@ -57,6 +36,27 @@ fn remove_last_window_out_of_two() {
     };
 
     check_ops(&mut mru, &ops);
+}
+
+#[test]
+fn dynamic_opened_binds_keep_compiled_triggers() {
+    let trigger = CompiledTrigger::PhysicalKey(Keycode::from(61u32));
+    let binds = vec![CompiledBind {
+        key: CompiledKey {
+            trigger,
+            modifiers: Modifiers::COMPOSITOR,
+        },
+        action: Action::CloseWindow,
+        repeat: true,
+        cooldown: None,
+        allow_when_locked: false,
+        allow_inhibiting: true,
+    }];
+
+    let opened = make_dynamic_opened_binds(&binds);
+    assert_eq!(opened.len(), 1);
+    assert_eq!(opened[0].key.trigger, trigger);
+    assert_eq!(opened[0].action, Action::MruCloseCurrentWindow);
 }
 
 fn arbitrary_scope() -> impl Strategy<Value = MruScope> {

--- a/src/ui/mru/tests.rs
+++ b/src/ui/mru/tests.rs
@@ -1,7 +1,29 @@
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
+use smithay::backend::input::Keycode;
 
 use super::*;
+
+#[test]
+fn dynamic_opened_binds_keep_compiled_triggers() {
+    let trigger = CompiledTrigger::PhysicalKey(Keycode::from(61u32));
+    let binds = vec![CompiledBind {
+        key: CompiledKey {
+            trigger,
+            modifiers: Modifiers::COMPOSITOR,
+        },
+        action: Action::CloseWindow,
+        repeat: true,
+        cooldown: None,
+        allow_when_locked: false,
+        allow_inhibiting: true,
+    }];
+
+    let opened = make_dynamic_opened_binds(&binds);
+    assert_eq!(opened.len(), 1);
+    assert_eq!(opened[0].key.trigger, trigger);
+    assert_eq!(opened[0].action, Action::MruCloseCurrentWindow);
+}
 
 fn create_thumbnail() -> Thumbnail {
     Thumbnail {


### PR DESCRIPTION
This PR adds explicit layout-independent keybinds that resolve symbolic binds against a reference `binds.xkb` keymap and then match them by physical key at runtime. The feature keeps normal `keysym` binds unchanged, while allowing punctuation and non-latin layout cases like `Mod+/` to continue working across layout switches.

Layout-independent resolution is configured locally within each `binds {}` block. A block can declare a default with `layout-independent true/false`, a reference keymap with `xkb { ... }`, and individual binds in that same block can opt in or out explicitly using `layout-independent=true/false`. The symbolic key must resolve to at least one physical key in the reference keymap; missing or colliding resolutions are treated as configuration errors.

Several existing issues point to the same underlying problem: keybind behavior changes unexpectedly across keyboard layouts, especially for non-latin layouts, punctuation, and keys whose logical meaning depends on the active XKB layout - e.g. #2818, #1519, #1913, #283, #1225, and #2390.

I did not find an issue that proposes this exact solution/ configuration model directly, but this seemed like a good direction for addressing that broader class of problems while maintaining the default bind behavior.

This also ended up being a larger PR then I intended for it to be, sorry.