### PR TITLE
support for focus-follows-mouse delay

### DIFF
--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -356,6 +356,29 @@ input {
 }
 ```
 
+<sup>Since: 25.04</sup> You can optionally set `delay-ms`.
+Then, focus-follows-mouse will only focus a window after the mouse has been over it for the specified delay.
+This prevents focus from changing while moving the mouse quickly across windows.
+
+```kdl
+input {
+    // Focus window after hovering for 200ms.
+    focus-follows-mouse {
+        delay-ms 200
+    }
+}
+```
+
+You can combine both options:
+
+```kdl
+input {
+    focus-follows-mouse max-scroll-amount="10%" {
+        delay-ms 200
+    }
+}
+```
+
 #### `workspace-auto-back-and-forth`
 
 Normally, switching to the same workspace by index twice will do nothing (since you're already on that workspace).

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -383,6 +383,8 @@ pub struct Touch {
 pub struct FocusFollowsMouse {
     #[knuffel(property, str)]
     pub max_scroll_amount: Option<Percent>,
+    #[knuffel(child, unwrap(argument))]
+    pub delay_ms: Option<u16>,
 }
 
 #[derive(knuffel::Decode, Debug, PartialEq, Eq, Clone, Copy)]

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1131,6 +1131,7 @@ mod tests {
                 focus_follows_mouse: Some(
                     FocusFollowsMouse {
                         max_scroll_amount: None,
+                        delay_ms: None,
                     },
                 ),
                 workspace_auto_back_and_forth: true,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -391,6 +391,7 @@ pub struct Niri {
 
     pub window_mru_ui: WindowMruUi,
     pub pending_mru_commit: Option<PendingMruCommit>,
+    pub pending_focus_follow_mouse: Option<PendingFocusFollowsMouseCommit>,
 
     pub pick_window: Option<async_channel::Sender<Option<MappedId>>>,
     pub pick_color: Option<async_channel::Sender<Option<niri_ipc::PickedColor>>>,
@@ -628,6 +629,13 @@ pub struct PendingMruCommit {
     id: MappedId,
     token: RegistrationToken,
     stamp: Duration,
+}
+
+/// Pending focus-follows-mouse window activation.
+#[derive(Debug)]
+pub struct PendingFocusFollowsMouseCommit {
+    window: Window,
+    token: RegistrationToken,
 }
 
 impl RedrawState {
@@ -2592,6 +2600,7 @@ impl Niri {
 
             window_mru_ui,
             pending_mru_commit: None,
+            pending_focus_follow_mouse: None,
 
             pick_window: None,
             pick_color: None,
@@ -6209,8 +6218,21 @@ impl Niri {
                     }
                 }
 
-                self.layout.activate_window_without_raising(window);
-                self.layer_shell_on_demand_focus = None;
+                match ffm.delay_ms {
+                    None | Some(0) => {
+                        self.layout.activate_window_without_raising(window);
+                        self.layer_shell_on_demand_focus = None;
+                    }
+                    Some(delay_ms) => {
+                        self.activate_window_without_raising_delayed(window, delay_ms);
+                    }
+                }
+            }
+        } else {
+            if let Some(PendingFocusFollowsMouseCommit { token, .. }) =
+                self.pending_focus_follow_mouse.take()
+            {
+                self.event_loop.remove(token);
             }
         }
 
@@ -6218,6 +6240,38 @@ impl Niri {
             if current_focus.layer.as_ref() != Some(layer) {
                 self.layer_shell_on_demand_focus = Some(layer.clone());
             }
+        }
+    }
+
+    fn activate_window_without_raising_delayed(&mut self, window: &Window, delay_ms: u16) {
+        let focused_window = window.clone();
+        let focus_token = self
+            .event_loop
+            .insert_source(
+                Timer::from_duration(Duration::from_millis(u64::from(delay_ms))),
+                move |_, _, state| {
+                    if let Some(pending) = state.niri.pending_focus_follow_mouse.take() {
+                        if pending.window == focused_window {
+                            state
+                                .niri
+                                .layout
+                                .activate_window_without_raising(&pending.window);
+                            state.niri.layer_shell_on_demand_focus = None;
+                        }
+                    }
+                    TimeoutAction::Drop
+                },
+            )
+            .unwrap();
+
+        if let Some(PendingFocusFollowsMouseCommit { token, .. }) = self
+            .pending_focus_follow_mouse
+            .replace(PendingFocusFollowsMouseCommit {
+                window: window.clone(),
+                token: focus_token,
+            })
+        {
+            self.event_loop.remove(token);
         }
     }
 


### PR DESCRIPTION
in response to discussion: https://github.com/niri-wm/niri/discussions/1996

This PR adds config parameter delay_ms to focus-follows-mouse

```
focus-follows-mouse {
  delay-ms 200
}

```

it prevents focus from changing while moving mouse quickly across windows