### PR TITLE
Make niri-session posix-compliant

### DIFF
--- a/resources/niri-session
+++ b/resources/niri-session
@@ -15,7 +15,7 @@ if [ -n "$SHELL" ] &&
    ! (echo "$SHELL" | grep -q "false") &&
    ! (echo "$SHELL" | grep -q "nologin"); then
   if [ "$1" != '-l' ]; then
-    exec bash -c "exec -l '$SHELL' -c '$0 -l $*'"
+    exec "$SHELL" -l -c "exec $0 -l $*"
   else
     shift
   fi
@@ -77,7 +77,7 @@ elif hash dinitctl >/dev/null 2>&1; then
     fi
 
     # Create the directory for the logfile, if doesn't exist
-    mkdir --parents $HOME/.local/share/niri
+    mkdir -p $HOME/.local/share/niri
     # Start niri
     dinitctl --quiet --user start niri.target 2>&1
 


### PR DESCRIPTION
`niri-session` currently has a hard dependency on `bash`, and `mkdir --parents` is not posix compliant either. This pr fixes both issues.