### PR TITLE
Revert "Stop including broken LFS files in source tarball"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,2 @@
 # LFS configuration for images from the wiki
 *.png filter=lfs diff=lfs merge=lfs -text
-
-# Exclude LFS-tracked files from the tarball
-/docs/wiki/img/ export-ignore
-
-# exclude .gitattributes itself from the tarball
-.gitattributes export-ignore
-
-# tip: can be tested using
-# git archive --format=tar.gz --output=source.tar.gz HEAD && \
-# tar tfvz source.tar.gz | grep -e '.png' -e '.gitattributes'


### PR DESCRIPTION
This reverts commit d8265ad34e3f5d21002810b6727d4badffb8d21c.

With the LFS option enabled on the repo:

<img width="1921" height="463" alt="screenshot_2026-04-27_11-03-20" src="https://github.com/user-attachments/assets/759c67ee-f357-45c5-bbb4-0b05c3e5fd7a" />

LFS files will be included in the release archive and there is no need to filter them out. Confirmed this in my fork by creating a test tag:

<img width="2722" height="762" alt="screenshot_2026-04-27_11-05-53" src="https://github.com/user-attachments/assets/f00cd14f-faa0-4af4-8a81-8ff8124dbe53" />

dowloading the release archive and checking:
```shell
dimitry@laptop:~/arch/desktop/niri.d$ tar -tvf niri-test.tar.gz | grep .png
-rw-rw-r-- root/root     97565 2026-04-27 10:13 niri-test/docs/wiki/img/RedrawState-dark.drawio.png
-rw-rw-r-- root/root     86906 2026-04-27 10:13 niri-test/docs/wiki/img/RedrawState-light.drawio.png
-rw-rw-r-- root/root    432355 2026-04-27 10:13 niri-test/docs/wiki/img/block-out-from-screencast.png
-rw-rw-r-- root/root   1582702 2026-04-27 10:13 niri-test/docs/wiki/img/blur.png
-rw-rw-r-- root/root     34239 2026-04-27 10:13 niri-test/docs/wiki/img/border-radius-clip.png
-rw-rw-r-- root/root      2623 2026-04-27 10:13 niri-test/docs/wiki/img/border.png
-rw-rw-r-- root/root     33591 2026-04-27 10:13 niri-test/docs/wiki/img/clip-to-geometry.png
-rw-rw-r-- root/root     11266 2026-04-27 10:13 niri-test/docs/wiki/img/different-corner-radius.png
-rw-rw-r-- root/root      4608 2026-04-27 10:13 niri-test/docs/wiki/img/focus-ring.png
-rw-rw-r-- root/root     31393 2026-04-27 10:13 niri-test/docs/wiki/img/fullscreen-window-in-overview.png
-rw-rw-r-- root/root      8495 2026-04-27 10:13 niri-test/docs/wiki/img/fullscreen-window.png
-rw-rw-r-- root/root     25777 2026-04-27 10:13 niri-test/docs/wiki/img/geometry-corner-radius.png
-rw-rw-r-- root/root     31700 2026-04-27 10:13 niri-test/docs/wiki/img/gradients-default.png
-rw-rw-r-- root/root     23180 2026-04-27 10:13 niri-test/docs/wiki/img/gradients-oklch.png
-rw-rw-r-- root/root     29540 2026-04-27 10:13 niri-test/docs/wiki/img/gradients-relative-to-workspace-view.png
-rw-rw-r-- root/root    559823 2026-04-27 10:13 niri-test/docs/wiki/img/layer-block-out-from-screencast.png
-rw-rw-r-- root/root     47121 2026-04-27 10:13 niri-test/docs/wiki/img/maximized-column.png
-rw-rw-r-- root/root     15837 2026-04-27 10:13 niri-test/docs/wiki/img/opacity-popup.png
-rw-rw-r-- root/root    166777 2026-04-27 10:13 niri-test/docs/wiki/img/popup-arrow.png
-rw-rw-r-- root/root     56936 2026-04-27 10:13 niri-test/docs/wiki/img/popup-no-arrow.png
-rw-rw-r-- root/root      4999 2026-04-27 10:13 niri-test/docs/wiki/img/simple-egl-border-with-background.png
-rw-rw-r-- root/root     15729 2026-04-27 10:13 niri-test/docs/wiki/img/simple-egl-border-without-background.png
-rw-rw-r-- root/root     20959 2026-04-27 10:13 niri-test/docs/wiki/img/struts.png
-rw-rw-r-- root/root     14069 2026-04-27 10:13 niri-test/docs/wiki/img/window-maximized-to-edges.png
-rw-rw-r-- root/root     16825 2026-04-27 10:13 niri-test/docs/wiki/img/workspaces-dark.png
-rw-rw-r-- root/root     17357 2026-04-27 10:13 niri-test/docs/wiki/img/workspaces-light.png
```