### PR TITLE
render: fix blur on gpus with opengl version below 2

### DIFF
--- a/src/render_helpers/blur.rs
+++ b/src/render_helpers/blur.rs
@@ -209,7 +209,7 @@ impl Blur {
 
             let mut fbos = [0; 2];
             gl.GenFramebuffers(fbos.len() as _, fbos.as_mut_ptr());
-            gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, fbos[0]);
+            gl.BindFramebuffer(ffi::FRAMEBUFFER, fbos[0]);
 
             let program = &self.program.0.down;
             gl.UseProgram(program.program);
@@ -244,7 +244,7 @@ impl Blur {
 
                 trace!("drawing down {src} to {dst}");
                 gl.FramebufferTexture2D(
-                    ffi::DRAW_FRAMEBUFFER,
+                    ffi::FRAMEBUFFER,
                     ffi::COLOR_ATTACHMENT0,
                     ffi::TEXTURE_2D,
                     dst,
@@ -307,7 +307,7 @@ impl Blur {
 
                 trace!("drawing up {src} to {dst}");
                 gl.FramebufferTexture2D(
-                    ffi::DRAW_FRAMEBUFFER,
+                    ffi::FRAMEBUFFER,
                     ffi::COLOR_ATTACHMENT0,
                     ffi::TEXTURE_2D,
                     dst,
@@ -333,7 +333,7 @@ impl Blur {
 
             gl.DisableVertexAttribArray(program.attrib_vert as u32);
 
-            gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, 0);
+            gl.BindFramebuffer(ffi::FRAMEBUFFER, 0);
             gl.DeleteFramebuffers(fbos.len() as _, fbos.as_ptr());
         })?;
 


### PR DESCRIPTION
The blur effect wasn't working on my machine (opengl 2.0), then i tried running niri with debug logs and found this:
```
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_ENUM in glFramebufferTexture2D(invalid target GL_DRAW_FRAMEBUFFER)
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_FRAMEBUFFER_OPERATION in glDrawArrays
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_ENUM in glFramebufferTexture2D(invalid target GL_DRAW_FRAMEBUFFER)
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_FRAMEBUFFER_OPERATION in glDrawArrays
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_ENUM in glFramebufferTexture2D(invalid target GL_DRAW_FRAMEBUFFER)
smithay::backend::renderer::gles: [GL] GL_INVALID_FRAMEBUFFER_OPERATION in glDrawArrays
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_ENUM in glFramebufferTexture2D(invalid target GL_DRAW_FRAMEBUFFER)
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_FRAMEBUFFER_OPERATION in glDrawArrays
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_ENUM in glFramebufferTexture2D(invalid target GL_DRAW_FRAMEBUFFER)
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_FRAMEBUFFER_OPERATION in glDrawArrays
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_ENUM in glFramebufferTexture2D(invalid target GL_DRAW_FRAMEBUFFER)
ERROR smithay::backend::renderer::gles: [GL] GL_INVALID_FRAMEBUFFER_OPERATION in glDrawArrays
```

Changing `GL_DRAW_FRAMEBUFFER` to `GL_FRAMEBUFFER` in `src/render_helpers/blur.rs` fixed it!

 Verified blur works on Intel G41 integrated graphics.
 
 ## screenshots before and after
<img width="759" height="556" alt="Screenshot from 2026-04-27 22-21-22" src="https://github.com/user-attachments/assets/16c74b42-c72f-406d-ac44-fa52e16aa8a4" />
<img width="779" height="512" alt="Screenshot from 2026-04-27 22-20-23" src="https://github.com/user-attachments/assets/f48d1da7-5362-4199-be2c-aec49ffada9f" />
