### PR TITLE
Allow auto-raise on focus for floating windows

### DIFF
--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -20,6 +20,7 @@ pub struct Input {
     pub disable_power_key_handling: bool,
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
+    pub auto_raise_on_focus: Option<AutoRaiseOnFocus>,
     pub workspace_auto_back_and_forth: bool,
     pub mod_key: Option<ModKey>,
     pub mod_key_nested: Option<ModKey>,
@@ -47,6 +48,8 @@ pub struct InputPart {
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     #[knuffel(child)]
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
+    #[knuffel(child)]
+    pub auto_raise_on_focus: Option<AutoRaiseOnFocus>,
     #[knuffel(child)]
     pub workspace_auto_back_and_forth: Option<Flag>,
     #[knuffel(child, unwrap(argument, str))]
@@ -78,6 +81,7 @@ impl MergeWith<InputPart> for Input {
             (self, part),
             warp_mouse_to_focus,
             focus_follows_mouse,
+            auto_raise_on_focus,
             mod_key,
             mod_key_nested,
         );
@@ -383,6 +387,12 @@ pub struct Touch {
 pub struct FocusFollowsMouse {
     #[knuffel(property, str)]
     pub max_scroll_amount: Option<Percent>,
+}
+
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+pub struct AutoRaiseOnFocus {
+    #[knuffel(property)]
+    pub delay_ms: Option<u32>,
 }
 
 #[derive(knuffel::Decode, Debug, PartialEq, Eq, Clone, Copy)]
@@ -743,5 +753,41 @@ mod tests {
             2.0,
         )
         ");
+    }
+
+    #[test]
+    fn parse_auto_raise_on_focus_with_delay() {
+        let parsed = do_parse(
+            r#"
+            auto-raise-on-focus delay-ms=300
+            "#,
+        );
+
+        assert_debug_snapshot!(parsed.auto_raise_on_focus, @r#"
+        Some(
+            AutoRaiseOnFocus {
+                delay_ms: Some(
+                    300,
+                ),
+            },
+        )
+        "#);
+    }
+
+    #[test]
+    fn parse_auto_raise_on_focus_no_delay() {
+        let parsed = do_parse(
+            r#"
+            auto-raise-on-focus
+            "#,
+        );
+
+        assert_debug_snapshot!(parsed.auto_raise_on_focus, @r#"
+        Some(
+            AutoRaiseOnFocus {
+                delay_ms: None,
+            },
+        )
+        "#);
     }
 }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -732,6 +732,7 @@ mod tests {
 
                 warp-mouse-to-focus
                 focus-follows-mouse
+                auto-raise-on-focus delay-ms=200
                 workspace-auto-back-and-forth
 
                 mod-key "Mod5"
@@ -1131,6 +1132,13 @@ mod tests {
                 focus_follows_mouse: Some(
                     FocusFollowsMouse {
                         max_scroll_amount: None,
+                    },
+                ),
+                auto_raise_on_focus: Some(
+                    AutoRaiseOnFocus {
+                        delay_ms: Some(
+                            200,
+                        ),
                     },
                 ),
                 workspace_auto_back_and_forth: true,

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -67,6 +67,11 @@ input {
     // Focus windows and outputs automatically when moving the mouse into them.
     // Setting max-scroll-amount="0%" makes it work only on windows already fully on screen.
     // focus-follows-mouse max-scroll-amount="0%"
+
+    // Automatically raise floating windows when they receive focus.
+    // The delay (in milliseconds) lets you move the mouse across windows
+    // without raising them; set to 0 for immediate raise.
+    // auto-raise-on-focus delay-ms=300
 }
 
 // You can configure outputs by their name, which you can find

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1494,6 +1494,9 @@ impl State {
 
         self.niri.config_error_notification.hide();
 
+        // Cancel any pending auto-raise timer in case the feature was disabled.
+        self.niri.cancel_pending_auto_raise();
+
         // Find & orphan removed named workspaces.
         let mut removed_workspaces: Vec<String> = vec![];
         for ws in &self.niri.config.borrow().workspaces {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -391,6 +391,7 @@ pub struct Niri {
 
     pub window_mru_ui: WindowMruUi,
     pub pending_mru_commit: Option<PendingMruCommit>,
+    pub pending_auto_raise: Option<PendingAutoRaise>,
 
     pub pick_window: Option<async_channel::Sender<Option<MappedId>>>,
     pub pick_color: Option<async_channel::Sender<Option<niri_ipc::PickedColor>>>,
@@ -628,6 +629,13 @@ pub struct PendingMruCommit {
     id: MappedId,
     token: RegistrationToken,
     stamp: Duration,
+}
+
+/// Pending auto-raise of a floating window after a focus change.
+#[derive(Debug)]
+pub struct PendingAutoRaise {
+    pub window_id: MappedId,
+    pub token: RegistrationToken,
 }
 
 impl RedrawState {
@@ -2602,6 +2610,7 @@ impl Niri {
 
             window_mru_ui,
             pending_mru_commit: None,
+            pending_auto_raise: None,
 
             pick_window: None,
             pick_color: None,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1310,7 +1310,57 @@ impl State {
                             self.niri.event_loop.remove(token);
                         }
                     }
+
+                    // Auto-raise: raise floating windows after an optional delay.
+                    let auto_raise = self.niri.config.borrow().input.auto_raise_on_focus;
+                    if let Some(auto_raise) = auto_raise {
+                        if mapped.is_floating() {
+                            let delay_ms = auto_raise.delay_ms.unwrap_or(0);
+                            let window_id = mapped.id();
+
+                            if delay_ms == 0 {
+                                // Immediate raise.
+                                self.niri.cancel_pending_auto_raise();
+                                if let Some(window) = self.niri.find_window_by_id(window_id) {
+                                    self.niri.layout.activate_window(&window);
+                                    self.niri.queue_redraw_all();
+                                }
+                            } else {
+                                // Delayed raise.
+                                let timer = Timer::from_duration(Duration::from_millis(u64::from(
+                                    delay_ms,
+                                )));
+
+                                let token = self
+                                    .niri
+                                    .event_loop
+                                    .insert_source(timer, move |_, _, state| {
+                                        state.niri.auto_raise_apply();
+                                        TimeoutAction::Drop
+                                    })
+                                    .unwrap();
+
+                                if let Some(old) = self
+                                    .niri
+                                    .pending_auto_raise
+                                    .replace(PendingAutoRaise { window_id, token })
+                                {
+                                    self.niri.event_loop.remove(old.token);
+                                }
+                            }
+                        } else {
+                            // Focused a tiled window; cancel any pending raise.
+                            self.niri.cancel_pending_auto_raise();
+                        }
+                    } else {
+                        // Feature disabled; cancel any pending raise.
+                        self.niri.cancel_pending_auto_raise();
+                    }
                 }
+            }
+
+            if !matches!(focus, KeyboardFocus::Layout { surface: Some(_) }) {
+                self.niri.cancel_pending_auto_raise();
             }
 
             if let Some(grab) = self.niri.popup_grab.as_mut() {
@@ -6458,6 +6508,28 @@ impl Niri {
             .find(|w| w.id() == pending.id)
         {
             window.set_focus_timestamp(pending.stamp);
+        }
+    }
+
+    /// Apply a pending auto-raise: raise the focused floating window to the top.
+    pub fn auto_raise_apply(&mut self) {
+        let Some(pending) = self.pending_auto_raise.take() else {
+            return;
+        };
+        self.event_loop.remove(pending.token);
+
+        let Some(window) = self.find_window_by_id(pending.window_id) else {
+            return;
+        };
+
+        self.layout.activate_window(&window);
+        self.queue_redraw_all();
+    }
+
+    /// Cancel any pending auto-raise timer.
+    pub fn cancel_pending_auto_raise(&mut self) {
+        if let Some(pending) = self.pending_auto_raise.take() {
+            self.event_loop.remove(pending.token);
         }
     }
 


### PR DESCRIPTION
Hi All,

My use-case is (different from the typical niri one) to have an all-floating layout. There aren't many wayland compositors outside of GNOME/KDE that offer this. So I was experimenting with different compositors under dank material shell to see which fits my workflow. Niri gets me 90% of the way there, with the only blocking issue so far is the lack of auto-raise on focus (without that, `focus-follows-mouse` is clunky and almost pointless - you still need to click). It works for all kinds of focus changes (on floating windows only).

I've implemented this using the niri event loop for the delay handling. It can be enabled in the config like this:

```
input {
      auto-raise-on-focus delay-ms=300
}
```

The delay is optional and defaults to `0` (immediate).

I've built and tested it locally and it works great. 

I hope you will consider merging this!