### PR TITLE
wiki: explicitly mention possible include methods

### DIFF
--- a/docs/wiki/Configuration:-Include.md
+++ b/docs/wiki/Configuration:-Include.md
@@ -16,6 +16,12 @@ Settings from included files will be merged with the settings from the main conf
 Included config files can in turn include more files.
 All included files are watched for changes, and the config live-reloads when any of them change.
 
+You can include by filename or path.
+
+* Relative to the current file: `other.kdl` or `./other.kdl`
+* By absolute path: `/path/to/file.kdl`
+* <sup>Since: next release</sup> Home dir paths: `~/file.kdl` expands to `/home/user/file.kdl`
+
 Includes work only at the top level of the config:
 
 ```kdl,must-fail


### PR DESCRIPTION
This explicitly outlines the possible methods for `include` in the docs, particularly the `~` expansion introduced in [404d6dc](https://github.com/niri-wm/niri/commit/404d6dccc475a290fa8b0938ef8524ea2a92575d) that will be available next release.
Not sure if the way I've done this is too verbose, open to changes.